### PR TITLE
Add debounce_wait and debounce_wait_max traitlet properties

### DIFF
--- a/python/vegafusion-jupyter/src/widget.ts
+++ b/python/vegafusion-jupyter/src/widget.ts
@@ -28,6 +28,8 @@ export class VegaFusionModel extends DOMWidgetModel {
       server_vega_spec: null,
       vegafusion_handle: null,
       verbose: null,
+      debounce_wait: 30,
+      debounce_max_wait: 60,
     };
   }
 
@@ -61,6 +63,9 @@ export class VegaFusionView extends DOMWidgetView {
     this.value_changed();
     this.model.on('change:spec', this.value_changed, this);
     this.model.on('change:verbose', this.value_changed, this);
+    this.model.on('change:debounce_wait', this.value_changed, this);
+    this.model.on('change:debounce_max_wait', this.value_changed, this);
+
     this.model.on("msg:custom", (ev: any, buffers: [DataView]) => {
       if (this.model.get("verbose")) {
         console.log("VegaFusion(js): Received response");
@@ -85,7 +90,11 @@ export class VegaFusionView extends DOMWidgetView {
       }
 
       this.vegafusion_handle = this.render_vegafusion(
-          this.viewElement, vega_spec_json, this.model.get("verbose") || false,
+          this.viewElement,
+          vega_spec_json,
+          this.model.get("verbose") || false,
+          this.model.get("debounce_wait") || 30,
+          this.model.get("debounce_max_wait"),
           (request: ArrayBuffer) => {
             if (this.model.get("verbose")) {
               console.log("VegaFusion(js): Send request");

--- a/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/widget.py
@@ -1,5 +1,5 @@
 from ipywidgets import DOMWidget
-from traitlets import Unicode, Bool
+from traitlets import Unicode, Bool, Float
 import time
 
 import logging
@@ -26,6 +26,8 @@ class VegaFusionWidget(DOMWidget):
     server_vega_spec = Unicode(None, allow_none=True, read_only=True).tag(sync=True)
     comm_plan = Unicode(None, allow_none=True, read_only=True).tag(sync=True)
     verbose = Bool(False).tag(sync=True)
+    debounce_wait = Float(30, allow_none=False).tag(sync=True)
+    debounce_max_wait = Float(60, allow_none=True).tag(sync=True)
 
     def __init__(self, *args, **kwargs):
 

--- a/vegafusion-wasm/js/vega_utils.js
+++ b/vegafusion-wasm/js/vega_utils.js
@@ -54,23 +54,32 @@ export function setDataValue(view, name, scope, value) {
     view.pulse(dataset.input, changeset);
 }
 
-export function addSignalListener(view, name, scope, handler) {
+export function addSignalListener(view, name, scope, handler, wait, maxWait) {
     let signal_op = lookupSignalOp(view, name, scope);
+    let options = {};
+    if (maxWait) {
+        options["maxWait"] = maxWait;
+    }
+
     return addOperatorListener(
         view,
         name,
         signal_op,
-        _.debounce(handler, 50, {'maxWait': 100}),
+        _.debounce(handler, wait, options),
     );
 }
 
-export function addDataListener(view, name, scope, handler) {
+export function addDataListener(view, name, scope, handler, wait, maxWait) {
     let dataset = dataref(view, name, scope).values;
+    let options = {};
+    if (maxWait) {
+        options["maxWait"] = maxWait;
+    }
     return addOperatorListener(
         view,
         name,
         dataset,
-        _.debounce(handler, 50, {'maxWait': 100}),
+        _.debounce(handler, wait, options),
     );
 }
 


### PR DESCRIPTION
This PR adds new `debounce_wait` and `debounce_wait_max` traitlet properties that make it possible to configure the chart's debouncing configuration. These properties correspond to the `wait` and `maxWait` configuration parametedrs of the lodash [`debounce`](https://lodash.com/docs/4.17.15#debounce) function.
