### PR TITLE
Support passing widget options through renderer.enable

### DIFF
--- a/python/vegafusion-jupyter/vegafusion_jupyter/__init__.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/__init__.py
@@ -12,7 +12,7 @@ import vegafusion_jupyter.renderer
 from .runtime import runtime
 
 
-def enable():
+def enable(debounce_wait=30, debounce_max_wait=60):
     """
     Enable the VegaFusion data transformer and renderer so that all Charts
     are displayed using VegaFusion.
@@ -27,7 +27,11 @@ def enable():
 
     This isn't necessary in order to use the VegaFusionWidget directly
     """
-    alt.renderers.enable('vegafusion')
+    alt.renderers.enable(
+        'vegafusion',
+        debounce_wait=debounce_wait,
+        debounce_max_wait=debounce_max_wait
+    )
     alt.data_transformers.enable('vegafusion-feather')
 
 

--- a/python/vegafusion-jupyter/vegafusion_jupyter/renderer.py
+++ b/python/vegafusion-jupyter/vegafusion_jupyter/renderer.py
@@ -1,7 +1,7 @@
 import altair as alt
 
 
-def vegafusion_renderer(spec):
+def vegafusion_renderer(spec, **widget_options):
     """
     Altair renderer that displays charts using a VegaFusionWidget
     """
@@ -11,7 +11,9 @@ def vegafusion_renderer(spec):
 
     # Display widget as a side effect, then return empty string text representation
     # so that Altair doesn't also display a string representation
-    widget = VegaFusionWidget(spec=json.dumps(spec))
+    widget = VegaFusionWidget(
+        spec=json.dumps(spec), **widget_options
+    )
     display(widget)
     return {'text/plain': ""}
 


### PR DESCRIPTION
This PR passes `VegaFusionWidget` traitlet options through `alt.renderers.enable('vegafusion', **opts)`.

The `vf.enable` function now has explicit options for `debounce_wait` and `debounce_wait_max`.
