### PR TITLE
Support Date32 type with Polars

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -386,7 +386,7 @@ jobs:
 
           python -m pip install $vegafusion
           python -m pip install $vegafusion_python_embed
-          python -m pip install pytest vega-datasets polars duckdb==0.9.2 vl-convert-python scikit-image
+          python -m pip install pytest vega-datasets polars[timezone] duckdb==0.9.2 vl-convert-python scikit-image
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -319,7 +319,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*manylinux_2_17_x86_64*.whl
-          python -m pip install pytest vega-datasets polars duckdb==0.9.2 "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars-lts-cpu duckdb==0.9.2 "vl-convert-python>=1.0.1rc1" scikit-image pandas==2.0
       - name: Test vegafusion
         working-directory: python/vegafusion/
         run: pytest
@@ -350,7 +350,7 @@ jobs:
           ls -la
           python -m pip install vegafusion-*.whl
           python -m pip install vegafusion_python_embed-*macosx_10_*_x86_64.whl
-          python -m pip install pytest vega-datasets polars duckdb==0.9.2 vl-convert-python scikit-image pandas==2.0
+          python -m pip install pytest vega-datasets polars-lts-cpu duckdb==0.9.2 vl-convert-python scikit-image pandas==2.0
           python -m pip install pyarrow==10.0 altair==5.1.2
       - name: Test vegafusion
         working-directory: python/vegafusion/

--- a/python/vegafusion/tests/test_pretransform.py
+++ b/python/vegafusion/tests/test_pretransform.py
@@ -1483,6 +1483,23 @@ def test_date32_pre_transform_dataset():
         pd.Timestamp('2022-01-03 00:00:00-0500', tz='America/New_York')
     ]
 
+def test_date32_pre_transform_dataset_polars():
+    # Test to make sure that date32 columns are interpreted in the local timezone
+    dates_df = pl.DataFrame({
+        "date_col": [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3)],
+    })
+    spec = date_column_spec()
+
+    (output_ds,), warnings = vf.runtime.pre_transform_datasets(
+        spec, ["data_0"], "America/New_York", default_input_tz="UTC", inline_datasets=dict(dates=dates_df)
+    )
+
+    # Timestamps are in the local timezone, so they should be midnight local time
+    assert list(output_ds["date_col"]) == [
+        pd.Timestamp('2022-01-01 00:00:00-0500', tz='America/New_York'),
+        pd.Timestamp('2022-01-02 00:00:00-0500', tz='America/New_York'),
+        pd.Timestamp('2022-01-03 00:00:00-0500', tz='America/New_York')
+    ]
 
 def test_date32_in_timeunit_duckdb_crash():
     try:

--- a/python/vegafusion/vegafusion/datasource/__init__.py
+++ b/python/vegafusion/vegafusion/datasource/__init__.py
@@ -1,3 +1,4 @@
 from .dfi_datasource import DfiDatasource
 from .pandas_datasource import PandasDatasource
+from .pyarrow_datasource import PyArrowDatasource
 from .datasource import Datasource

--- a/python/vegafusion/vegafusion/datasource/pyarrow_datasource.py
+++ b/python/vegafusion/vegafusion/datasource/pyarrow_datasource.py
@@ -1,0 +1,16 @@
+from typing import Iterable
+import pyarrow as pa
+from .datasource import Datasource
+
+class PyArrowDatasource(Datasource):
+    def __init__(self, dataframe: pa.Table):
+        self._table = dataframe
+
+    def schema(self) -> pa.Schema:
+        return self._table.schema
+
+    def fetch(self, columns: Iterable[str]) -> pa.Table:
+        return pa.Table.from_arrays(
+            [self._table[c] for c in columns],
+            names=list(columns)
+        )


### PR DESCRIPTION
This PR was motivated by https://github.com/altair-viz/altair/issues/3280. This same PyArrow cropped up when using VegaFusion with a Polars DataFrame containing a Date32 column.  This PR adds a simple PyArrowDatasource that bypasses the DataFrame Interchange protocol, and this Date32 error. Then it converts Polars to PyArrow and uses this data source. The Polars docs say this is mostly a zero-cost conversion.