### PR TITLE
Altair gallery test suite improvements (tenacity, variable tolerance, etc.)

### DIFF
--- a/python/vegafusion-jupyter/setup.py
+++ b/python/vegafusion-jupyter/setup.py
@@ -104,7 +104,8 @@ setup_args = dict(
             'nbval',
             'jupytext',
             'selenium',
-            'scikit-image'
+            'scikit-image',
+            'tenacity'
         ],
         'examples': [
             # Any requirements for the examples to run

--- a/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/other/errorbars_with_ci/mock.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/other/errorbars_with_ci/mock.py
@@ -1,4 +1,5 @@
 # https://altair-viz.github.io/gallery/errorbars_with_ci.html
+# Padding updates to make size deterministic even when data is not
 
 import altair as alt
 from vega_datasets import data
@@ -15,4 +16,6 @@ points = alt.Chart(source).mark_point(filled=True, color='black').encode(
     y=alt.Y('variety:N'),
 )
 
-error_bars + points
+(error_bars + points).properties(
+    padding={"left": 50, "top": 5, "right": 50, "bottom": 5}
+)

--- a/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/other/sorted_error_bars_with_ci/mock.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/other/sorted_error_bars_with_ci/mock.py
@@ -1,4 +1,5 @@
 # https://altair-viz.github.io/gallery/sorted_error_bars_with_ci.html
+# Padding updates to make size deterministic even when data is not
 
 import altair as alt
 from vega_datasets import data
@@ -28,4 +29,6 @@ error_bars = points.mark_rule().encode(
     x2='ci1(yield)',
 )
 
-points + error_bars
+(points + error_bars).properties(
+    padding={"left": 50, "top": 5, "right": 50, "bottom": 5}
+)

--- a/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/scatter/stripplot/mock.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/tests/altair_mocks/scatter/stripplot/mock.py
@@ -1,11 +1,12 @@
 # https://altair-viz.github.io/gallery/stripplot.html
+# Padding and bounds updates to make size deterministic even when data is not
 
 import altair as alt
 from vega_datasets import data
 
 source = data.movies.url
 
-stripplot =  alt.Chart(source, width=40).mark_circle(size=8).encode(
+stripplot =  alt.Chart(source, width=40, padding=60, bounds="flush").mark_circle(size=8).encode(
     x=alt.X(
         'jitter:Q',
         title=None,


### PR DESCRIPTION
This PR makes a few updates to improve the Altair baseline test suite:
 - Update Altair mock tests to use tenacity for more robust retrying
 - Make image comparison tolerance configurable per mock
 - Update non-deterministic mocks to have deterministic size, and test with lower tolerance