### PR TITLE
It is better to use the repository field

### DIFF
--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -8,6 +8,7 @@ license = "BSD-3-Clause"
 version = "1.6.7"
 edition = "2021"
 description = "VegaFusion Server"
+repository = "https://github.com/vega/vegafusion"
 
 [features]
 protobuf-src = [ "vegafusion-core/protobuf-src", "dep:protobuf-src",]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.