### PR TITLE
Fix panics for out-of-range timestamps

### DIFF
--- a/vegafusion-datafusion-udfs/src/udfs/datetime/str_to_utc_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/str_to_utc_timestamp.rs
@@ -80,7 +80,7 @@ pub fn parse_datetime(
                     dt
                 } else {
                     // Handle positive timezone transition by adding 1 hour
-                    let datetime = datetime.with_hour(datetime.hour() + 1).unwrap();
+                    let datetime = datetime.with_hour(datetime.hour() + 1)?;
                     local_tz.from_local_datetime(&datetime).earliest()?
                 };
                 let dt_utc = dt.with_timezone(&chrono::Utc);

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/to_utc_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/to_utc_timestamp.rs
@@ -117,8 +117,7 @@ pub fn to_utc_timestamp(timestamp_array: ArrayRef, tz: Tz) -> Result<ArrayRef, D
                     } else {
                         // Try adding 1 hour to handle daylight savings boundaries
                         let hour = naive_local_datetime.hour();
-                        let new_naive_local_datetime =
-                            naive_local_datetime.with_hour(hour + 1).unwrap();
+                        let new_naive_local_datetime = naive_local_datetime.with_hour(hour + 1)?;
                         tz.from_local_datetime(&new_naive_local_datetime).earliest()
                     };
 


### PR DESCRIPTION
The PR removes some panics that could happen in datetime conversions. In particular, we were using arrow's `unary` function to map a custom function across the elements of an arrow array. For performance reasons, the function will be run on the underlying arrow memory even when the corresponding element is `null`, so the function must be valid for any possible value of the type. For the Date/timestamp types, this causes problems because not all valid integers represent value Dates or Timestamps.  This PR switches to using the `try_unary` function which only evaluates the input function on non-null elements. In addition, I removed a bunch of `unwrap` with proper error propagation.