### PR TITLE
Add get_column_usage utility function

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -678,7 +678,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flaky-3.7.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
@@ -4284,25 +4284,6 @@ packages:
   timestamp: 1692026296517
 - kind: conda
   name: executing
-  version: 1.2.0
-  build: pyhd8ed1ab_0
-  subdir: osx-arm64
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-1.2.0-pyhd8ed1ab_0.tar.bz2
-  sha256: 9c03425cd58c474af20e179c9ba121a82984d6c4bfc896bbc992f5ed75dd7539
-  md5: 4c1bc140e2be5c8ba6e3acab99e25c50
-  depends:
-  - python >=2.7
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/executing
-  size: 25013
-  timestamp: 1667317463548
-- kind: conda
-  name: executing
   version: 2.0.1
   build: pyhd8ed1ab_0
   subdir: win-64
@@ -4320,6 +4301,21 @@ packages:
   - pkg:pypi/executing
   size: 27689
   timestamp: 1698580072627
+- kind: conda
+  name: executing
+  version: 2.1.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
+  sha256: a52d7516e2e11d3eb10908e10d3eb3f8ef267fea99ed9b09d52d96c4db3441b8
+  md5: d0441db20c827c11721889a241df1220
+  depends:
+  - python >=2.7
+  license: MIT
+  license_family: MIT
+  size: 28337
+  timestamp: 1725214501850
 - kind: conda
   name: expat
   version: 2.5.0

--- a/pixi.toml
+++ b/pixi.toml
@@ -10,6 +10,7 @@ platforms = ["osx-arm64", "osx-64", "linux-64", "win-64"]
 macos = "12.0"
 
 [tasks]
+fmt-rs = "cargo fmt --all"
 check-rs-fmt = "cargo fmt --all -- --check"
 check-rs-warnings = "export RUSTFLAGS=\"-D warnings\" && cargo check --tests"
 check-rs-clippy = "cargo clippy -- -A clippy::borrow_deref_ref"

--- a/vegafusion-core/src/spec/data.rs
+++ b/vegafusion-core/src/spec/data.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_common::error::VegaFusionError;
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct DataSpec {
     pub name: String,
 

--- a/vegafusion-python/tests/test_get_column_usage.py
+++ b/vegafusion-python/tests/test_get_column_usage.py
@@ -1,0 +1,17 @@
+import json
+from pathlib import Path
+
+
+import vegafusion as vf
+
+here = Path(__file__).parent
+
+spec_dir = here / ".." / ".." / "vegafusion-runtime" / "tests" / "specs"
+
+
+def test_get_column_usage():
+    spec_file = spec_dir / "vegalite" / "concat_marginal_histograms.vg.json"
+    spec = json.loads(spec_file.read_text("utf8"))
+    usages = vf.get_column_usage(spec)
+
+    assert usages == {"source_0": ["IMDB Rating", "Rotten Tomatoes Rating"]}

--- a/vegafusion-python/vegafusion/__init__.py
+++ b/vegafusion-python/vegafusion/__init__.py
@@ -5,6 +5,7 @@ from typing import cast
 from ._vegafusion import __version__
 from .local_tz import get_local_tz, set_local_tz
 from .runtime import runtime
+from .utils import get_column_usage
 
 
 def patched_version(distribution_name: str) -> str:
@@ -20,8 +21,10 @@ def patched_version(distribution_name: str) -> str:
 # Patch importlib.metadata.version to handle our dummy package
 importlib.metadata.version = patched_version
 
+
 __all__ = [
     "runtime",
     "set_local_tz",
     "get_local_tz",
+    "get_column_usage",
 ]

--- a/vegafusion-python/vegafusion/utils.py
+++ b/vegafusion-python/vegafusion/utils.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+from ._vegafusion import get_column_usage as _get_column_usage
+
+
+def get_column_usage(spec: dict[str, Any]) -> dict[str, list[str] | None]:
+    """
+    Compute the columns from each root dataset that are referenced in a
+    Vega spec.
+
+    Args:
+        spec: Vega spec
+
+    Returns:
+        dict[str, list[str] | None]: Dict from root-level dataset name
+            to either:
+               - A list of columns that are referenced in this dataset if this can
+                 be determined precisely
+               - None if it was not possible to determine the full set of columns
+                 that are referenced from this dataset
+    """
+    return cast("dict[str, list[str] | None]", _get_column_usage(spec))

--- a/vegafusion-runtime/tests/test_projection_pushdown.rs
+++ b/vegafusion-runtime/tests/test_projection_pushdown.rs
@@ -6,9 +6,11 @@ fn crate_dir() -> String {
 #[cfg(test)]
 mod test_custom_specs {
     use crate::crate_dir;
+    use itertools::Itertools;
     use rstest::rstest;
     use std::fs;
     use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
+    use vegafusion_core::planning::projection_pushdown::get_column_usage;
     use vegafusion_core::spec::chart::ChartSpec;
     use vegafusion_core::spec::transform::TransformSpec;
 
@@ -32,7 +34,7 @@ mod test_custom_specs {
             "bin_maxbins_60_IMDB Rating_end"
         ]),
     )]
-    fn test(spec_name: &str, data_index: usize, projection_fields: Vec<&str>) {
+    fn test_proj_pushdown(spec_name: &str, data_index: usize, projection_fields: Vec<&str>) {
         // Load spec
         let spec_path = format!("{}/tests/specs/{}.vg.json", crate_dir(), spec_name);
         let spec_str = fs::read_to_string(spec_path).unwrap();
@@ -49,12 +51,40 @@ mod test_custom_specs {
 
         // Print data
         // println!("{}", serde_json::to_string_pretty(&spec_plan.server_spec.data).unwrap());
+        let expected_fields: Vec<_> = projection_fields
+            .into_iter()
+            .map(String::from)
+            .sorted()
+            .collect();
 
         if let TransformSpec::Project(project) = tx {
-            let expected_fields: Vec<_> = projection_fields.iter().map(|f| f.to_string()).collect();
             assert_eq!(project.fields, expected_fields);
         } else {
             panic!("Expected project transform")
         }
+    }
+
+    # [rstest(
+        spec_name,
+        projection_fields,
+        case("vegalite/point_2d", vec!["Horsepower", "Miles_per_Gallon"]),
+        case("vegalite/point_bubble", vec!["Acceleration", "Horsepower", "Miles_per_Gallon"]),
+        case("vegalite/concat_marginal_histograms", vec![
+            "IMDB Rating",
+            "Rotten Tomatoes Rating",
+        ]),
+        case("vegalite/rect_binned_heatmap", vec![
+            "IMDB Rating",
+            "Rotten Tomatoes Rating",
+        ]),
+    )]
+    fn test_get_column_usage(spec_name: &str, projection_fields: Vec<&str>) {
+        // Load spec
+        let spec_path = format!("{}/tests/specs/{}.vg.json", crate_dir(), spec_name);
+        let spec_str = fs::read_to_string(spec_path).unwrap();
+        let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
+        let root_usages = get_column_usage(&spec).unwrap();
+        let expected_fields: Vec<_> = projection_fields.into_iter().map(String::from).collect();
+        assert_eq!(root_usages["source_0"], Some(expected_fields));
     }
 }


### PR DESCRIPTION
Adds a `get_column_usage` utility function for Rust and Python that compute the columns from the root datasets that are used by a Vega spec.

I'm planning to remove the Python Datasource logic in favor of projecting down to the required columns and then using the Arrow PyCapsule API.  This should be more efficient as it won't involve calling back into Python to load data.