### PR TITLE
Fix projection pushdown with offset encodings

### DIFF
--- a/vegafusion-core/src/planning/projection_pushdown.rs
+++ b/vegafusion-core/src/planning/projection_pushdown.rs
@@ -6,7 +6,9 @@ use crate::planning::dependency_graph::build_dependency_graph;
 use crate::proto::gen::tasks::{Variable, VariableNamespace};
 use crate::spec::chart::{ChartSpec, ChartVisitor, MutChartVisitor};
 use crate::spec::data::DataSpec;
-use crate::spec::mark::{MarkEncodeSpec, MarkEncodingField, MarkEncodingSpec, MarkSpec};
+use crate::spec::mark::{
+    EncodingOffset, MarkEncodeSpec, MarkEncodingField, MarkEncodingSpec, MarkSpec,
+};
 use crate::spec::scale::{
     ScaleDataReferenceOrSignalSpec, ScaleDataReferenceSort, ScaleDomainSpec,
     ScaleFieldReferenceSpec, ScaleRangeSpec, ScaleSpec,
@@ -147,6 +149,16 @@ impl GetDatasetsColumnUsage for MarkEncodingSpec {
                         usage = usage.with_unknown_usage(datum_var);
                     }
                 }
+            }
+
+            // Handle offset
+            if let Some(EncodingOffset::Encoding(offset)) = &self.offset {
+                usage = usage.union(&offset.datasets_column_usage(
+                    &Some(datum_var.clone()),
+                    usage_scope,
+                    task_scope,
+                    vl_selection_fields,
+                ))
             }
         }
         usage

--- a/vegafusion-core/src/spec/mark.rs
+++ b/vegafusion-core/src/spec/mark.rs
@@ -200,6 +200,9 @@ pub struct MarkEncodingSpec {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<String>,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<EncodingOffset>,
+
     #[serde(flatten)]
     pub extra: HashMap<String, Value>,
 }
@@ -267,4 +270,11 @@ pub struct MarkFacetAggregate {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cross: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum EncodingOffset {
+    Encoding(Box<MarkEncodingSpec>),
+    Value(Value),
 }

--- a/vegafusion-runtime/tests/specs/custom/offset_inside_x.comm_plan.json
+++ b/vegafusion-runtime/tests/specs/custom/offset_inside_x.comm_plan.json
@@ -1,0 +1,20 @@
+{
+  "server_to_client": [
+    {
+      "name": "source_0",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_0_color_domain_Origin",
+      "namespace": "data",
+      "scope": []
+    },
+    {
+      "name": "source_0_y_domain_Miles_per_Gallon",
+      "namespace": "data",
+      "scope": []
+    }
+  ],
+  "client_to_server": []
+}

--- a/vegafusion-runtime/tests/specs/custom/offset_inside_x.vg.json
+++ b/vegafusion-runtime/tests/specs/custom/offset_inside_x.vg.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://vega.github.io/schema/vega/v5.json",
+  "background": "white",
+  "padding": 5,
+  "width": 200,
+  "height": 200,
+  "style": "cell",
+  "data": [
+    {
+      "name": "source_0",
+      "url": "data/cars.json",
+      "format": {"type": "json"},
+      "transform": [
+        {"type": "formula", "expr": "datum.Origin[0]", "as": "OriginInitial"},
+        {
+          "type": "filter",
+          "expr": "isValid(datum[\"Horsepower\"]) && isFinite(+datum[\"Horsepower\"]) && isValid(datum[\"Miles_per_Gallon\"]) && isFinite(+datum[\"Miles_per_Gallon\"])"
+        }
+      ]
+    }
+  ],
+  "marks": [
+    {
+      "name": "marks",
+      "type": "text",
+      "style": ["text"],
+      "from": {"data": "source_0"},
+      "encode": {
+        "update": {
+          "fill": {"scale": "color", "field": "Origin"},
+          "x": {
+            "value": 0,
+            "offset": {
+              "scale": "x", "field": "Horsepower"
+            }
+          },
+          "y": {"scale": "y", "field": "Miles_per_Gallon"},
+          "text": {
+            "signal": "isValid(datum[\"OriginInitial\"]) ? datum[\"OriginInitial\"] : \"\"+datum[\"OriginInitial\"]"
+          },
+          "align": {"value": "center"},
+          "baseline": {"value": "middle"}
+        }
+      }
+    }
+  ],
+  "scales": [
+    {
+      "name": "x",
+      "type": "linear",
+      "domain": [0, 300],
+      "range": [0, {"signal": "width"}],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "y",
+      "type": "linear",
+      "domain": {"data": "source_0", "field": "Miles_per_Gallon"},
+      "range": [{"signal": "height"}, 0],
+      "nice": true,
+      "zero": true
+    },
+    {
+      "name": "color",
+      "type": "ordinal",
+      "domain": {"data": "source_0", "field": "Origin", "sort": true},
+      "range": "category"
+    }
+  ]
+}

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -157,6 +157,7 @@ mod test_custom_specs {
         case("custom/gh_456", 0.001, true),
         case("custom/facet_dots_sort_datum", 0.001, true),
         case("custom/gh_463", 0.001, true),
+        case("custom/offset_inside_x", 0.001, true),
     )]
     fn test_image_comparison(spec_name: &str, tolerance: f64, extract_inline_values: bool) {
         println!("spec_name: {spec_name}");


### PR DESCRIPTION
Fix projection pushdown to detect column usage inside the `offset` encoding inside a parent position encoding. For example:

```json
          "x": {
            "value": 0,
            "offset": {
              "scale": "x", "field": "Horsepower"
            }
          }
```

I don't see documentation for this in https://vega.github.io/vega-lite/docs/encoding.html#position, but Vega-Lite produces it sometimes.