### PR TITLE
Add initial Arrow PyCapsule support

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -316,7 +316,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
@@ -348,7 +348,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install Chrome
         uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,6 +2669,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2774,21 @@ name = "multimap"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+
+[[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
 
 [[package]]
 name = "normalize-line-endings"
@@ -2864,6 +2889,22 @@ checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+]
+
+[[package]]
+name = "numpy"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf314fca279e6e6ac2126a4ff98f26d88aa4ad06bc68fb6ae5cf4bd706758311"
+dependencies = [
+ "half",
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -3227,6 +3268,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcdd8420072e66d54a407b3316991fe946ce3ab1083a7f575b2463866624704d"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3371,11 +3421,13 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15ee168e30649f7f234c3d49ef5a7a6cbf5134289bc46c29ff3155fa3221c225"
+checksum = "00e89ce2565d6044ca31a3eb79a334c3a79a841120a98f64eea9f579564cb691"
 dependencies = [
  "cfg-if",
+ "chrono",
+ "indexmap 2.6.0",
  "indoc",
  "libc",
  "memoffset",
@@ -3388,10 +3440,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3-build-config"
-version = "0.22.3"
+name = "pyo3-arrow"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61cef80755fe9e46bb8a0b8f20752ca7676dcc07a5277d8b7768c6172e529b3"
+checksum = "41daebb73c3f012db97bd7af03ee989b8ae9b9802f140dc2ccf0ce95345236f4"
+dependencies = [
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "indexmap 2.6.0",
+ "numpy",
+ "pyo3",
+ "thiserror",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8afbaf3abd7325e08f35ffb8deb5892046fcb2608b703db6a583a5ba4cea01e"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -3399,9 +3468,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce096073ec5405f5ee2b8b31f03a68e02aa10d5d4f565eca04acc41931fa1c"
+checksum = "ec15a5ba277339d04763f4c23d85987a5b08cbb494860be141e6a10a8eb88022"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -3409,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2440c6d12bc8f3ae39f1e775266fa5122fd0c8891ce7520fa6048e683ad3de28"
+checksum = "15e0f01b5364bcfbb686a52fc4181d412b708a68ed20c330db9fc8d2c2bf5a43"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -3421,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be962f0e06da8f8465729ea2cb71a416d2257dff56cbe40a70d3e62a93ae5d1"
+checksum = "a09b550200e1e5ed9176976d0060cbc2ea82dc8515da07885e7b8153a85caacb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3462,7 +3531,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.14",
  "socket2",
  "thiserror",
@@ -3479,7 +3548,7 @@ dependencies = [
  "bytes",
  "rand",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "rustls 0.23.14",
  "slab",
  "thiserror",
@@ -3538,6 +3607,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -3818,6 +3893,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -4849,9 +4930,11 @@ dependencies = [
  "datafusion-functions",
  "datafusion-proto",
  "datafusion-proto-common",
+ "deterministic-hash",
  "jni",
  "object_store",
  "pyo3",
+ "pyo3-arrow",
  "serde_json",
  "sqlparser",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,12 @@ chrono-tz = { version = "0.9.0", features = [
   "case-insensitive",
   "filter-by-regex",
 ] }
+deterministic-hash = "1.0.1"
 reqwest = { version = "0.11.22", default-features = false }
 tokio = { version = "1.36.0" }
-pyo3 = { version = "0.22" }
+pyo3 = { version = "0.22.4" }
 pythonize = { version = "0.22" }
+pyo3-arrow = "0.5.0"
 prost = { version = "0.12.3" }
 prost-types = { version = "0.12.3" }
 object_store = { version = "0.11.0" }

--- a/pixi.lock
+++ b/pixi.lock
@@ -14,11 +14,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aom-3.6.1-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.4-hc8144f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.2-h09139f6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.3-hd590300_0.conda
@@ -41,7 +41,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.5-h0f2a231_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hd590300_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
@@ -52,22 +52,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.0-h3faef2a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/charls-2.4.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.6-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.2-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.7-py311hfdbb021_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flaky-3.7.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
@@ -84,12 +84,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py310h1b8f574_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py311ha6695c7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2023.9.18-py310h3a85d3a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2023.9.18-py311h9b38416_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
@@ -102,13 +102,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
@@ -141,13 +141,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h516909a_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-devel_linux-64-13.2.0-ha9c7c90_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h315aac3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h840a212_1.conda
@@ -163,7 +164,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.3-hd1fb520_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.2.0-h7e041cc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
@@ -174,19 +175,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.44.2-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.15-h0b41bf4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-h4ab18f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzopfli-1.0.3-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.9.4-hcb278e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.1-py311h2dc5d0c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.2.3-py310h75e40e8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.2.3-py311h63ff55d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minio-server-2023.09.23.03.47.50-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py310ha75aee5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
@@ -195,12 +197,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbval-0.9.6-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nodejs-20.5.1-hb753e55_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py310hb13e2d6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-20.0.0-hfea2f88_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
@@ -208,7 +210,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py310h7cbd5c2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py311h320fe9a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.3-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
@@ -216,39 +218,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.1-py310h29da1c1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.1-py311h8aef010_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.42.2-h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-0.18.15-py310h2d36a57_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-1.8.2-py311hcc3b33b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.23.3-py310hb875b13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.23.3-py311hbec7ed6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-12.0.1-py310hf9e7431_12_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-12.0.1-py311h39c9aba_12_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.0.0-py310hea249c9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.0.0-py311hf86e51f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.4.1-py310h1f7b6fc_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.7.0-py311h9f3472d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.03.02-h8c504da_0.conda
@@ -257,13 +259,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py310h624018c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.20.0-py311h9e33e62_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py311hef32070_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.54-h06160fa_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.21.0-py310hc6cd4ac_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.21.0-py311hb755f60_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he1f765f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/selenium-4.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/selenium-manager-4.11.0-he8a937b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
@@ -284,9 +286,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/trio-0.22.2-py310hff52083_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/trio-0.26.2-py311h38be061_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trio-websocket-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -297,17 +299,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vega_datasets-0.9.0-pyhd3deb0d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-1.7.0-py310ha75aee5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-1.7.0-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.21.0-py310hcb5633a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py311h9e33e62_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-12.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-13.1-py311h9ecbd09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py310h2372a71_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h9ecbd09_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
@@ -343,11 +345,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aom-3.6.1-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.4-h7fea801_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.2-hfc10710_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.3-h0dc2134_0.conda
@@ -369,26 +371,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-1.1.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-bin-1.1.0-h0dc2134_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brunsli-0.1-h046ec9c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.21.0-h10d778d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.10.5-h354e526_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.14.3-h0ae8482_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/charls-2.4.2-he965462_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.6-unix_pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.2-py310h6729b98_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.2-py311h1314207_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/dav1d-1.2.1-h0dc2134_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.7-py311hd89902b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
@@ -401,11 +403,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hb1e8313_1004.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py310h0d4bf3c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py311h43071ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2023.9.18-py310hc703689_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2024.1.1-py311hc08054d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
@@ -418,13 +420,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
@@ -436,7 +438,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/jxrlib-1.1-h35c211d_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/krb5-1.21.2-hb884880_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230125.3-cxx17_h000cb23_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
@@ -454,19 +456,22 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-haf1e3a3_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h37a168a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.56.2-he6801ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.1.0-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.10.3-hfb90b89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.55.1-hc0a10c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.23.3-h5feb325_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
@@ -476,18 +481,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.2.13-h8a1eda9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzopfli-1.0.3-h046ec9c_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.1-h545e0da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lz4-c-1.9.4-hf0c8a7f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.1-py311ha971863_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.2.3-py310hcdf1ef2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.2.3-py311hc3cf65e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/minio-server-2023.09.23.03.47.50-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py310h837254d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py311h3336109_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
@@ -496,60 +501,60 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbval-0.9.6-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.8-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/nodejs-20.5.1-h119ffd7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py310h0171094_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-20.0.0-h7d26f99_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hef23039_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.3-py310h5e4fcda_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.3-py311hab14417_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.3-h9d075a6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py311h1b85569_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-0.18.15-py310h95fa17d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-1.8.2-py311h859c8f9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.23.3-py310h4e8a696_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.23.3-py311h700567c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-12.0.1-py310h6eef95f_12_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-12.0.1-py311h7c6147c_12_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.9-h657bba9_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.0.0-py310he0a0c5d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.0.0-py311hbafa61a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pywavelets-1.4.1-py310hf0b6da5_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pywavelets-1.7.0-py311h0034819_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h95f92fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rav1e-0.6.6-h7205ca4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.03.02-h096449b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
@@ -557,12 +562,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.9-py310h4f26fa7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.20.0-py311h95688db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.9-py311h8c6096b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/rust-1.80.1-h6c54e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-apple-darwin-1.80.1-h38e4360_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-image-0.21.0-py310h9e9d8ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scikit-image-0.21.0-py311hdf8f085_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hb3ed397_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/selenium-4.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/selenium-manager-4.11.0-h7205ca4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
@@ -582,9 +587,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hef22860_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/trio-0.22.2-py310h2ec42d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/trio-0.26.2-py311h6eed73b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trio-websocket-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -594,17 +599,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vega_datasets-0.9.0-pyhd3deb0d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-1.7.0-py310h837254d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-1.7.0-py311h3336109_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.21.0-py310h0e083fb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py311h95688db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/websockets-12.0-py310hb372a2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/websockets-13.1-py311h3336109_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py310hb372a2b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py311h3336109_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxau-1.0.11-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xorg-libxdmcp-1.1.3-h35c211d_0.tar.bz2
@@ -612,37 +617,36 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarn-3.6.1-h31011fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zfp-1.0.0-hf3d7188_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/zfp-1.0.1-h469392a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.2.13-h8a1eda9_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-ng-2.0.7-hb7f2c08_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.4.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aom-3.5.0-h7ea286d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-21.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h8e9501a_3.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.2.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-h109ad1a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.1-hb406d48_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-hab8b942_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.2-he70778a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.0-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-he70778a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.1-hcf14f3f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.11-hcbec455_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-he8ad1d2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.3-hf45dd20_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-hf0e1321_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hcf14f3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.12-he297698_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-h3c776e5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.5-h83b98fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-h24e141d_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-he70778a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-he70778a_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.21.0-hda227cd_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h1190f42_19.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.23.0-h04fc39a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h0092a47_21.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
@@ -652,7 +656,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.4-hc338f07_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.0.9-h1a8c8d9_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.0.9-h1a8c8d9_9.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py310h0f1eb42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py311ha397e9f_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brunsli-0.1-h9f76cd9_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h3422bc3_4.tar.bz2
@@ -663,7 +667,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cairo-1.16.0-h1e71087_1016.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py310h2399d43_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.2.0-h2f961c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/charls-2.4.2-h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.2.0-pyhd8ed1ab_0.conda
@@ -671,15 +675,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.0-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.6.2-py311hae2e1ce_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.6.8-py310h1253130_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.7-py311h3f08180_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/executing-2.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/flaky-3.7.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/flit-core-3.9.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
@@ -701,12 +705,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.76.4-ha614eb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py310h95b248a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py311hea943cd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-7.3.0-h46e5fef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-72.1-he12128b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2023.1.23-py310hd30fb6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2023.1.23-py311h7b871a3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.1-pyh24c5eb1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
@@ -726,7 +730,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.1-py310hbe9552e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.7.0-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
@@ -742,7 +746,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230125.3-cxx17_h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.0.6-hb7217d7_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-12.0.1-hb74b275_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-12.0.1-h6e4acf5_9_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif-0.11.1-h9f83d30_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-17_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_9.conda
@@ -756,7 +760,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-12_2_0_hd922786_32.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-12.2.0-h0eea778_32.conda
@@ -771,7 +775,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.23.3-hf32f9b9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librsvg-2.56.3-h0db3404_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.18.1-ha061701_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda
@@ -785,15 +789,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-16.0.6-h1c12783_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.9.4-hb7217d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.1-py311h0ecf0c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.2.3-py310hdd3b5e7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.2.3-py311h5fb2c35_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minio-server-2023.09.23.03.47.50-hf0a4a13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py310h493c2e1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py311h460d6c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
@@ -802,12 +806,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.7.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbval-0.9.6-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.5.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-20.5.1-ha2ed473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.2-py310haa1e00c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-20.0.0-hbe7ddab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
@@ -815,7 +819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.3-py310h1cdf563_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.3-py311h9e438b8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.1.3-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pango-1.50.14-h9f7e0c6_1.conda
@@ -824,55 +828,55 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.8.0-pyh1a96a4e_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py310h5a7539a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py311h627eb56_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.40.0-h27ca646_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pkg-config-0.29.2-hab62308_1008.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.2.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-0.18.15-py310h49106b5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.8.2-py311h749c62c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pooch-1.7.0-pyha770c72_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.17.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.23.3-py310hf4e154e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h8e9501a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.23.3-py311h4acf6a1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-12.0.1-py310hfbab16f_8_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-12.0.1-py311hd7bc329_9_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-9.2-py310hd07e440_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-9.2-py310hd07e440_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.12-h01493a6_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.9-h932a869_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.0.0-py310hcf9f62a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.0.0-py311hb9542d7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-3_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pywavelets-1.4.1-py310hf1a086a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0-py310h8e9501a_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h30b7201_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pywavelets-1.7.0-py311h0f07fe1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h137d824_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.03.02-hc5e2d97_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.9.2-py310had9acf8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.6.9-py310he174661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.20.0-py311h481aa64_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.6.9-py311h2cf8269_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rust-1.80.1-h4ff7c5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-aarch64-apple-darwin-1.80.1-hf6ec828_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-image-0.21.0-py310h1253130_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.1-py310h0975f3d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-image-0.21.0-py311ha891d26_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.1-py311h93d07a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/selenium-4.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/selenium-manager-4.11.0-h69fbcac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
@@ -888,12 +892,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/terminado-0.17.1-pyhd1c38e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tifffile-2023.8.12-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.2-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/trio-0.21.0-py310hbe9552e_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/trio-0.26.2-py311h267d04e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trio-websocket-0.10.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
@@ -902,24 +906,24 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vega_datasets-0.9.0-pyhd3deb0d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-1.7.0-py310h493c2e1_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-1.7.0-py311h460d6c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.21.0-py310hd442715_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py311h481aa64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.6-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-11.0.3-py310h2aa6e3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-13.1-py311h460d6c5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.8-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py310hd125d64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py311h460d6c5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.11-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.3-h27ca646_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarn-3.6.1-h31011fe_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.4-hbdafb3b_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hcc0f68c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zfp-1.0.0-hb6e4faa_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.16.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.2.13-h53f4e23_5.conda
@@ -931,11 +935,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.6.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.4-hc10d58f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.2-hd5965a7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.3-hcfcfb64_0.conda
@@ -955,25 +959,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.21.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.10.5-h183a6f4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.14.3-h183a6f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2023.7.22-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/charls-2.4.2-h1537add_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.1.6-win_pyh7428d3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/comm-0.1.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/configparser-5.3.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.3.2-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.2-py311he736701_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/dav1d-1.2.1-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.7-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
@@ -984,10 +989,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/giflib-5.2.1-h64bf75a_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py310hb84602e_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py311h5bc0dda_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2023.9.18-py310h0dcf169_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.1.1-py311hd83dc81_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
@@ -1001,13 +1006,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.2-pyhd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.7.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.5.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.9.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.4.4-pyhd8ed1ab_1.conda
@@ -1017,12 +1022,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jupytext-1.15.0-pyhcff175f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/jxrlib-1.1-h8ffe710_2.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy_loader-0.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230125.3-cxx17_h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-12.0.1-hba3d5be_12_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libavif-1.0.1-hea6d26e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
@@ -1031,9 +1036,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-hbc1b25b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.56.2-hea2d5f7_1.conda
@@ -1041,18 +1047,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/liblapack-3.9.0-19_win64_mkl.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.23.3-h1975477_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-h013a479_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.6-hc3477c8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libzopfli-1.0.3-h0e60522_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/lz4-c-1.9.4-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gcc-libgfortran-5.3.0-6.tar.bz2
@@ -1061,9 +1067,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-gmp-6.1.0-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/m2w64-libwinpthread-git-5.0.0.4634.697f757-2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-3.0.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.1-py311h5082efb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.2.3-py310he2c049f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/maturin-1.2.3-py311h9a9e57f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdit-py-plugins-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/minio-7.1.17-pyhd8ed1ab_0.conda
@@ -1071,7 +1077,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2023.2.0-h6a75c08_50496.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/msys2-conda-epoch-20160418-1.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py310ha8f682b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.0.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.8.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.7.4-pyhd8ed1ab_0.conda
@@ -1084,66 +1090,66 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.5.1-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py310hf667824_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjdk-20.0.0-h57928b3_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hf2b8f0d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.3-py310h1c4a608_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.3-py311hf63dbb6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.3-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pep517-0.13.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py311h5592be9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-23.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-3.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.3.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-0.18.15-py310he0a9947_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/polars-1.8.2-py311h445572d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.18.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.39-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.39-hd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/protobuf-4.23.3-py310ha3d488f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/protobuf-4.23.3-py311h03b55d4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/psygnal-0.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-12.0.1-py310hd0bb7c2_12_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-12.0.1-py311h6a6099b_12_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-7.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-cov-4.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_2_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.0.0-py310h9e98ed7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.0.0-py311hda3d55a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.18.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2023.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2023.3.post1-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pywavelets-1.4.1-py310h3e78b6c_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywavelets-1.7.0-py311h0a17f05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py311hda3d55a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rav1e-0.6.6-h975169c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/re2-2023.03.02-hd4eee63_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.31.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.9-py310h11b6ba5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.20.0-py311h533ab2d_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.9-py311heeab51b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/rust-1.80.1-hf8d6059_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-pc-windows-msvc-1.80.1-h17fc481_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-image-0.21.0-py310h00ffb61_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scikit-image-0.21.0-py311h12c1d0e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hd4686c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/selenium-4.11.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/selenium-manager-4.11.0-h975169c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
@@ -1165,9 +1171,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/tk-8.6.13-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.0.1-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.13.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/trio-0.22.2-py310h5588dad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/trio-0.26.2-py311h1ea47a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/trio-websocket-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.12.2-hd8ed1ab_0.conda
@@ -1180,31 +1186,31 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h64f974e_17.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.40.33810-ha82c5b3_20.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vega_datasets-0.9.0-pyhd3deb0d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vl-convert-python-1.7.0-py310hdfd1e6a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vl-convert-python-1.7.0-py311h7b6d46a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/voila-0.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.40.33810-h3bf8584_20.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.21.0-py310h87d50f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py311h533ab2d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.6.4-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/websockets-12.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/websockets-13.1-py311he736701_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.41.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.9-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyhd8ed1ab_6.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py310h8d17308_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py311he736701_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wsproto-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxau-1.0.11-hcd874cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xorg-libxdmcp-1.1.3-hcd874cb_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/xz-5.2.6-h8d14728_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/yarn-3.6.1-h5737063_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zfp-1.0.0-h63175ca_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zfp-1.0.1-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.0.7-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
 - kind: conda
   name: _libgcc_mutex
@@ -1292,31 +1298,6 @@ packages:
   timestamp: 1724754076209
 - kind: conda
   name: anyio
-  version: 3.7.1
-  build: pyhd8ed1ab_0
-  subdir: osx-arm64
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-3.7.1-pyhd8ed1ab_0.conda
-  sha256: 62637ac498bcf47783cbf4f48e9b09e4e2f5a6ad42f43ca8f632c353827b94f4
-  md5: 7b517e7a6f0790337906c055aa97ca49
-  depends:
-  - exceptiongroup *
-  - python >=3.7
-  - typing_extensions *
-  - idna >=2.8
-  - sniffio >=1.1
-  constrains:
-  - trio >=0.16,<0.22
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/anyio
-  size: 96707
-  timestamp: 1688651250785
-- kind: conda
-  name: anyio
   version: 4.0.0
   build: pyhd8ed1ab_0
   subdir: win-64
@@ -1339,6 +1320,29 @@ packages:
   - pkg:pypi/anyio
   size: 98958
   timestamp: 1693488730301
+- kind: conda
+  name: anyio
+  version: 4.6.0
+  build: pyhd8ed1ab_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.6.0-pyhd8ed1ab_1.conda
+  sha256: d05493abca6ac1b0cb15f5d48c3117bddd73cc21e48bfcb460570cfa2ea2f909
+  md5: bc13891a047f50728b03595531f7f92e
+  depends:
+  - exceptiongroup >=1.0.2
+  - idna >=2.8
+  - python >=3.9
+  - sniffio >=1.1
+  - typing_extensions >=4.1
+  constrains:
+  - uvloop >=0.21.0b1
+  - trio >=0.26.1
+  license: MIT
+  license_family: MIT
+  size: 108445
+  timestamp: 1726931347728
 - kind: conda
   name: anywidget
   version: 0.9.13
@@ -1493,91 +1497,79 @@ packages:
 - kind: conda
   name: argon2-cffi-bindings
   version: 21.2.0
-  build: py310h2372a71_4
-  build_number: 4
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py310h2372a71_4.conda
-  sha256: af94cc9b4dcaa164e1cc7e7fa0b9eb56b87ea3dc6e093c8ef6c31cfa02d9ffdf
-  md5: 68ee85860502d53c8cbfa0e4cef0f6cb
-  depends:
-  - cffi >=1.0.1
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/argon2-cffi-bindings
-  size: 34384
-  timestamp: 1695386695142
-- kind: conda
-  name: argon2-cffi-bindings
-  version: 21.2.0
-  build: py310h6729b98_4
-  build_number: 4
+  build: py311h3336109_5
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py310h6729b98_4.conda
-  sha256: c413de1658b9f34978e1a5c8dc1e93b75fdef8e453f0983a4d2fa4b6a669e2b2
-  md5: fea2a01f85aee10b268e0474a03eb148
+  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py311h3336109_5.conda
+  sha256: fa5eb633b320e10fc2138f3d842d8a8ca72815f106acbab49a68ec9783e4d70d
+  md5: 29b46bd410067f668c4cef7fdc78fe25
   depends:
+  - __osx >=10.13
   - cffi >=1.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/argon2-cffi-bindings
-  size: 31851
-  timestamp: 1695387111978
+  size: 32275
+  timestamp: 1725356815696
 - kind: conda
   name: argon2-cffi-bindings
   version: 21.2.0
-  build: py310h8d17308_4
-  build_number: 4
+  build: py311h460d6c5_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py311h460d6c5_5.conda
+  sha256: 6eabd1bcefc235b7943688d865519577d7668a2f4dc3a24ee34d81eb4bfe77d1
+  md5: 1e8260965552c6ec86453b7d15a598de
+  depends:
+  - __osx >=11.0
+  - cffi >=1.0.1
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 33008
+  timestamp: 1725356833036
+- kind: conda
+  name: argon2-cffi-bindings
+  version: 21.2.0
+  build: py311h9ecbd09_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py311h9ecbd09_5.conda
+  sha256: d1af1fbcb698c2e07b0d1d2b98384dd6021fa55c8bcb920e3652e0b0c393881b
+  md5: 18143eab7fcd6662c604b85850f0db1e
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.0.1
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 35025
+  timestamp: 1725356735679
+- kind: conda
+  name: argon2-cffi-bindings
+  version: 21.2.0
+  build: py311he736701_5
+  build_number: 5
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310h8d17308_4.conda
-  sha256: ae143aec777823b2291caabc3fd89078a3ff12f41945e0f9abd168997ad35d39
-  md5: ece29c9dd68f962fd416a3ddcce24080
+  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py311he736701_5.conda
+  sha256: 8bbce5e61e012a06e248f58bb675fdc82ba2900c78590696d185150fb9cea91f
+  md5: 8917bf795c40ec1839ed9d0ab3ad9735
   depends:
   - cffi >=1.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/argon2-cffi-bindings
-  size: 33906
-  timestamp: 1695387195123
-- kind: conda
-  name: argon2-cffi-bindings
-  version: 21.2.0
-  build: py310h8e9501a_3
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py310h8e9501a_3.tar.bz2
-  sha256: 87810814f179c6160faccb463831f32fe19d48bc6f669050b4f4c577662733b4
-  md5: d4b00cfac2beb306e8ac5fc664eb94d9
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - cffi >=1.0.1
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/argon2-cffi-bindings
-  size: 33737
-  timestamp: 1666851190124
+  size: 34883
+  timestamp: 1725357113431
 - kind: conda
   name: arrow
   version: 1.2.3
@@ -1677,65 +1669,39 @@ packages:
   size: 15342
   timestamp: 1690563152778
 - kind: conda
-  name: async_generator
-  version: '1.10'
-  build: py_0
-  subdir: osx-arm64
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/async_generator-1.10-py_0.tar.bz2
-  sha256: b45a479387f9eab020da572f87f37d55182e5b41c21a7851d6fc7dcb635a3cf0
-  md5: d56c596e61b1c4952acf0a9920856c12
-  depends:
-  - python >2.7
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/async-generator
-  size: 18014
-  timestamp: 1533114627495
-- kind: conda
   name: attrs
-  version: 23.1.0
-  build: pyh71513ae_1
-  build_number: 1
-  subdir: win-64
+  version: 24.2.0
+  build: pyh71513ae_0
+  subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/attrs-23.1.0-pyh71513ae_1.conda
-  sha256: 063639cd568f5c7a557b0fb1cc27f098598c0d8ff869088bfeb82934674f8821
-  md5: 3edfead7cedd1ab4400a6c588f3e75f8
+  url: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+  sha256: 28dba85a7e0f7fb57d7315e13f603d1e41b83c5b88aa2a602596b52c833a2ff8
+  md5: 6732fa52eb8e66e5afeb32db8701a791
   depends:
   - python >=3.7
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/attrs
-  size: 55022
-  timestamp: 1683424195402
+  size: 56048
+  timestamp: 1722977241383
 - kind: conda
   name: aws-c-auth
   version: 0.7.3
-  build: h109ad1a_1
-  build_number: 1
+  build: hab8b942_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-h109ad1a_1.conda
-  sha256: 547c24057cb8459186aa09cbc97c58eeca7c9e44d227a01457a2261e1954a36a
-  md5: 55852033dc22d5a2c00d58583447d051
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-hab8b942_3.conda
+  sha256: f27b21ba66bfdccd6e892c78f83d53cbc21ce8fdf594c3d677eede9f225b3820
+  md5: 8c9ad5cf200ddc532d73cd63a4458b76
   depends:
-  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-cal >=0.6.1,<0.6.2.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
   - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
   - aws-c-io >=0.13.32,<0.13.33.0a0
-  arch: aarch64
-  platform: osx
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 91853
-  timestamp: 1691776552289
+  size: 92315
+  timestamp: 1692935723694
 - kind: conda
   name: aws-c-auth
   version: 0.7.4
@@ -1805,24 +1771,6 @@ packages:
   timestamp: 1695806693576
 - kind: conda
   name: aws-c-cal
-  version: 0.6.1
-  build: hb406d48_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.1-hb406d48_1.conda
-  sha256: 066a1933fe8c0c8c0e8a7dc11bada019813b1c09ab290cbaf904bddcd11e036d
-  md5: 2461f9de775b064f549d8e1c2e74c682
-  depends:
-  - aws-c-common >=0.9.0,<0.9.1.0a0
-  - openssl >=3.1.2,<4.0a0
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: Apache
-  size: 36100
-  timestamp: 1691450054491
-- kind: conda
-  name: aws-c-cal
   version: 0.6.2
   build: h09139f6_2
   build_number: 2
@@ -1860,6 +1808,21 @@ packages:
   license_family: Apache
   size: 51212
   timestamp: 1695756000021
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.2
+  build: he70778a_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.2-he70778a_1.conda
+  sha256: a79d40403b1e07f16c7631b1de255a5852f8181a8109d07ee14c3f03b1d050c1
+  md5: 83a5e6490ab433f6045dfeb096f93c17
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 36212
+  timestamp: 1695089175156
 - kind: conda
   name: aws-c-cal
   version: 0.6.2
@@ -2013,26 +1976,6 @@ packages:
   timestamp: 1691607429629
 - kind: conda
   name: aws-c-event-stream
-  version: 0.3.1
-  build: hcf14f3f_4
-  build_number: 4
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.1-hcf14f3f_4.conda
-  sha256: eb127382b09a721a916ebf54c7aef8acbeefd00d5e2b14c45ec69f847bb50bf1
-  md5: e8196ecb071eb3c07067008403182323
-  depends:
-  - aws-c-io >=0.13.32,<0.13.33.0a0
-  - libcxx >=15.0.7
-  - aws-checksums >=0.1.17,<0.1.18.0a0
-  - aws-c-common >=0.9.0,<0.9.1.0a0
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: Apache
-  size: 48878
-  timestamp: 1691761518448
-- kind: conda
-  name: aws-c-event-stream
   version: 0.3.2
   build: hab6341b_1
   build_number: 1
@@ -2051,6 +1994,23 @@ packages:
   license_family: Apache
   size: 46908
   timestamp: 1695787042268
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hcf14f3f_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hcf14f3f_0.conda
+  sha256: 1923838df400cf19d21a54dc7f19afe5a949339cd998725504c936fe0b24d68a
+  md5: 6c6fc8e9f1fa171136e58a33ffb95d5f
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 48862
+  timestamp: 1692836283506
 - kind: conda
   name: aws-c-event-stream
   version: 0.3.2
@@ -2096,24 +2056,22 @@ packages:
   timestamp: 1695787146551
 - kind: conda
   name: aws-c-http
-  version: 0.7.11
-  build: hcbec455_4
-  build_number: 4
+  version: 0.7.12
+  build: he297698_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.11-hcbec455_4.conda
-  sha256: de3b7d7729acbe9883ce8b4ab28130042b9c2e39616b616ee57555522afed65d
-  md5: 13a5f11f32954de3c6ee5680700ce421
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.12-he297698_1.conda
+  sha256: 5afb1a690124d76a6771b52567fe38a348e5feb113a0c6ea173123dbaaa51f51
+  md5: 8d952fa86e3c02043e85650080ba817b
   depends:
-  - aws-c-cal >=0.6.1,<0.6.2.0a0
-  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
   - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
   - aws-c-io >=0.13.32,<0.13.33.0a0
-  arch: aarch64
-  platform: osx
   license: Apache-2.0
   license_family: Apache
-  size: 158248
-  timestamp: 1691761391491
+  size: 157732
+  timestamp: 1692913796109
 - kind: conda
   name: aws-c-http
   version: 0.7.13
@@ -2219,6 +2177,22 @@ packages:
 - kind: conda
   name: aws-c-io
   version: 0.13.32
+  build: h3c776e5_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-h3c776e5_3.conda
+  sha256: 5600008b82bdf1d3b025a99e6a39ca9b6cedf901c2c98357cccc7b4fb94237ba
+  md5: f88f5e6e0dbe5e19d55344b8c2cfc900
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139753
+  timestamp: 1694551424429
+- kind: conda
+  name: aws-c-io
+  version: 0.13.32
   build: ha16e049_6
   build_number: 6
   subdir: win-64
@@ -2238,41 +2212,22 @@ packages:
   size: 158041
   timestamp: 1696720098642
 - kind: conda
-  name: aws-c-io
-  version: 0.13.32
-  build: he8ad1d2_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-he8ad1d2_0.conda
-  sha256: b01fb7cbc6a2563ab88486f288334f4961fecc476709747aa74cb31f38e31854
-  md5: d4db40638882d969a04c1822c8a6f19b
-  depends:
-  - aws-c-cal >=0.6.1,<0.6.2.0a0
-  - aws-c-common >=0.9.0,<0.9.1.0a0
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: Apache
-  size: 140021
-  timestamp: 1691713205392
-- kind: conda
   name: aws-c-mqtt
-  version: 0.9.3
-  build: hf45dd20_1
+  version: 0.9.5
+  build: h83b98fe_1
   build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.3-hf45dd20_1.conda
-  sha256: 1b0e3ac3b683f00f37e6caac12f3a3e257ded1c5f8e3f7cd59bdfb7068a5abee
-  md5: 2602feff0c3c7904cc9f743d5c5bdb74
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.5-h83b98fe_1.conda
+  sha256: 1e02fdc8853eaf607093930d6696f0eedd3f4caf65addf2ebcb12a48b438b984
+  md5: 2b1cf8c40fe264f66c51ddfbf4a6c643
   depends:
-  - aws-c-io >=0.13.32,<0.13.33.0a0
   - aws-c-common >=0.9.0,<0.9.1.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  arch: aarch64
-  platform: osx
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 123718
-  timestamp: 1691776601878
+  size: 123424
+  timestamp: 1692895315126
 - kind: conda
   name: aws-c-mqtt
   version: 0.9.6
@@ -2337,25 +2292,23 @@ packages:
 - kind: conda
   name: aws-c-s3
   version: 0.3.14
-  build: hf0e1321_1
-  build_number: 1
+  build: h24e141d_3
+  build_number: 3
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-hf0e1321_1.conda
-  sha256: 02b7cd21bf1db9284d5e26cf9fb5a7f8a3e0a856ada807eb51d60e1d66cd8e78
-  md5: 01eb867a0851892b41cb57a7ecaeee8b
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-h24e141d_3.conda
+  sha256: f9bf1668f323197268f9239722cc9273f2ebb4329ab48c469d0798958a952bb3
+  md5: 0fbd1f360ec8b6b08669e900cf31a2bd
   depends:
-  - aws-c-common >=0.9.0,<0.9.1.0a0
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-cal >=0.6.1,<0.6.2.0a0
   - aws-c-auth >=0.7.3,<0.7.4.0a0
-  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
   - aws-c-io >=0.13.32,<0.13.33.0a0
-  arch: aarch64
-  platform: osx
+  - aws-checksums >=0.1.17,<0.1.18.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 77780
-  timestamp: 1691791444688
+  size: 78329
+  timestamp: 1692950426132
 - kind: conda
   name: aws-c-s3
   version: 0.3.17
@@ -2573,30 +2526,28 @@ packages:
   timestamp: 1691457138566
 - kind: conda
   name: aws-crt-cpp
-  version: 0.21.0
-  build: hda227cd_5
+  version: 0.23.0
+  build: h04fc39a_5
   build_number: 5
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.21.0-hda227cd_5.conda
-  sha256: 861bb8ca04a5cad23dfd444967e29735b2430350c7789dc5e869a4e71dac82ae
-  md5: dd47301eea0a420faa1546f5c5d708ff
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.23.0-h04fc39a_5.conda
+  sha256: fdce32ae99b57e0fe9d1b52e56d4dea40c641d9bfa3b38239a9f22c69def37f7
+  md5: 9bfad48efc52d9142f7416978b960ffe
   depends:
-  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
-  - aws-c-event-stream >=0.3.1,<0.3.2.0a0
   - aws-c-auth >=0.7.3,<0.7.4.0a0
-  - aws-c-io >=0.13.32,<0.13.33.0a0
-  - aws-c-s3 >=0.3.14,<0.3.15.0a0
-  - aws-c-mqtt >=0.9.3,<0.9.4.0a0
-  - libcxx >=15.0.7
-  - aws-c-http >=0.7.11,<0.7.12.0a0
-  - aws-c-cal >=0.6.1,<0.6.2.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
   - aws-c-common >=0.9.0,<0.9.1.0a0
-  arch: aarch64
-  platform: osx
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.5,<0.9.6.0a0
+  - aws-c-s3 >=0.3.14,<0.3.15.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=15.0.7
   license: Apache-2.0
   license_family: Apache
-  size: 222274
-  timestamp: 1692188781165
+  size: 223696
+  timestamp: 1692969704783
 - kind: conda
   name: aws-crt-cpp
   version: 0.23.1
@@ -2681,26 +2632,24 @@ packages:
 - kind: conda
   name: aws-sdk-cpp
   version: 1.10.57
-  build: h1190f42_19
-  build_number: 19
+  build: h0092a47_21
+  build_number: 21
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h1190f42_19.conda
-  sha256: b176a2cf86d8c6891f5d234b2be4503492b37554241bad183b4524988c2e82e9
-  md5: bd16f7f2a92c33d1767592c45588dbc7
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h0092a47_21.conda
+  sha256: b11bcb92ea37c422f3fa5939ad953a7eff10c711f2e83082351d38f1a1aad8c8
+  md5: e2e6eecb276e5faa419c1ecfc6a831b1
   depends:
   - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-crt-cpp >=0.23.0,<0.23.1.0a0
   - libcurl >=8.2.1,<9.0a0
-  - openssl >=3.1.2,<4.0a0
   - libcxx >=15.0.7
-  - aws-c-event-stream >=0.3.1,<0.3.2.0a0
-  - aws-crt-cpp >=0.21.0,<0.21.1.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
   license: Apache-2.0
   license_family: Apache
-  size: 3367360
-  timestamp: 1692212958949
+  size: 3363572
+  timestamp: 1692911449964
 - kind: conda
   name: aws-sdk-cpp
   version: 1.11.156
@@ -2715,12 +2664,10 @@ packages:
   - aws-c-event-stream >=0.3.2,<0.3.3.0a0
   - aws-checksums >=0.1.17,<0.1.18.0a0
   - aws-crt-cpp >=0.23.1,<0.23.2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 3228453
@@ -3001,15 +2948,13 @@ packages:
   sha256: 73cee35e5366ce998ef36ccccb4c11ef9ead297886cc08269379f91539131288
   md5: 77a5cea2ce92907b7d1e7954457a526a
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.1.10,<1.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 50069
@@ -3150,90 +3095,83 @@ packages:
 - kind: conda
   name: brotli-python
   version: 1.0.9
-  build: py310h0f1eb42_9
+  build: py311ha397e9f_9
   build_number: 9
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py310h0f1eb42_9.conda
-  sha256: 5a006513c2be8726688ce1f25f88788c59c26c6c0e28d14455c534584b83ed8f
-  md5: 907f4a8f11d2e49fcf85322a8b71a188
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.0.9-py311ha397e9f_9.conda
+  sha256: a0f54181606c26b754567feac9d0595b7d5de5d199aa15129dcfa3eed10ef3b7
+  md5: 34c36b315dc70cde887ea8c3991b994d
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
   - libcxx >=14.0.6
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   constrains:
   - libbrotlicommon 1.0.9 h1a8c8d9_9
-  arch: aarch64
-  platform: osx
   license: MIT
   license_family: MIT
-  size: 325644
-  timestamp: 1687884931491
+  size: 325107
+  timestamp: 1687885049582
 - kind: conda
   name: brotli-python
   version: 1.1.0
-  build: py310h00ffb61_1
+  build: py311h12c1d0e_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
-  sha256: 8de77cf62a653dd6ffe19927b92c421f5fa73c078d7799181f5211a1bac2883b
-  md5: 42bfbc1d41cbe2696a3c9d8b0342324f
+  url: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py311h12c1d0e_1.conda
+  sha256: 5390e1e5e8e159d4893ecbfd2c08ca75ef51bdce1a4a44ff4ee9e2d596004aac
+  md5: 42fbf4e947c17ea605e6a4d7f526669a
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
   - libbrotlicommon 1.1.0 hcfcfb64_1
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 321672
-  timestamp: 1695990897641
+  size: 322086
+  timestamp: 1695990976742
 - kind: conda
   name: brotli-python
   version: 1.1.0
-  build: py310h9e9d8ca_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py310h9e9d8ca_1.conda
-  sha256: 57d66ca3e072b889c94cfaf56eb7e1794d3b1b3179bd475a4edef50a03359354
-  md5: 2362e323293e7699cf1e621d502f86d6
-  depends:
-  - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - libbrotlicommon 1.1.0 h0dc2134_1
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 367037
-  timestamp: 1695990378635
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py310hc6cd4ac_1
+  build: py311hb755f60_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py310hc6cd4ac_1.conda
-  sha256: e22268d81905338570786921b3def88e55f9ed6d0ccdd17d9fbae31a02fbef69
-  md5: 1f95722c94f00b69af69a066c7433714
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hb755f60_1.conda
+  sha256: 559093679e9fdb6061b7b80ca0f9a31fe6ffc213f1dae65bc5c82e2cd1a94107
+  md5: cce9e7c3f1c307f2a5fb08a2922d6164
   depends:
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - libbrotlicommon 1.1.0 hd590300_1
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
-  size: 349397
-  timestamp: 1695990295884
+  size: 351340
+  timestamp: 1695990160360
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py311hdf8f085_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hdf8f085_1.conda
+  sha256: 0f5e0a7de58006f349220365e32db521a1fe494c37ee455e5ecf05b8fe567dcc
+  md5: 546fdccabb90492fbaf2da4ffb78f352
+  depends:
+  - libcxx >=15.0.7
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h0dc2134_1
+  license: MIT
+  license_family: MIT
+  size: 366864
+  timestamp: 1695990449997
 - kind: conda
   name: brunsli
   version: '0.1'
@@ -3456,47 +3394,6 @@ packages:
 - kind: conda
   name: c-blosc2
   version: 2.10.5
-  build: h183a6f4_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.10.5-h183a6f4_0.conda
-  sha256: 68df42bafc5f66e067b8ad0e379cbbbbba233617134d807f23b29f0e274a207a
-  md5: f68bc8958f78c65eee4468bd1b88cd76
-  depends:
-  - lz4-c >=1.9.3,<1.10.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zlib-ng >=2.0.7,<2.1.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 206162
-  timestamp: 1696540181571
-- kind: conda
-  name: c-blosc2
-  version: 2.10.5
-  build: h354e526_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.10.5-h354e526_0.conda
-  sha256: 7db0135f77951f26162152e88d979dcf51b8f04f4136f8a259f5f9ef096df7fd
-  md5: 3d05cf7fe24f5b82cdb618e3f79b1e0c
-  depends:
-  - __osx >=10.9
-  - libcxx >=16.0.6
-  - lz4-c >=1.9.3,<1.10.0a0
-  - zlib-ng >=2.0.7,<2.1.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 273097
-  timestamp: 1696539711149
-- kind: conda
-  name: c-blosc2
-  version: 2.10.5
   build: hb4ffafa_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.10.5-hb4ffafa_0.conda
@@ -3514,6 +3411,42 @@ packages:
   license_family: BSD
   size: 312140
   timestamp: 1696539380773
+- kind: conda
+  name: c-blosc2
+  version: 2.14.3
+  build: h0ae8482_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.14.3-h0ae8482_0.conda
+  sha256: 98ae52dc0d1408452b70481730c02e4bf941a9600d1f9b1f21ecb4e89bf504a3
+  md5: 67bb1c7bc9b81c13a206aaf2e1bcb9cd
+  depends:
+  - libcxx >=16
+  - lz4-c >=1.9.3,<1.10.0a0
+  - zlib-ng >=2.0.7,<2.1.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 278429
+  timestamp: 1712415524207
+- kind: conda
+  name: c-blosc2
+  version: 2.14.3
+  build: h183a6f4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.14.3-h183a6f4_0.conda
+  sha256: 32aa27a47c96975f28fce8618d57d5d0b2a00cc4dc60836a214732fa1c0e4993
+  md5: cb3c2e859ac57ae26fe5b0b35546fda9
+  depends:
+  - lz4-c >=1.9.3,<1.10.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zlib-ng >=2.0.7,<2.1.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 210505
+  timestamp: 1712415661052
 - kind: conda
   name: ca-certificates
   version: 2023.7.22
@@ -3675,84 +3608,79 @@ packages:
   timestamp: 1690024617757
 - kind: conda
   name: cffi
-  version: 1.15.1
-  build: py310h2399d43_3
-  build_number: 3
+  version: 1.17.1
+  build: py311h137bacd_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- kind: conda
+  name: cffi
+  version: 1.17.1
+  build: py311h3a79f62_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.15.1-py310h2399d43_3.conda
-  sha256: 7d5ad84aa0644033b37e51b957f195324eb040f3d167e79a3dc8ada9e746b1eb
-  md5: d0ae0fd0363f0baef9d485c857d1d421
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - pycparser *
+  - __osx >=11.0
   - libffi >=3.4,<4.0a0
-  arch: aarch64
-  platform: osx
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 219352
-  timestamp: 1671180201388
+  size: 288211
+  timestamp: 1725560745212
 - kind: conda
   name: cffi
-  version: 1.16.0
-  build: py310h2fee648_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.16.0-py310h2fee648_0.conda
-  sha256: 007e7f69ab45553b7bf11f2c1b8d3f3a13fd42997266a0d57795f41c7d38df36
-  md5: 45846a970e71ac98fd327da5d40a0a2c
-  depends:
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - pycparser *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 241339
-  timestamp: 1696001848492
-- kind: conda
-  name: cffi
-  version: 1.16.0
-  build: py310h8d17308_0
+  version: 1.17.1
+  build: py311he736701_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.16.0-py310h8d17308_0.conda
-  sha256: 1aeebb88518ab48c927d7360648a2799def172d8fcb0d7e20cb7208a3570ef9e
-  md5: b4bcce1a7ea1164e6dcea6c4f00d962b
+  url: https://conda.anaconda.org/conda-forge/win-64/cffi-1.17.1-py311he736701_0.conda
+  sha256: 9689fbd8a31fdf273f826601e90146006f6631619767a67955048c7ad7798a1d
+  md5: e1c69be23bd05471a6c623e91680ad59
   depends:
-  - pycparser *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 237888
-  timestamp: 1696002116250
+  size: 297627
+  timestamp: 1725561079708
 - kind: conda
   name: cffi
-  version: 1.16.0
-  build: py310hdca579f_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.16.0-py310hdca579f_0.conda
-  sha256: 37802485964f1a3137ed6ab21ebc08fe9d35e7dc4da39f2b72a814644dd1ac15
-  md5: b9e6213f0eb91f40c009ce69139c1869
+  version: 1.17.1
+  build: py311hf29c0ef_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
   depends:
+  - __glibc >=2.17,<3.0.a0
   - libffi >=3.4,<4.0a0
-  - pycparser *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - libgcc >=13
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 229407
-  timestamp: 1696002017767
+  size: 302115
+  timestamp: 1725560701719
 - kind: conda
   name: cfitsio
   version: 4.2.0
@@ -3976,88 +3904,92 @@ packages:
   timestamp: 1660952265700
 - kind: conda
   name: coverage
-  version: 7.3.0
-  build: py310h2aa6e3c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.0-py310h2aa6e3c_0.conda
-  sha256: 64d626181e7555587685a13da684d68bef85c6913ba4639e1566acc4734a37e6
-  md5: ce3af48e45ac649a01ce33c253ec6d82
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - tomli *
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/coverage
-  size: 282030
-  timestamp: 1691874785538
-- kind: conda
-  name: coverage
-  version: 7.3.2
-  build: py310h2372a71_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py310h2372a71_0.conda
-  sha256: f9c07ee8807188c39bd415dd8ce39ac7a90c41cb0cc741e9af429e1f886930c6
-  md5: 33c03cd5711885c920ddff676fb84f98
-  depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli *
-  arch: x86_64
-  platform: linux
-  license: Apache-2.0
-  license_family: APACHE
-  purls:
-  - pkg:pypi/coverage
-  size: 281112
-  timestamp: 1696281815257
-- kind: conda
-  name: coverage
-  version: 7.3.2
-  build: py310h6729b98_0
+  version: 7.6.2
+  build: py311h1314207_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.2-py310h6729b98_0.conda
-  sha256: f12ce7d3ccb8e3a242a70c7a3c348f76326d8118779eadcefdd8a36eb6707c64
-  md5: 3ec14aac0eac885648fe49e4b2e3bde6
+  url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.2-py311h1314207_0.conda
+  sha256: eb3cfd8630cfd589a50c1d445555cdec66f7d126df5ce7f88455ea75a6cae864
+  md5: ec27c8676d9a2dcf9ca3e103e749ecfb
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli *
-  arch: x86_64
-  platform: osx
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli
   license: Apache-2.0
   license_family: APACHE
-  purls:
-  - pkg:pypi/coverage
-  size: 279267
-  timestamp: 1696282086797
+  size: 372754
+  timestamp: 1728527524382
 - kind: conda
   name: coverage
-  version: 7.3.2
-  build: py310h8d17308_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.3.2-py310h8d17308_0.conda
-  sha256: 44b3e74b0de819ec9f6fa9947f349eb4af29a5e5167c7ecdfc85064fae4c1ec3
-  md5: 262bccdaf31082d0458aa45e47a66088
+  version: 7.6.2
+  build: py311h9ecbd09_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.2-py311h9ecbd09_0.conda
+  sha256: 57eafdc8e65e4425147da2ee4a8d3e47f67c01a67241e3a47345067cfb235d3a
+  md5: 98129024a76d1b01a31c39621976e42e
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli *
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 373748
+  timestamp: 1728527476566
+- kind: conda
+  name: coverage
+  version: 7.6.2
+  build: py311hae2e1ce_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.6.2-py311hae2e1ce_0.conda
+  sha256: 326a2b889a74abe49c7aff92d6cb3310b2b0919779ec0d171950acaaa4d1548a
+  md5: d4d301dbf0521a23a5d0e7687bb66306
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tomli
+  license: Apache-2.0
+  license_family: APACHE
+  size: 371770
+  timestamp: 1728527594059
+- kind: conda
+  name: coverage
+  version: 7.6.2
+  build: py311he736701_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/coverage-7.6.2-py311he736701_0.conda
+  sha256: 4ba0c3efe52b46c905794e1082156006d66d0b4e9a592f2a3244a397f85ab98b
+  md5: bdc4af1c847581fa10c686301fb0dda5
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
-  purls:
-  - pkg:pypi/coverage
-  size: 298542
-  timestamp: 1696282336567
+  size: 398611
+  timestamp: 1728527817146
+- kind: conda
+  name: cpython
+  version: 3.11.10
+  build: py311hd8ed1ab_2
+  build_number: 2
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/cpython-3.11.10-py311hd8ed1ab_2.conda
+  sha256: 88ec585b4578c4ce5802908e40ea4acf966e1650d67251204938ab5aa60aebd3
+  md5: 185b1719742d5377721a6d93582a4a1f
+  depends:
+  - python 3.11.10.*
+  - python_abi * *_cp311
+  license: Python-2.0
+  size: 46735
+  timestamp: 1727719034185
 - kind: conda
   name: dav1d
   version: 1.2.1
@@ -4122,90 +4054,75 @@ packages:
   timestamp: 1685695754230
 - kind: conda
   name: debugpy
-  version: 1.6.8
-  build: py310h1253130_0
+  version: 1.8.7
+  build: py311h3f08180_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.6.8-py310h1253130_0.conda
-  sha256: 22a3526c6990b412e45f3f044ff4525a42fde2a8ff431aec18110662ede34735
-  md5: d7501e5751ccab397b997e855b437ceb
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.7-py311h3f08180_0.conda
+  sha256: 88a6c8db209168a20e9e3c91db527f531b2994013852e6ac9f122b8ce28d88ea
+  md5: 6bea7745539923fc0facaa2cba50369c
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - libcxx >=15.0.7
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/debugpy
-  size: 1892601
-  timestamp: 1691021813132
+  size: 2493171
+  timestamp: 1728594326810
 - kind: conda
   name: debugpy
-  version: 1.8.0
-  build: py310h00ffb61_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.0-py310h00ffb61_1.conda
-  sha256: c500ddc59777e7f7fc8f364ae1b9d6487343bc34bfd078a549fbd0f59c4efc1a
-  md5: 5ccaf32fb16dd1336f74a635ef6acf7d
+  version: 1.8.7
+  build: py311hd89902b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.7-py311hd89902b_0.conda
+  sha256: 4188b10fa63dff1cd6d3d05ee90fc2242be4f79a84a598785aa41b61fceaa0f2
+  md5: e88d2e577bfb45271a4590cb9d010e5d
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 2487953
+  timestamp: 1728594270483
+- kind: conda
+  name: debugpy
+  version: 1.8.7
+  build: py311hda3d55a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.7-py311hda3d55a_0.conda
+  sha256: 714deaaa5ed757b259062f7979c2ed5e9fea66361ef72a5b63c644ea4b75232d
+  md5: 351ff5f8591856aa848a2cc89ca53957
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/debugpy
-  size: 3416775
-  timestamp: 1695534920376
+  size: 3548917
+  timestamp: 1728594758491
 - kind: conda
   name: debugpy
-  version: 1.8.0
-  build: py310h9e9d8ca_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.0-py310h9e9d8ca_1.conda
-  sha256: ec80231e963753692b62245a94f5025db6a44ae70f7a36c6dcb8195f971c33ae
-  md5: 64be4364c95d1d58b2bdeba61c4ddf99
-  depends:
-  - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/debugpy
-  size: 2386610
-  timestamp: 1695534781106
-- kind: conda
-  name: debugpy
-  version: 1.8.0
-  build: py310hc6cd4ac_1
-  build_number: 1
+  version: 1.8.7
+  build: py311hfdbb021_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.0-py310hc6cd4ac_1.conda
-  sha256: 77593f7b60d8f3b4d27a97a1b9e6c07c3f2490cfab77039d5e403166448b5de2
-  md5: 01388b4ec9eed3b26fa732aa39745475
+  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.7-py311hfdbb021_0.conda
+  sha256: 540d6b509d68ba77f6ad06f3bc419ba42930f1b3139ab4fda0476e12de8d7f4d
+  md5: e02dac14097eb3605342cd35c13f0a26
   depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/debugpy
-  size: 2436014
-  timestamp: 1695534502620
+  size: 2544636
+  timestamp: 1728594337523
 - kind: conda
   name: decorator
   version: 5.1.1
@@ -4318,39 +4235,35 @@ packages:
   timestamp: 1725214501850
 - kind: conda
   name: expat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
-  sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
-  md5: 624fa0dd6fdeaa650b71a62296fdfedf
+  version: 2.6.3
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.3-h5888daf_0.conda
+  sha256: 65bd479c75ce876f26600cb230d6ebc474086e31fa384af9b4282b36842ed7e2
+  md5: 6595440079bed734b113de44ffd3cd0a
   depends:
-  - libexpat ==2.5.0 hb7217d7_1
-  arch: aarch64
-  platform: osx
+  - __glibc >=2.17,<3.0.a0
+  - libexpat 2.6.3 h5888daf_0
+  - libgcc >=13
   license: MIT
   license_family: MIT
-  size: 117851
-  timestamp: 1680190940654
+  size: 137891
+  timestamp: 1725568750673
 - kind: conda
   name: expat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  md5: 8b9b5aca60558d02ddaa09d599e55920
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.3-hf9b8971_0.conda
+  sha256: 4d52ad7a7eb39f71a38bbf2b6377183024bd3bf4cfb5dcd33b31636a6f9a7abc
+  md5: 726bbcf3549fe22b4556285d946fed2d
   depends:
-  - libexpat ==2.5.0 hcb278e6_1
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
+  - __osx >=11.0
+  - libexpat 2.6.3 hf9b8971_0
   license: MIT
   license_family: MIT
-  size: 136778
-  timestamp: 1680190541750
+  size: 125005
+  timestamp: 1725568799108
 - kind: conda
   name: flaky
   version: 3.7.0
@@ -4601,12 +4514,10 @@ packages:
   md5: 3761b23693f768dc75a8fd0a73ca053f
   depends:
   - libpng >=1.6.39,<1.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: GPL-2.0-only OR FTL
   size: 510306
   timestamp: 1694616398888
@@ -4940,84 +4851,84 @@ packages:
 - kind: conda
   name: grpcio
   version: 1.56.2
-  build: py310h0d4bf3c_1
+  build: py311h43071ad_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py310h0d4bf3c_1.conda
-  sha256: ab9c89203aaa5e32cbfbc955ab8fdb6e36a59827f8658f072e148205f9daf082
-  md5: 07b3f0664ef56646ee40424ee7657e78
+  url: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py311h43071ad_1.conda
+  sha256: 1457f57849cc7e31097e5507302836b7ddcd81ab02c0855c3de3ac46cffc49ba
+  md5: 91b197fb13842e9c91356235baaae321
   depends:
   - __osx >=10.13
   - libcxx >=15.0.7
   - libgrpc 1.56.2 he6801ca_1
   - libzlib >=1.2.13,<2.0.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: APACHE
-  size: 710917
-  timestamp: 1692025409041
+  size: 754067
+  timestamp: 1692025138905
 - kind: conda
   name: grpcio
   version: 1.56.2
-  build: py310h1b8f574_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py310h1b8f574_1.conda
-  sha256: c2eda195f4de3210c1798439a37c075337d331ab2fe0cc9e4a6acb115a15a1ab
-  md5: 08d2538a6907851ea70d8f7cddc2f0d3
-  depends:
-  - libgcc-ng >=12
-  - libgrpc 1.56.2 h3905398_1
-  - libstdcxx-ng >=12
-  - libzlib >=1.2.13,<2.0.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: Apache-2.0
-  license_family: APACHE
-  size: 764791
-  timestamp: 1692023633876
-- kind: conda
-  name: grpcio
-  version: 1.56.2
-  build: py310h95b248a_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py310h95b248a_1.conda
-  sha256: f1b22c8492fcbb41021e909c75786a6c864eb29115098076a8af0a5efe45288e
-  md5: ed8ce58613462ac09ebe53a3606a74d5
-  depends:
-  - libcxx >=15.0.7
-  - libgrpc 1.56.2 h9075ed4_1
-  - libzlib >=1.2.13,<2.0.0a0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: Apache-2.0
-  license_family: APACHE
-  size: 695887
-  timestamp: 1692025592968
-- kind: conda
-  name: grpcio
-  version: 1.56.2
-  build: py310hb84602e_1
+  build: py311h5bc0dda_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py310hb84602e_1.conda
-  sha256: bc0bcd5a1aa53f87ae6d2ca35f2a1b5f38145fc337c18e4e0f77bc275aa0a669
-  md5: 9a0b9fafd6453839c986d8d876ce202a
+  url: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py311h5bc0dda_1.conda
+  sha256: 1e4c9ae7b95467c02b3a995ca15f6c3a42f08d0c82c4d03089afb38743e6b1d6
+  md5: 542a67fa7546ddc82ac202ea2dabbafc
   depends:
   - libgrpc 1.56.2 hea2d5f7_1
   - libzlib >=1.2.13,<2.0.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 607527
-  timestamp: 1692025811162
+  size: 656135
+  timestamp: 1692025628115
+- kind: conda
+  name: grpcio
+  version: 1.56.2
+  build: py311ha6695c7_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py311ha6695c7_1.conda
+  sha256: bc89765ad078ca231bec7a866dcc7e94b6fa1c8218522fb8d729ef9f7fb9458f
+  md5: 0028efc3e350948480e5a00add01c4cd
+  depends:
+  - libgcc-ng >=12
+  - libgrpc 1.56.2 h3905398_1
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 809557
+  timestamp: 1692023777490
+- kind: conda
+  name: grpcio
+  version: 1.56.2
+  build: py311hea943cd_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py311hea943cd_1.conda
+  sha256: b63902911824d674f2ef16ebe1418f29c806a6a88c14651219255976e4534d85
+  md5: acdd1dae2d98784b7dd84443970aa6a4
+  depends:
+  - libcxx >=15.0.7
+  - libgrpc 1.56.2 h9075ed4_1
+  - libzlib >=1.2.13,<2.0.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 741500
+  timestamp: 1692025479352
 - kind: conda
   name: h11
   version: 0.14.0
@@ -5148,110 +5059,57 @@ packages:
 - kind: conda
   name: imagecodecs
   version: 2023.1.23
-  build: py310hd30fb6a_0
+  build: py311h7b871a3_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2023.1.23-py310hd30fb6a_0.conda
-  sha256: a83e53dd6934d54e228f437e8f4e76491b2d5af070ff32a944e47472556f2862
-  md5: 5aef93755b0fd85fc100cba5fa43f63a
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/imagecodecs-2023.1.23-py311h7b871a3_0.conda
+  sha256: 23c824103cfe7ef693cbfe4448f7be26b10e59b3e3de89025b1e4c6ead84710e
+  md5: 19d71bcd42196fdaedba1dab0d7f9edb
   depends:
-  - libdeflate >=1.17,<1.18.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - cfitsio >=4.2.0,<4.2.1.0a0
-  - jpeg >=9e,<10a
-  - xz >=5.2.6,<6.0a0
-  - brunsli >=0.1,<1.0a0
-  - snappy >=1.1.9,<2.0a0
-  - charls >=2.4.1,<2.5.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - jxrlib >=1.1,<1.2.0a0
-  - libwebp-base >=1.2.4,<2.0a0
-  - libaec >=1.0.6,<2.0a0
-  - lcms2 >=2.14,<3.0a0
-  - libzopfli >=1.0.3,<1.1.0a0
-  - lerc >=4.0.0,<5.0a0
-  - python_abi 3.10.* *_cp310
-  - libpng >=1.6.39,<1.7.0a0
-  - openjpeg >=2.5.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
   - blosc >=1.21.3,<2.0a0
-  - zstd >=1.5.2,<1.6.0a0
-  - libbrotlidec >=1.0.9,<1.1.0a0
-  - zfp >=1.0.0,<2.0a0
-  - libbrotlienc >=1.0.9,<1.1.0a0
-  - giflib >=5.2.1,<5.3.0a0
-  - libtiff >=4.5.0,<4.6.0a0
+  - brunsli >=0.1,<1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - libavif >=0.11.1,<0.11.2.0a0
-  - libcxx >=14.0.6
-  - c-blosc2 >=2.6.1,<3.0a0
-  - libbrotlicommon >=1.0.9,<1.1.0a0
-  - numpy >=1.21.6,<2.0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/imagecodecs
-  size: 1612235
-  timestamp: 1674483915355
-- kind: conda
-  name: imagecodecs
-  version: 2023.9.18
-  build: py310h0dcf169_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2023.9.18-py310h0dcf169_2.conda
-  sha256: 7ff765c4eadb52ecc862df8b1a8257f6ef5fc9fff71e818af04086b2fdfd9d94
-  md5: f7186544d0172e3de1c85c33adf64338
-  depends:
-  - blosc >=1.21.5,<2.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.10.4,<3.0a0
-  - charls >=2.4.2,<2.5.0a0
+  - c-blosc2 >=2.6.1,<2.13.0a0
+  - cfitsio >=4.2.0,<4.2.1.0a0
+  - charls >=2.4.1,<2.5.0a0
   - giflib >=5.2.1,<5.3.0a0
+  - jpeg >=9e,<10a
   - jxrlib >=1.1,<1.2.0a0
-  - lcms2 >=2.15,<3.0a0
+  - lcms2 >=2.14,<3.0a0
   - lerc >=4.0.0,<5.0a0
-  - libaec >=1.1.1,<2.0a0
-  - libavif >=1.0.1,<1.0.2.0a0
-  - libbrotlicommon >=1.1.0,<1.2.0a0
-  - libbrotlidec >=1.1.0,<1.2.0a0
-  - libbrotlienc >=1.1.0,<1.2.0a0
-  - libdeflate >=1.19,<1.20.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libaec >=1.0.6,<2.0a0
+  - libavif >=0.11.1,<0.11.2.0a0
+  - libbrotlicommon >=1.0.9,<1.1.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=14.0.6
+  - libdeflate >=1.17,<1.18.0a0
   - libpng >=1.6.39,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - libzopfli >=1.0.3,<1.1.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - snappy >=1.1.10,<2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - snappy >=1.1.9,<1.2.0a0
   - xz >=5.2.6,<6.0a0
   - zfp >=1.0.0,<2.0a0
-  - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: win
+  - zstd >=1.5.2,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/imagecodecs
-  size: 1550076
-  timestamp: 1696192628440
+  size: 1627329
+  timestamp: 1674483895418
 - kind: conda
   name: imagecodecs
   version: 2023.9.18
-  build: py310h3a85d3a_0
+  build: py311h9b38416_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2023.9.18-py310h3a85d3a_0.conda
-  sha256: 29ff98858cf4e9d149ccc047221de61b3e5e3171457fa52b9e0dc8d0f8579d79
-  md5: 717a5eec4b393f58f161c9c84386931b
+  url: https://conda.anaconda.org/conda-forge/linux-64/imagecodecs-2023.9.18-py311h9b38416_0.conda
+  sha256: db9fe890c6ed2295a6c2e943a0b73493f33fda103a1af1806f9f5cd806414ec8
+  md5: 67bed2bd92ffa76b20506d83427706ae
   depends:
   - blosc >=1.21.5,<2.0a0
   - brunsli >=0.1,<1.0a0
@@ -5272,72 +5130,115 @@ packages:
   - libjpeg-turbo >=2.1.5.1,<3.0a0
   - libpng >=1.6.39,<1.7.0a0
   - libstdcxx-ng >=12
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libzlib >=1.2.13,<2.0.0a0
   - libzopfli >=1.0.3,<1.1.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - snappy >=1.1.10,<1.2.0a0
   - xz >=5.2.6,<6.0a0
   - zfp >=1.0.0,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1924280
-  timestamp: 1695139671006
+  size: 1955794
+  timestamp: 1695139731169
 - kind: conda
   name: imagecodecs
-  version: 2023.9.18
-  build: py310hc703689_2
+  version: 2024.1.1
+  build: py311hc08054d_2
   build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2023.9.18-py310hc703689_2.conda
-  sha256: 7485e7203168b9f09888e46c9a4da35de8e39c352a85f80e1f0a5c52599d2038
-  md5: 7f3644633aa78960116e98b0d4831875
+  url: https://conda.anaconda.org/conda-forge/osx-64/imagecodecs-2024.1.1-py311hc08054d_2.conda
+  sha256: 1e89c1c10f40d3eb43d42c009cbe2539fe4e40d7c501a5fa8b023e099357c4f5
+  md5: e4e68ae3fd612cace7f422f15392ddb7
   depends:
   - blosc >=1.21.5,<2.0a0
   - brunsli >=0.1,<1.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.10.4,<3.0a0
+  - c-blosc2 >=2.13.2,<2.14.4.0a0
   - charls >=2.4.2,<2.5.0a0
   - giflib >=5.2.1,<5.3.0a0
   - jxrlib >=1.1,<1.2.0a0
-  - lcms2 >=2.15,<3.0a0
+  - lcms2 >=2.16,<3.0a0
   - lerc >=4.0.0,<5.0a0
-  - libaec >=1.1.1,<2.0a0
+  - libaec >=1.1.2,<2.0a0
   - libavif16 >=1.0.1,<2.0a0
   - libbrotlicommon >=1.1.0,<1.2.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
-  - libcxx >=15.0.7
+  - libcxx >=16
   - libdeflate >=1.19,<1.20.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libpng >=1.6.39,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libjxl >=0.10,<0.11.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.3.2,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - libzopfli >=1.0.3,<1.1.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - numpy >=1.22.4,<2.0a0
-  - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - snappy >=1.1.10,<2.0a0
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - snappy >=1.1.10,<1.2.0a0
   - xz >=5.2.6,<6.0a0
-  - zfp >=1.0.0,<2.0a0
+  - zfp >=1.0.1,<2.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/imagecodecs
-  size: 1567135
-  timestamp: 1696192539863
+  size: 1675625
+  timestamp: 1709943541800
+- kind: conda
+  name: imagecodecs
+  version: 2024.1.1
+  build: py311hd83dc81_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.1.1-py311hd83dc81_3.conda
+  sha256: 78a95284bd41bb734afc4a133b00de58bdd442b44bc0da9def5ff7c321433345
+  md5: ea8c52dec4e31e193973b361356ec592
+  depends:
+  - blosc >=1.21.5,<2.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - c-blosc2 >=2.13.2,<2.14.4.0a0
+  - charls >=2.4.2,<2.5.0a0
+  - giflib >=5.2.1,<5.3.0a0
+  - jxrlib >=1.1,<1.2.0a0
+  - lcms2 >=2.16,<3.0a0
+  - lerc >=4.0.0,<5.0a0
+  - libaec >=1.1.3,<2.0a0
+  - libavif >=1.0.1,<1.0.2.0a0
+  - libbrotlicommon >=1.1.0,<1.2.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libdeflate >=1.20,<1.21.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - libzopfli >=1.0.3,<1.1.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - numpy >=1.23.5,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  - zfp >=1.0.1,<2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1611400
+  timestamp: 1711243343283
 - kind: conda
   name: imageio
   version: 2.31.1
@@ -5907,64 +5808,52 @@ packages:
   size: 8737
 - kind: conda
   name: jsonpointer
-  version: '2.4'
-  build: py310h2ec42d9_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py310h2ec42d9_3.conda
-  sha256: 3d1196f7c81ea64398c01e2285ae59f83e9366dda21c7427f11dde8d0da38609
-  md5: ca02450dbc1c346a06fc454b36ddab32
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/jsonpointer
-  size: 16313
-  timestamp: 1695397584568
-- kind: conda
-  name: jsonpointer
-  version: '2.4'
-  build: py310h5588dad_3
-  build_number: 3
+  version: 3.0.0
+  build: py311h1ea47a8_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py310h5588dad_3.conda
-  sha256: 50b86f741719065c235dd00c706bc00fd5cc59cb48bf31505d8ff620a0eb7a02
-  md5: 55a7275d703b4c73bae42dcf54cc1441
+  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-3.0.0-py311h1ea47a8_1.conda
+  sha256: 9a667eeae67936e710ff69ee7ce0e784d6052eeba9670b268c565a55178098c4
+  md5: 943f7fab631e12750641efd7279a268c
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: win
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/jsonpointer
-  size: 32969
-  timestamp: 1695398011639
+  size: 42891
+  timestamp: 1725303340467
 - kind: conda
   name: jsonpointer
-  version: '2.4'
-  build: py310hff52083_3
-  build_number: 3
+  version: 3.0.0
+  build: py311h38be061_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py310hff52083_3.conda
-  sha256: 316db08863469a56cdbfd030de5a2cc11ec7649ed7c50eff507e9caa0070ccaa
-  md5: 08ec1463dbc5c806a32fc431874032ca
+  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-3.0.0-py311h38be061_1.conda
+  sha256: 2f082f7b12a7c6824e051321c1029452562ad6d496ad2e8c8b7b3dea1c8feb92
+  md5: 5ca76f61b00a15a9be0612d4d883badc
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/jsonpointer
-  size: 16170
-  timestamp: 1695397381208
+  size: 17645
+  timestamp: 1725303065473
+- kind: conda
+  name: jsonpointer
+  version: 3.0.0
+  build: py311h6eed73b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-3.0.0-py311h6eed73b_1.conda
+  sha256: 2499e5ebb3efa4186d6922122224d16bac791a5c0adad5b48b2bcd1e1e2afc8d
+  md5: b6c1710105dad14d47001a339cd14da6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17727
+  timestamp: 1725302991176
 - kind: conda
   name: jsonschema
   version: 4.19.0
@@ -6157,81 +6046,44 @@ packages:
   timestamp: 1698232162661
 - kind: conda
   name: jupyter_core
-  version: 5.3.1
-  build: py310hbe9552e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.3.1-py310hbe9552e_0.conda
-  sha256: ea5951e4c3412acd1295eb678b1763bb89a53b6874868da0afcfff0ed9571cc2
-  md5: 1266abcc013599e8296cb23f4432c6f9
+  version: 5.7.2
+  build: pyh31011fe_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh31011fe_1.conda
+  sha256: 732b1e8536bc22a5a174baa79842d79db2f4956d90293dd82dc1b3f6099bcccd
+  md5: 0a2980dada0dd7fd0998f0342308b1b1
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
+  - __unix
   - platformdirs >=2.5
+  - python >=3.8
   - traitlets >=5.3
-  arch: aarch64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  size: 93173
-  timestamp: 1686776278938
+  size: 57671
+  timestamp: 1727163547058
 - kind: conda
   name: jupyter_core
-  version: 5.5.0
-  build: py310h2ec42d9_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.5.0-py310h2ec42d9_0.conda
-  sha256: 14ed1c62603b53132a74cb73409cd0bfd133bbc79e7e4a78523e162e54f945ce
-  md5: e7b118f9dd76e48119bce8358a0f09c7
+  version: 5.7.2
+  build: pyh5737063_1
+  build_number: 1
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_core-5.7.2-pyh5737063_1.conda
+  sha256: 7c903b2d62414c3e8da1f78db21f45b98de387aae195f8ca959794113ba4b3fd
+  md5: 46d87d1c0ea5da0aae36f77fa406e20d
   depends:
+  - __win
+  - cpython
   - platformdirs >=2.5
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - traitlets >=5.3
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 79037
-  timestamp: 1698674181050
-- kind: conda
-  name: jupyter_core
-  version: 5.5.0
-  build: py310h5588dad_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.5.0-py310h5588dad_0.conda
-  sha256: 7dc48c8b66631de41c1f76981e05c0b2f5023bb2b95f3de088a6e2935ff8ed68
-  md5: 3e5945e27a3b647fe00097c27ffbd67c
-  depends:
-  - platformdirs >=2.5
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.8
   - pywin32 >=300
   - traitlets >=5.3
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  size: 95749
-  timestamp: 1698674415793
-- kind: conda
-  name: jupyter_core
-  version: 5.5.0
-  build: py310hff52083_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.5.0-py310hff52083_0.conda
-  sha256: 35e05ff1ad8b070b1378886c5ee4b82a000ea078494af6d0552d1c455b3f6220
-  md5: 9ca8f0d07c512cef3fd07b121bb2b023
-  depends:
-  - platformdirs >=2.5
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - traitlets >=5.3
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 79275
-  timestamp: 1698673792929
+  size: 58269
+  timestamp: 1727164026641
 - kind: conda
   name: jupyter_events
   version: 0.7.0
@@ -6703,23 +6555,21 @@ packages:
   timestamp: 1692098004387
 - kind: conda
   name: krb5
-  version: 1.21.2
-  build: heb0366b_0
+  version: 1.21.3
+  build: hdf4eb48_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.2-heb0366b_0.conda
-  sha256: 6002adff9e3dcfc9732b861730cb9e33d45fd76b2035b2cdb4e6daacb8262c0b
-  md5: 6e8b0f22b4eef3b3cb3849bb4c3d47f9
+  url: https://conda.anaconda.org/conda-forge/win-64/krb5-1.21.3-hdf4eb48_0.conda
+  sha256: 18e8b3430d7d232dad132f574268f56b3eb1a19431d6d5de8c53c29e6c18fa81
+  md5: 31aec030344e962fbd7dbbbbd68e60a9
   depends:
-  - openssl >=3.1.2,<4.0a0
+  - openssl >=3.3.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 710894
-  timestamp: 1692098129546
+  size: 712034
+  timestamp: 1719463874284
 - kind: conda
   name: lazy_loader
   version: '0.3'
@@ -6759,27 +6609,6 @@ packages:
 - kind: conda
   name: lcms2
   version: '2.15'
-  build: h67d730c_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.15-h67d730c_3.conda
-  sha256: 8819d74571b6321e0ed93b07c19b4fd9a9b669df3fdd797ab4798ab7c684ae1d
-  md5: f92e86636451e3f6cea03e395346fa90
-  depends:
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 498833
-  timestamp: 1695969944045
-- kind: conda
-  name: lcms2
-  version: '2.15'
   build: h7f713cb_2
   build_number: 2
   subdir: linux-64
@@ -6798,22 +6627,37 @@ packages:
   timestamp: 1694650174930
 - kind: conda
   name: lcms2
-  version: '2.15'
-  build: hd6ba6f3_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.15-hd6ba6f3_3.conda
-  sha256: b2234f24e3b0030762430ec3414410119d1129804a95ef65af50ad36cabd9bd5
-  md5: 8059507d52f477fbd4b81841e085e25b
+  version: '2.16'
+  build: h67d730c_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/lcms2-2.16-h67d730c_0.conda
+  sha256: f9fd9e80e46358a57d9bb97b1e37a03da4022143b019aa3c4476d8a7795de290
+  md5: d3592435917b62a8becff3a60db674f6
   depends:
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  arch: x86_64
-  platform: osx
+  - libtiff >=4.6.0,<4.8.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 224895
-  timestamp: 1695969874291
+  size: 507632
+  timestamp: 1701648249706
+- kind: conda
+  name: lcms2
+  version: '2.16'
+  build: ha2f27b4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/lcms2-2.16-ha2f27b4_0.conda
+  sha256: 222ebc0a55544b9922f61e75015d02861e65b48f12113af41d48ba0814e14e4e
+  md5: 1442db8f03517834843666c422238c9b
+  depends:
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  license: MIT
+  license_family: MIT
+  size: 224432
+  timestamp: 1701648089496
 - kind: conda
   name: ld_impl_linux-64
   version: '2.40'
@@ -7013,25 +6857,6 @@ packages:
 - kind: conda
   name: libaec
   version: 1.1.2
-  build: h63175ca_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
-  sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
-  md5: 0b252d2bf460364bccb1523bcdbe4af6
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 33554
-  timestamp: 1696474526588
-- kind: conda
-  name: libaec
-  version: 1.1.2
   build: he965462_1
   build_number: 1
   subdir: osx-64
@@ -7046,6 +6871,22 @@ packages:
   license_family: BSD
   size: 29027
   timestamp: 1696474151758
+- kind: conda
+  name: libaec
+  version: 1.1.3
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
+  sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
+  md5: 8723000f6ffdbdaef16025f0a01b64c5
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 32567
+  timestamp: 1711021603471
 - kind: conda
   name: libarrow
   version: 12.0.1
@@ -7090,43 +6931,42 @@ packages:
 - kind: conda
   name: libarrow
   version: 12.0.1
-  build: hb74b275_8_cpu
-  build_number: 8
+  build: h6e4acf5_9_cpu
+  build_number: 9
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-12.0.1-hb74b275_8_cpu.conda
-  sha256: 903037d7155bf7c2aaac7fd73ed39c7eed883682ec3b976874a8176531d828b5
-  md5: 050c52a52b5c090a72b86f3d580c2a56
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-12.0.1-h6e4acf5_9_cpu.conda
+  sha256: c3a74517283c7f6a708dde3163a4652729db8b2f8129af3bd2453cdb91a17a51
+  md5: cb6fef3b78103b37b42d9f388d06f709
   depends:
-  - openssl >=3.1.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - libgrpc >=1.56.2,<1.57.0a0
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - re2 >=2023.3.2,<2023.3.3.0a0
+  - aws-crt-cpp >=0.23.0,<0.23.1.0a0
   - aws-sdk-cpp >=1.10.57,<1.10.58.0a0
-  - snappy >=1.1.10,<2.0a0
-  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - bzip2 >=1.0.8,<2.0a0
   - glog >=0.6.0,<0.7.0a0
-  - orc >=1.9.0,<1.9.1.0a0
-  - zstd >=1.5.2,<1.6.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
   - libbrotlidec >=1.0.9,<1.1.0a0
   - libbrotlienc >=1.0.9,<1.1.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - libthrift >=0.18.1,<0.18.2.0a0
-  - aws-crt-cpp >=0.21.0,<0.21.1.0a0
-  - bzip2 >=1.0.8,<2.0a0
   - libcxx >=15.0.7
-  - libabseil >=20230125.3,<20230126.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.56.2,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libthrift >=0.18.1,<0.18.2.0a0
   - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
   constrains:
   - apache-arrow-proc =*=cpu
-  - arrow-cpp =12.0.1
   - parquet-cpp <0.0a0
-  arch: aarch64
-  platform: osx
+  - arrow-cpp =12.0.1
   license: Apache-2.0
   license_family: APACHE
-  size: 17770766
-  timestamp: 1691481218036
+  size: 17808981
+  timestamp: 1692675470741
 - kind: conda
   name: libarrow
   version: 12.0.1
@@ -7140,6 +6980,7 @@ packages:
   - aws-crt-cpp >=0.23.1,<0.23.2.0a0
   - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
   - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
   - libabseil >=20230125.3,<20230126.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
@@ -7150,12 +6991,12 @@ packages:
   - libprotobuf >=4.23.3,<4.23.4.0a0
   - libthrift >=0.19.0,<0.19.1.0a0
   - libutf8proc >=2.8.0,<3.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
   - openssl >=3.1.2,<4.0a0
   - orc >=1.9.0,<1.9.1.0a0
   - re2 >=2023.3.2,<2023.3.3.0a0
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.1.10,<1.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
@@ -7164,8 +7005,6 @@ packages:
   - arrow-cpp =12.0.1
   - apache-arrow-proc =*=cpu
   - parquet-cpp <0.0a0
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 16492252
@@ -7822,25 +7661,23 @@ packages:
   timestamp: 1697009208544
 - kind: conda
   name: libcurl
-  version: 8.4.0
-  build: hd5e4a3a_0
+  version: 8.10.1
+  build: h1ee3ff0_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.4.0-hd5e4a3a_0.conda
-  sha256: f1367d8a3f115ee4c16ea4bcc313c21009decb0217f65d3bb94618939c518a71
-  md5: 13e4e3824a0212103330f57058601c21
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
   depends:
-  - krb5 >=1.21.2,<1.22.0a0
+  - krb5 >=1.21.3,<1.22.0a0
   - libssh2 >=1.11.0,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.3.1,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: curl
   license_family: MIT
-  size: 321118
-  timestamp: 1697009866852
+  size: 342388
+  timestamp: 1726660508261
 - kind: conda
   name: libcxx
   version: 19.1.1
@@ -7900,24 +7737,6 @@ packages:
 - kind: conda
   name: libdeflate
   version: '1.19'
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
-  sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
-  md5: 002b1b723b44dbd286b9e3708762433c
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 153203
-  timestamp: 1694922596415
-- kind: conda
-  name: libdeflate
-  version: '1.19'
   build: hd590300_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
@@ -7931,6 +7750,22 @@ packages:
   license_family: MIT
   size: 67080
   timestamp: 1694922285678
+- kind: conda
+  name: libdeflate
+  version: '1.20'
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
+  sha256: 6628a5b76ad70c1a0909563c637ddc446ee824739ba7c348d4da2f0aa6ac9527
+  md5: b12b5bde5eb201a1df75e49320cc938a
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 155358
+  timestamp: 1711197066985
 - kind: conda
   name: libedit
   version: 3.1.20191231
@@ -8104,40 +7939,71 @@ packages:
   timestamp: 1685725977222
 - kind: conda
   name: libexpat
-  version: 2.5.0
-  build: hb7217d7_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
-  sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
-  md5: 5a097ad3d17e42c148c9566280481317
+  version: 2.6.3
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+  sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
+  md5: 59f4c43bb1b5ef1c71946ff2cbf59524
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
   constrains:
-  - expat 2.5.0.*
-  arch: aarch64
-  platform: osx
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 63442
-  timestamp: 1680190916539
+  size: 73616
+  timestamp: 1725568742634
 - kind: conda
   name: libexpat
-  version: 2.5.0
-  build: hcb278e6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
-  sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
-  md5: 6305a3dd2752c76335295da4e581f2fd
+  version: 2.6.3
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
+  sha256: dd22dffad6731c352f4c14603868c9cce4d3b50ff5ff1e50f416a82dcb491947
+  md5: c1db99b0a94a2f23bd6ce39e2d314e07
   depends:
-  - libgcc-ng >=12
+  - __osx >=10.13
   constrains:
-  - expat 2.5.0.*
-  arch: x86_64
-  platform: linux
+  - expat 2.6.3.*
   license: MIT
   license_family: MIT
-  size: 77980
-  timestamp: 1680190528313
+  size: 70517
+  timestamp: 1725568864316
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: he0c23c2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.3-he0c23c2_0.conda
+  sha256: 9543965d155b8da96fc67dd81705fe5c2571c7c00becc8de5534c850393d4e3c
+  md5: 21415fbf4d0de6767a621160b43e5dea
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 138992
+  timestamp: 1725569106114
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
+  md5: 5f22f07c2ab2dea8c66fe9585a062c96
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 63895
+  timestamp: 1725568783033
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -8287,22 +8153,37 @@ packages:
   size: 109855
   timestamp: 1694165674845
 - kind: conda
-  name: libgfortran-ng
-  version: 13.2.0
-  build: h69a702a_2
-  build_number: 2
+  name: libgfortran
+  version: 14.1.0
+  build: h69a702a_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-13.2.0-h69a702a_2.conda
-  sha256: 767d71999e5386210fe2acaf1b67073e7943c2af538efa85c101e3401e94ff62
-  md5: e75a75a6eaf6f318dae2631158c46575
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-14.1.0-h69a702a_1.conda
+  sha256: ed77f04f873e43a26e24d443dd090631eedc7d0ace3141baaefd96a123e47535
+  md5: 591e631bc1ae62c64f2ab4f66178c097
   depends:
-  - libgfortran5 ==13.2.0 ha4646dd_2
-  arch: x86_64
-  platform: linux
+  - libgfortran5 14.1.0 hc5f4f2c_1
+  constrains:
+  - libgfortran-ng ==14.1.0=*_1
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 23722
-  timestamp: 1695219642066
+  size: 52142
+  timestamp: 1724801872472
+- kind: conda
+  name: libgfortran-ng
+  version: 14.1.0
+  build: h69a702a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-ng-14.1.0-h69a702a_1.conda
+  sha256: a2dc35cb7f87bb5beebf102d4085574c6a740e1df58e743185d4434cc5e4e0ae
+  md5: 16cec94c5992d7f42ae3f9fa8b25df8d
+  depends:
+  - libgfortran 14.1.0 h69a702a_1
+  license: GPL-3.0-only WITH GCC-exception-3.1
+  license_family: GPL
+  size: 52212
+  timestamp: 1724802086021
 - kind: conda
   name: libgfortran5
   version: 12.2.0
@@ -8343,23 +8224,21 @@ packages:
   timestamp: 1694165583047
 - kind: conda
   name: libgfortran5
-  version: 13.2.0
-  build: ha4646dd_2
-  build_number: 2
+  version: 14.1.0
+  build: hc5f4f2c_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-13.2.0-ha4646dd_2.conda
-  sha256: 55ecf5c46c05a98b4822a041d6e1cb196a7b0606126eb96b24131b7d2c8ca561
-  md5: 78fdab09d9138851dde2b5fe2a11019e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
+  sha256: c40d7db760296bf9c776de12597d2f379f30e890b9ae70c1de962ff2aa1999f6
+  md5: 10a0cef64b784d6ab6da50ebca4e984d
   depends:
-  - libgcc-ng >=13.2.0
+  - libgcc >=14.1.0
   constrains:
-  - libgfortran-ng 13.2.0
-  arch: x86_64
-  platform: linux
+  - libgfortran 14.1.0
   license: GPL-3.0-only WITH GCC-exception-3.1
   license_family: GPL
-  size: 1441830
-  timestamp: 1695219403435
+  size: 1459939
+  timestamp: 1724801851300
 - kind: conda
   name: libglib
   version: 2.76.4
@@ -8608,9 +8487,10 @@ packages:
   md5: 706baf79d5928afd39e7b747dc43b5ae
   depends:
   - c-ares >=1.19.1,<2.0a0
+  - libabseil * cxx17*
   - libabseil >=20230125.3,<20230126.0a0
   - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.2,<4.0a0
   - re2 >=2023.3.2,<2023.3.3.0a0
   - ucrt >=10.0.20348.0
@@ -8618,8 +8498,6 @@ packages:
   - vc14_runtime >=14.29.30139
   constrains:
   - grpc-cpp =1.56.2
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 12851376
@@ -8645,6 +8523,20 @@ packages:
   license_family: BSD
   size: 2578462
   timestamp: 1694533393675
+- kind: conda
+  name: libhwy
+  version: 1.1.0
+  build: h7728843_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.1.0-h7728843_0.conda
+  sha256: 153504156c3e35496e07af7dc8c25e29fe894632985cebce239a9609e1a70daa
+  md5: 1e87bbdfa248e26a2d13c0a8e8d63d08
+  depends:
+  - libcxx >=16
+  license: Apache-2.0
+  license_family: Apache
+  size: 778925
+  timestamp: 1708225689339
 - kind: conda
   name: libiconv
   version: '1.17'
@@ -8743,6 +8635,24 @@ packages:
   license: IJG AND BSD-3-Clause AND Zlib
   size: 822966
   timestamp: 1694475223854
+- kind: conda
+  name: libjxl
+  version: 0.10.3
+  build: hfb90b89_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.10.3-hfb90b89_0.conda
+  sha256: 910d123abbfce3454fb6bc9bf6bb4045653be1331b4b80e24847a3d3cd75b59b
+  md5: 1eaaa53596c649ff6198062a234fc773
+  depends:
+  - __osx >=10.13
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=16
+  - libhwy >=1.1.0,<1.2.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 1404105
+  timestamp: 1720754049517
 - kind: conda
   name: liblapack
   version: 3.9.0
@@ -8982,24 +8892,6 @@ packages:
 - kind: conda
   name: libpng
   version: 1.6.39
-  build: h19919ed_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.39-h19919ed_0.conda
-  sha256: 1f139a72109366ba1da69f5bdc569b0e6783f887615807c02d7bfcc2c7575067
-  md5: ab6febdb2dbd9c00803609079db4de71
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vs2015_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: zlib-acknowledgement
-  size: 343883
-  timestamp: 1669076173145
-- kind: conda
-  name: libpng
-  version: 1.6.39
   build: h76d750c_0
   subdir: osx-arm64
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.39-h76d750c_0.conda
@@ -9012,21 +8904,6 @@ packages:
   license: zlib-acknowledgement
   size: 259412
   timestamp: 1669075883972
-- kind: conda
-  name: libpng
-  version: 1.6.39
-  build: ha978bb4_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.39-ha978bb4_0.conda
-  sha256: 5ad9f5e96e6770bfc8b0a826f48835e7f337c2d2e9512d76027a62f9c120b2a3
-  md5: 35e4928794c5391aec14ffdf1deaaee5
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
-  license: zlib-acknowledgement
-  size: 271689
-  timestamp: 1669075890643
 - kind: conda
   name: libpng
   version: 1.6.43
@@ -9042,6 +8919,35 @@ packages:
   size: 288221
   timestamp: 1708780443939
 - kind: conda
+  name: libpng
+  version: 1.6.43
+  build: h92b6c6a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
+  sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
+  md5: 65dcddb15965c9de2c0365cb14910532
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  license: zlib-acknowledgement
+  size: 268524
+  timestamp: 1708780496420
+- kind: conda
+  name: libpng
+  version: 1.6.44
+  build: h3ca93ac_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.44-h3ca93ac_0.conda
+  sha256: 0d3d6ff9225f6918ac225e3839c0d91e5af1da08a4ebf59cac1bfd86018db945
+  md5: 639ac6b55a40aa5de7b8c1b4d78f9e81
+  depends:
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: zlib-acknowledgement
+  size: 348933
+  timestamp: 1726235196095
+- kind: conda
   name: libprotobuf
   version: 4.23.3
   build: h1975477_1
@@ -9051,13 +8957,12 @@ packages:
   sha256: ed3ac552a1c27e624d16bc476e45929dcde6a672ec4cc4bd761b490e94b97b09
   md5: efa7ba46d136b9db9bb128e5dfb9808f
   depends:
+  - libabseil * cxx17*
   - libabseil >=20230125.3,<20230126.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 5175646
@@ -9188,23 +9093,6 @@ packages:
 - kind: conda
   name: libsodium
   version: 1.0.18
-  build: h8d14728_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
-  sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
-  md5: 5c1fb45b5e2912c19098750ae8a32604
-  depends:
-  - vc >=14.1,<15.0a0
-  - vs2015_runtime >=14.16.27012
-  arch: x86_64
-  platform: win
-  license: ISC
-  size: 713431
-  timestamp: 1605135918736
-- kind: conda
-  name: libsodium
-  version: 1.0.18
   build: hbcb3906_1
   build_number: 1
   subdir: osx-64
@@ -9217,66 +9105,78 @@ packages:
   size: 528765
   timestamp: 1605135849110
 - kind: conda
-  name: libsqlite
-  version: 3.42.0
-  build: hb31c410_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.42.0-hb31c410_0.conda
-  sha256: 120913cf0fb694546fbaf95dff211ac5c1e3e91bc69c73350891a05dc106355f
-  md5: 6ae1bbf3ae393a45a75685072fffbe8d
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: aarch64
-  platform: osx
-  license: Unlicense
-  size: 822883
-  timestamp: 1684265273102
-- kind: conda
-  name: libsqlite
-  version: 3.44.0
-  build: h92b6c6a_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.44.0-h92b6c6a_0.conda
-  sha256: 0832dc9cf18e811d2b41f8f4951d5ab608678e3459b1a4f36347097d8a9abf68
-  md5: 5dd5e957ebfee02720c30e0e2d127bbe
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
-  license: Unlicense
-  size: 891073
-  timestamp: 1698854990507
-- kind: conda
-  name: libsqlite
-  version: 3.44.0
-  build: hcfcfb64_0
+  name: libsodium
+  version: 1.0.20
+  build: hc70643c_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.44.0-hcfcfb64_0.conda
-  sha256: b2be4125343d89765269b537e90ea5ab7f219e7398e7ad610ddcdcf31e7b9e65
-  md5: 446fb1973cfeb8b32de4add3c9ac1057
+  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
+  sha256: 7bcb3edccea30f711b6be9601e083ecf4f435b9407d70fc48fbcf9e5d69a0fc6
+  md5: 198bb594f202b205c7d18b936fa4524f
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: Unlicense
-  size: 852871
-  timestamp: 1698855272921
+  license: ISC
+  size: 202344
+  timestamp: 1716828757533
 - kind: conda
   name: libsqlite
   version: 3.46.0
-  build: hde9e2c9_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.0-hde9e2c9_0.conda
-  sha256: daee3f68786231dad457d0dfde3f7f1f9a7f2018adabdbb864226775101341a8
-  md5: 18aa975d2094c34aef978060ae7da7d8
+  build: h1b8f9f3_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+  sha256: 63af1a9e3284c7e4952364bafe7267e41e2d9d8bcc0e85a4ea4b0ec02d3693f6
+  md5: 5dadfbc1a567fe6e475df4ce3148be09
   depends:
-  - libgcc-ng >=12
+  - __osx >=10.13
   - libzlib >=1.2.13,<2.0a0
   license: Unlicense
-  size: 865346
-  timestamp: 1718050628718
+  size: 908643
+  timestamp: 1718050720117
+- kind: conda
+  name: libsqlite
+  version: 3.46.0
+  build: hfb93653_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
+  sha256: 73048f9cb8647d3d3bfe6021c0b7d663e12cffbe9b4f31bd081e713b0a9ad8f9
+  md5: 12300188028c9bc02da965128b91b517
+  depends:
+  - __osx >=11.0
+  - libzlib >=1.2.13,<2.0a0
+  license: Unlicense
+  size: 830198
+  timestamp: 1718050644825
+- kind: conda
+  name: libsqlite
+  version: 3.46.1
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+  sha256: ef83f90961630bc54a95e48062b05cf9c9173a822ea01784288029613a45eea4
+  md5: 8a7c1ad01f58623bfbae8d601db7cf3b
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Unlicense
+  size: 876666
+  timestamp: 1725354171439
+- kind: conda
+  name: libsqlite
+  version: 3.46.1
+  build: hadc24fc_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
+  sha256: 9851c049abafed3ee329d6c7c2033407e2fc269d33a75c071110ab52300002b0
+  md5: 36f79405ab16bf271edb55b213836dac
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  license: Unlicense
+  size: 865214
+  timestamp: 1725353659783
 - kind: conda
   name: libssh2
   version: 1.11.0
@@ -9319,13 +9219,11 @@ packages:
   sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
   md5: dc262d03aae04fe26825062879141a41
   depends:
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.1,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
   size: 266806
@@ -9428,13 +9326,11 @@ packages:
   md5: d3432b9d4950e91d2fdf3bed91248ee0
   depends:
   - libevent >=2.1.12,<2.1.13.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - openssl >=3.1.3,<4.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
   size: 612342
@@ -9529,27 +9425,25 @@ packages:
 - kind: conda
   name: libtiff
   version: 4.6.0
-  build: h6e2ebb7_2
-  build_number: 2
+  build: hddb2be6_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
-  sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
-  md5: 08d653b74ee2dec0131ad4259ffbb126
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
+  sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
+  md5: 6d1828c9039929e2f185c5fa9d133018
   depends:
   - lerc >=4.0.0,<5.0a0
-  - libdeflate >=1.19,<1.20.0a0
+  - libdeflate >=1.20,<1.21.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zstd >=1.5.5,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: HPND
-  size: 787430
-  timestamp: 1695662030293
+  size: 787198
+  timestamp: 1711218639912
 - kind: conda
   name: libutf8proc
   version: 2.8.0
@@ -9710,26 +9604,6 @@ packages:
 - kind: conda
   name: libwebp-base
   version: 1.3.2
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.3.2-hcfcfb64_0.conda
-  sha256: af1453fab10d1fb8b379c61a78882614051a8bac37307d7ac4fb58eac667709e
-  md5: dcde8820959e64378d4e06147ffecfdd
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  constrains:
-  - libwebp 1.3.2
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 268870
-  timestamp: 1694709461733
-- kind: conda
-  name: libwebp-base
-  version: 1.3.2
   build: hd590300_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
@@ -9745,6 +9619,24 @@ packages:
   license_family: BSD
   size: 401830
   timestamp: 1694709121323
+- kind: conda
+  name: libwebp-base
+  version: 1.4.0
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
+  sha256: d0ca51cb1de9192be9a3238e71fbcca5a535619c499c4f4c9b2ed41c14d36770
+  md5: abd61d0ab127ec5cd68f62c2969e6f34
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - libwebp 1.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 274359
+  timestamp: 1713200524021
 - kind: conda
   name: libxcb
   version: '1.13'
@@ -9803,45 +9695,37 @@ packages:
   timestamp: 1682083036825
 - kind: conda
   name: libxcb
-  version: '1.15'
-  build: hcd874cb_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.15-hcd874cb_0.conda
-  sha256: d01322c693580f53f8d07a7420cd6879289f5ddad5531b372c3efd1c37cac3bf
-  md5: 090d91b69396f14afef450c285f9758c
-  depends:
-  - m2w64-gcc-libs *
-  - m2w64-gcc-libs-core *
-  - pthread-stubs *
-  - xorg-libxau *
-  - xorg-libxdmcp *
-  arch: x86_64
-  platform: win
-  license: MIT
-  license_family: MIT
-  size: 969788
-  timestamp: 1682083087243
-- kind: conda
-  name: libxml2
-  version: 2.11.5
-  build: hc3477c8_1
+  version: '1.16'
+  build: h013a479_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.5-hc3477c8_1.conda
-  sha256: ad3b5a510be2c5f9fe90b2c20e10adb135717304bcb3a197f256feb48d713d99
-  md5: 27974f880a010b1441093d9f737a949f
+  url: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-h013a479_1.conda
+  sha256: abae56e12a4c62730b899fdfb82628a9ac171c4ce144fc9f34ae024957a82a0e
+  md5: f0b599acdc82d5bc7e3b105833e7c5c8
   depends:
-  - libiconv >=1.17,<2.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - pthread-stubs
+  - xorg-libxau >=1.0.11,<2.0a0
+  - xorg-libxdmcp
   license: MIT
   license_family: MIT
-  size: 1600640
-  timestamp: 1692960798126
+  size: 989459
+  timestamp: 1724419883091
+- kind: conda
+  name: libxcrypt
+  version: 4.4.36
+  build: hd590300_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
+  sha256: 6ae68e0b86423ef188196fff6207ed0c8195dd84273cb5623b85aa08033a410c
+  md5: 5aa797f8787fe7a17d1b0821485b5adc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-or-later
+  size: 100393
+  timestamp: 1702724383534
 - kind: conda
   name: libxml2
   version: 2.11.5
@@ -9861,6 +9745,24 @@ packages:
   license_family: MIT
   size: 615813
   timestamp: 1691593272628
+- kind: conda
+  name: libxml2
+  version: 2.11.6
+  build: hc3477c8_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.6-hc3477c8_0.conda
+  sha256: 6ed853ef69bf43998eacc6fd022d7ac170d9e2d3d273b0be0dc3da593fb0fc90
+  md5: 08ffbb4c22dd3622e122058368f8b708
+  depends:
+  - libiconv >=1.17,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 1627582
+  timestamp: 1700245325646
 - kind: conda
   name: libzlib
   version: 1.2.13
@@ -9897,25 +9799,23 @@ packages:
   timestamp: 1686575566695
 - kind: conda
   name: libzlib
-  version: 1.2.13
-  build: hcfcfb64_5
-  build_number: 5
+  version: 1.3.1
+  build: h2466b09_2
+  build_number: 2
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.2.13-hcfcfb64_5.conda
-  sha256: c161822ee8130b71e08b6d282b9919c1de2c5274b29921a867bca0f7d30cad26
-  md5: 5fdb9c6a113b6b6cb5e517fd972d5f41
+  url: https://conda.anaconda.org/conda-forge/win-64/libzlib-1.3.1-h2466b09_2.conda
+  sha256: ba945c6493449bed0e6e29883c4943817f7c79cbff52b83360f7b341277c6402
+  md5: 41fbfac52c601159df6c01f875de31b9
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - zlib 1.2.13 *_5
-  arch: x86_64
-  platform: win
+  - zlib 1.3.1 *_2
   license: Zlib
   license_family: Other
-  size: 55800
-  timestamp: 1686575452215
+  size: 55476
+  timestamp: 1727963768015
 - kind: conda
   name: libzlib
   version: 1.3.1
@@ -10017,20 +9917,20 @@ packages:
   timestamp: 1686865657336
 - kind: conda
   name: llvm-openmp
-  version: 17.0.4
-  build: hb6ac08f_0
+  version: 19.1.1
+  build: h545e0da_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.4-hb6ac08f_0.conda
-  sha256: d49b6958d22075de5fb707fd5f593cfa4be059015db48b7f1cd5e47e7efde2ff
-  md5: 31391b68245bc68504169e98ffaf2c44
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.1-h545e0da_0.conda
+  sha256: 7e15f5ac89e750dadbc6fe81dc2909dd056c7324c72379a8440b57a6174a1146
+  md5: 3f3e4a599dd2638a945fc5821090db07
+  depends:
+  - __osx >=10.13
   constrains:
-  - openmp 17.0.4|17.0.4.*
-  arch: x86_64
-  platform: osx
+  - openmp 19.1.1|19.1.1.*
   license: Apache-2.0 WITH LLVM-exception
   license_family: APACHE
-  size: 299744
-  timestamp: 1698833439461
+  size: 305199
+  timestamp: 1728517141555
 - kind: conda
   name: lz4-c
   version: 1.9.4
@@ -10207,95 +10107,84 @@ packages:
   timestamp: 1686175179621
 - kind: conda
   name: markupsafe
-  version: 2.1.3
-  build: py310h2372a71_1
+  version: 3.0.1
+  build: py311h0ecf0c1_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.1-py311h0ecf0c1_1.conda
+  sha256: a74c76b7286e13983f057bee629456e48fa950203e772de8c88574032eb2f1fd
+  md5: 6695c608873406694c0a9252884757e0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25128
+  timestamp: 1728489362504
+- kind: conda
+  name: markupsafe
+  version: 3.0.1
+  build: py311h2dc5d0c_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.3-py310h2372a71_1.conda
-  sha256: ac46cc2f6d4bbeedcd2f508e43f43143a9286ced55730d8d97a3c91ceceb0d56
-  md5: b74e07a054c479e45a83a83fc5be713c
+  url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.1-py311h2dc5d0c_1.conda
+  sha256: 3f632607bf3b12a5a98845f2c8b2d52104ad945eaa06d0bf778822db7bbc1cc2
+  md5: 137fc3129d21210605d8ee63db86b66f
   depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - jinja2 >=3.0.0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/markupsafe
-  size: 24054
-  timestamp: 1695367637074
+  size: 25450
+  timestamp: 1728489178847
 - kind: conda
   name: markupsafe
-  version: 2.1.3
-  build: py310h2aa6e3c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.3-py310h2aa6e3c_0.conda
-  sha256: ed4bd96b711ae21bd01d619b8f3837b58c616eb707293b39fe6e3e4874979b08
-  md5: e48e45e6bacea28483819a465fcbcd00
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - jinja2 >=3.0.0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/markupsafe
-  size: 23574
-  timestamp: 1685769603445
-- kind: conda
-  name: markupsafe
-  version: 2.1.3
-  build: py310h6729b98_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.3-py310h6729b98_1.conda
-  sha256: 62076b034a92959d25a1321a4340745ff87b5d191b3fcfef607b746daeb845c5
-  md5: 000b20b3974452969efe63f980b69e33
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - jinja2 >=3.0.0
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/markupsafe
-  size: 23056
-  timestamp: 1695367898746
-- kind: conda
-  name: markupsafe
-  version: 2.1.3
-  build: py310h8d17308_1
+  version: 3.0.1
+  build: py311h5082efb_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-2.1.3-py310h8d17308_1.conda
-  sha256: cab9683af159f18b782a876afb4aa3f84512dc3c39e4315a963ba267751581da
-  md5: 8bb26993f6787d08908136ce07894bf0
+  url: https://conda.anaconda.org/conda-forge/win-64/markupsafe-3.0.1-py311h5082efb_1.conda
+  sha256: 95c6dd6d4af9d92040e37fdb9eaab7c74c48c75a0a6056df659977161105e8a6
+  md5: e344a7dbeae2587c8ab3f3ea3467012d
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
   - jinja2 >=3.0.0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/markupsafe
-  size: 26628
-  timestamp: 1695367927795
+  size: 28549
+  timestamp: 1728490094930
+- kind: conda
+  name: markupsafe
+  version: 3.0.1
+  build: py311ha971863_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.1-py311ha971863_1.conda
+  sha256: 2af5eafc1d88a6f32f200b4fcfca8bf8f1f2f3e50f7bc499449916c2c6e7d053
+  md5: 257339ac5fa1aceefd4b2e826d343c22
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - jinja2 >=3.0.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 24661
+  timestamp: 1728489218742
 - kind: conda
   name: matplotlib-inline
   version: 0.1.6
@@ -10319,84 +10208,78 @@ packages:
 - kind: conda
   name: maturin
   version: 1.2.3
-  build: py310h75e40e8_1
+  build: py311h5fb2c35_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.2.3-py311h5fb2c35_1.conda
+  sha256: 9f700c486b99d82486179b3753cd3c659524894027e470a26c9f0d6e946c7107
+  md5: 780d65d2967dc7987626a82daf99e3f5
+  depends:
+  - openssl >=3.1.3,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 4916128
+  timestamp: 1695301464437
+- kind: conda
+  name: maturin
+  version: 1.2.3
+  build: py311h63ff55d_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.2.3-py310h75e40e8_1.conda
-  sha256: 9be24f72040783bda4995d3d9e944c023842df5263e189bcd5af02272049b31f
-  md5: 3f4a302c782f760f047d9f5b37574e4b
+  url: https://conda.anaconda.org/conda-forge/linux-64/maturin-1.2.3-py311h63ff55d_1.conda
+  sha256: c45d9759cf85b97f0cdcea830bb638add184c89444763dec2cf0c184bc94b19a
+  md5: 0be66c9619f41fed2376198425ac83be
   depends:
   - libgcc-ng >=12
   - openssl >=3.1.3,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - tomli >=1.1.0
-  arch: x86_64
-  platform: linux
   license: MIT
   license_family: MIT
-  size: 6346814
-  timestamp: 1695300560297
+  size: 6350393
+  timestamp: 1695300499701
 - kind: conda
   name: maturin
   version: 1.2.3
-  build: py310hcdf1ef2_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.2.3-py310hcdf1ef2_1.conda
-  sha256: f036563a45b0735bf611bfdddb198e8864be17eab107f18744923578d7f5a935
-  md5: 88dae580b9c4f2d075f9556d29b276c3
-  depends:
-  - openssl >=3.1.3,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 4955123
-  timestamp: 1695300939556
-- kind: conda
-  name: maturin
-  version: 1.2.3
-  build: py310hdd3b5e7_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/maturin-1.2.3-py310hdd3b5e7_0.conda
-  sha256: 1280cf7837c6311ac1b735864af384d16d161e02990df3331730d8784f5b0bdd
-  md5: a6c84e255b57205f6009fd33d219ff46
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - openssl >=3.1.2,<4.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 4852478
-  timestamp: 1692269215924
-- kind: conda
-  name: maturin
-  version: 1.2.3
-  build: py310he2c049f_1
+  build: py311h9a9e57f_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/maturin-1.2.3-py310he2c049f_1.conda
-  sha256: 9e8779d3e4746e8c3ca3f2f4f2a5c36045051f97d4da9c28345bd818cbc549ec
-  md5: df9c03a9001e8d7a3e84a53094dfa52a
+  url: https://conda.anaconda.org/conda-forge/win-64/maturin-1.2.3-py311h9a9e57f_1.conda
+  sha256: 96ac1ea9a0e9befbc9ec9751f746561828a71932afc135f01243f02f40c79583
+  md5: 199761c2524d4687718b52437f989fa9
   depends:
-  - m2w64-gcc-libs *
-  - m2w64-gcc-libs-core *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - m2w64-gcc-libs
+  - m2w64-gcc-libs-core
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - tomli >=1.1.0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 4675858
-  timestamp: 1695301814558
+  size: 4679496
+  timestamp: 1695301754883
+- kind: conda
+  name: maturin
+  version: 1.2.3
+  build: py311hc3cf65e_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/maturin-1.2.3-py311hc3cf65e_1.conda
+  sha256: a3d2bc74b18cf5020906fc97a6e574dec5cfa6410c0302dcfdf21417e6250b98
+  md5: 74aa386b7c74734b249a40653e697358
+  depends:
+  - openssl >=3.1.3,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tomli >=1.1.0
+  license: MIT
+  license_family: MIT
+  size: 4959024
+  timestamp: 1695300899663
 - kind: conda
   name: mdit-py-plugins
   version: 0.4.0
@@ -10591,87 +10474,83 @@ packages:
 - kind: conda
   name: mypy
   version: 1.11.2
-  build: py310h493c2e1_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py310h493c2e1_0.conda
-  sha256: b7e8939b7d6744d20904e13684b33b0a9547f5a34b2399190a3b4ffd8fb683ae
-  md5: c1c91361a25c70ebee323b47d2cb6fe0
-  depends:
-  - __osx >=11.0
-  - mypy_extensions >=1.0.0
-  - psutil >=4.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
-  - typing_extensions >=4.1.0
-  license: MIT
-  license_family: MIT
-  size: 9243747
-  timestamp: 1724602122831
-- kind: conda
-  name: mypy
-  version: 1.11.2
-  build: py310h837254d_0
+  build: py311h3336109_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py310h837254d_0.conda
-  sha256: 56cb03b5123514b2bb0dcab09311061cec1969feb444a0d07a7968f95a9b6851
-  md5: 8908c49155ac6d84d76c956f8291806c
+  url: https://conda.anaconda.org/conda-forge/osx-64/mypy-1.11.2-py311h3336109_0.conda
+  sha256: 0550ddaf5e7d8ffff133ad2beb91ed65478188334d4ab95833561e4064cd2cc1
+  md5: 4d8c373615565fdc89e5518e4add4bf7
   depends:
   - __osx >=10.13
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - typing_extensions >=4.1.0
   license: MIT
   license_family: MIT
-  size: 11773874
-  timestamp: 1724601916692
+  size: 12360403
+  timestamp: 1724601912385
 - kind: conda
   name: mypy
   version: 1.11.2
-  build: py310ha75aee5_0
+  build: py311h460d6c5_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/mypy-1.11.2-py311h460d6c5_0.conda
+  sha256: f0d811f213b332baea7ae9cf4c7014b2e4c2acfeea251ad7106951424cbf09e9
+  md5: 660fb67571430a8f9fe9c5e4fbd3bce3
+  depends:
+  - __osx >=11.0
+  - mypy_extensions >=1.0.0
+  - psutil >=4.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - typing_extensions >=4.1.0
+  license: MIT
+  license_family: MIT
+  size: 9939551
+  timestamp: 1724601950009
+- kind: conda
+  name: mypy
+  version: 1.11.2
+  build: py311h9ecbd09_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py310ha75aee5_0.conda
-  sha256: a6d23ab439793aa31822060251d5839ff472120928cecc75028d8999dcb70b89
-  md5: 5abca238950289c9fb9c4e942218092e
+  url: https://conda.anaconda.org/conda-forge/linux-64/mypy-1.11.2-py311h9ecbd09_0.conda
+  sha256: 2cf425c5f3aa91ab87e1aabeea9be8531aa7741943356a20a6197522d250c13c
+  md5: a1b63adcfaa652bb9c3943a0514ed1df
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=13
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - typing_extensions >=4.1.0
   license: MIT
   license_family: MIT
-  size: 17827218
-  timestamp: 1724602150638
+  size: 18347599
+  timestamp: 1724602120050
 - kind: conda
   name: mypy
   version: 1.11.2
-  build: py310ha8f682b_0
+  build: py311he736701_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py310ha8f682b_0.conda
-  sha256: d61e3a8305198eedf22226721bd2e1a8bbcabb786a85ffca9bc042e77564e1f3
-  md5: 4d0795f72fd05090c272d40c20f3ac61
+  url: https://conda.anaconda.org/conda-forge/win-64/mypy-1.11.2-py311he736701_0.conda
+  sha256: 79e9fc970ce212065ed0fb09489b15e29451a4fa995e38866e7d770687c272b4
+  md5: 179500418dfd455e63a51d9287b0f2f6
   depends:
   - mypy_extensions >=1.0.0
   - psutil >=4.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tomli >=1.1.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - typing_extensions >=4.1.0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 9641286
-  timestamp: 1724601937116
+  size: 10277667
+  timestamp: 1724602077202
 - kind: conda
   name: mypy_extensions
   version: 1.0.0
@@ -10916,49 +10795,47 @@ packages:
   timestamp: 1596196217832
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h59595ed_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
-  sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
-  md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-  depends:
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
-  license: X11 AND BSD-3-Clause
-  size: 884434
-  timestamp: 1698751260967
-- kind: conda
-  name: ncurses
-  version: '6.4'
-  build: h7ea286d_0
+  version: '6.5'
+  build: h7bae524_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h7ea286d_0.conda
-  sha256: 017e230a1f912e15005d4c4f3d387119190b53240f9ae0ba8a319dd958901780
-  md5: 318337fb9d0c53ba635efb7888242373
-  arch: aarch64
-  platform: osx
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
+  sha256: 27d0b9ff78ad46e1f3a6c96c479ab44beda5f96def88e2fe626e0a49429d8afc
+  md5: cb2b0ea909b97b3d70cd3921d1445e1a
+  depends:
+  - __osx >=11.0
   license: X11 AND BSD-3-Clause
-  size: 799196
-  timestamp: 1686077139703
+  size: 802321
+  timestamp: 1724658775723
 - kind: conda
   name: ncurses
-  version: '6.4'
-  build: h93d8f39_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
-  sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
-  md5: e58f366bd4d767e9ab97ab8b272e7670
+  version: '6.5'
+  build: he02047a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
+  sha256: 6a1d5d8634c1a07913f1c525db6455918cbc589d745fac46d9d6e30340c8731a
+  md5: 70caf8bb6cf39a0b6b7efc885f51c0fe
   depends:
-  - __osx >=10.9
-  arch: x86_64
-  platform: osx
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
   license: X11 AND BSD-3-Clause
-  size: 822031
-  timestamp: 1698751567986
+  size: 889086
+  timestamp: 1724658547447
+- kind: conda
+  name: ncurses
+  version: '6.5'
+  build: hf036a51_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
+  sha256: b0b3180039ef19502525a2abd5833c00f9624af830fd391f851934d57bffb9af
+  md5: e102bbf8a6ceeaf429deab8032fc8977
+  depends:
+  - __osx >=10.13
+  license: X11 AND BSD-3-Clause
+  size: 822066
+  timestamp: 1724658603042
 - kind: conda
   name: nest-asyncio
   version: 1.5.6
@@ -11144,107 +11021,92 @@ packages:
   timestamp: 1682360712235
 - kind: conda
   name: numpy
-  version: 1.25.2
-  build: py310haa1e00c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.25.2-py310haa1e00c_0.conda
-  sha256: d8eddb8573609b03fa60f5daec29da55141a1faeff8c442bb4c6fd309e40411d
-  md5: 6242d13bf330eccd490979aaf3b5f7e4
-  depends:
-  - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15.0.7
-  - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - libblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/numpy
-  size: 5765063
-  timestamp: 1691057015909
-- kind: conda
-  name: numpy
-  version: 1.26.0
-  build: py310h0171094_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.0-py310h0171094_0.conda
-  sha256: d2fb0614f41d426249fdc8980cdb6068442c963cc1bcc687df35842a13ead800
-  md5: d58ec8238a040c4cfedbc6b1afbb9d56
+  version: 1.26.4
+  build: py311h0b4df5a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py311h0b4df5a_0.conda
+  sha256: 14116e72107de3089cc58119a5ce5905c22abf9a715c9fe41f8ac14db0992326
+  md5: 7b240edd44fd7a0991aa409b07cee776
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15.0.7
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/numpy
-  size: 6521202
-  timestamp: 1695291583890
+  size: 7104093
+  timestamp: 1707226459646
 - kind: conda
   name: numpy
-  version: 1.26.0
-  build: py310hb13e2d6_0
+  version: 1.26.4
+  build: py311h64a7726_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.0-py310hb13e2d6_0.conda
-  sha256: d4671e365c2ed30bf8a376bdc65afcbeeae440ca2091c8712ff8f23678f64973
-  md5: ac3b67e928cc71548efad9b522d42fef
+  url: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py311h64a7726_0.conda
+  sha256: 3f4365e11b28e244c95ba8579942b0802761ba7bb31c026f50d1a9ea9c728149
+  md5: a502d7aad449a1206efb366d6a12c52d
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - libgcc-ng >=12
   - liblapack >=3.9.0,<4.0a0
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: linux
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/numpy
-  size: 6893487
-  timestamp: 1695291234099
+  size: 8065890
+  timestamp: 1707225944355
 - kind: conda
   name: numpy
-  version: 1.26.0
-  build: py310hf667824_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.0-py310hf667824_0.conda
-  sha256: 8cbf1502ff9f7cc382ab0a269554da9fa8ea5fd28c30a4e01856a0e3ef7f537d
-  md5: a4f8b5a677ba150fcc10a1265bb0554a
+  version: 1.26.4
+  build: py311h7125741_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py311h7125741_0.conda
+  sha256: 160a52a01fea44fe9753a2ed22cf13d7b55c8a89ea0b8738546fdbf4795d6514
+  md5: 3160b93669a0def35a7a8158ebb33816
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
   - liblapack >=3.9.0,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   constrains:
   - numpy-base <0a0
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/numpy
-  size: 6001376
-  timestamp: 1695291827551
+  size: 6652352
+  timestamp: 1707226297967
+- kind: conda
+  name: numpy
+  version: 1.26.4
+  build: py311hc43a94b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/numpy-1.26.4-py311hc43a94b_0.conda
+  sha256: dc9628197125ee1d02b2e7a859a769d26291d747ed79337309b8a9e67a8b8e00
+  md5: bb02b8801d17265160e466cf8bbf28da
+  depends:
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libcxx >=16
+  - liblapack >=3.9.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7504319
+  timestamp: 1707226235372
 - kind: conda
   name: openjdk
   version: 20.0.0
@@ -11334,48 +11196,6 @@ packages:
 - kind: conda
   name: openjpeg
   version: 2.5.0
-  build: h3d672ee_3
-  build_number: 3
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
-  sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
-  md5: 45a9628a04efb6fc326fff0a8f47b799
-  depends:
-  - libpng >=1.6.39,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 236847
-  timestamp: 1694708878963
-- kind: conda
-  name: openjpeg
-  version: 2.5.0
-  build: ha4da562_3
-  build_number: 3
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
-  sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
-  md5: 40a36f8e9a6fdf6a78c6428ee6c44188
-  depends:
-  - libcxx >=15.0.7
-  - libpng >=1.6.39,<1.7.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  arch: x86_64
-  platform: osx
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 335643
-  timestamp: 1694708811338
-- kind: conda
-  name: openjpeg
-  version: 2.5.0
   build: hbc2ba62_2
   build_number: 2
   subdir: osx-arm64
@@ -11396,6 +11216,25 @@ packages:
 - kind: conda
   name: openjpeg
   version: 2.5.2
+  build: h3d672ee_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
+  sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
+  md5: 7e7099ad94ac3b599808950cec30ad4e
+  depends:
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 237974
+  timestamp: 1709159764160
+- kind: conda
+  name: openjpeg
+  version: 2.5.2
   build: h488ebb8_0
   subdir: linux-64
   url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
@@ -11412,26 +11251,39 @@ packages:
   size: 341592
   timestamp: 1709159244431
 - kind: conda
-  name: openssl
-  version: 3.1.4
-  build: hcfcfb64_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.1.4-hcfcfb64_0.conda
-  sha256: e30b7f55c27d06e3322876c9433a3522e751d06a40b3bb6c4f8b4bcd781a3794
-  md5: 2eebbc64373a1c6db62ad23304e9678e
+  name: openjpeg
+  version: 2.5.2
+  build: h7310d3a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
+  sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
+  md5: 05a14cc9d725dd74995927968d6547e3
   depends:
-  - ca-certificates *
+  - libcxx >=16
+  - libpng >=1.6.43,<1.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 331273
+  timestamp: 1709159538792
+- kind: conda
+  name: openssl
+  version: 3.3.2
+  build: h2466b09_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+  sha256: a45c42f3577294e22ac39ddb6ef5a64fd5322e8a6725afefbf4f2b4109340bf9
+  md5: 1dc86753693df5e3326bb8a85b74c589
+  depends:
+  - ca-certificates
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  constrains:
-  - pyopenssl >=22.1
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
-  size: 7427765
-  timestamp: 1698166937344
+  size: 8396053
+  timestamp: 1725412961673
 - kind: conda
   name: openssl
   version: 3.3.2
@@ -11554,15 +11406,13 @@ packages:
   md5: 2d5dfd05e0d6673662f21342caed3d0f
   depends:
   - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.1.10,<2.0a0
+  - snappy >=1.1.10,<1.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zstd >=1.5.2,<1.6.0a0
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
   size: 874908
@@ -11666,98 +11516,91 @@ packages:
 - kind: conda
   name: pandas
   version: 2.0.3
-  build: py310h1c4a608_1
+  build: py311h320fe9a_1
   build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.3-py310h1c4a608_1.conda
-  sha256: 2bd9ed92347d53d7ce99b3b45b832ecd6c3dd9ae68ca7153841dcab943ba6a85
-  md5: 9fb6d4a7414daf2aa66ddfa14d568fd0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py311h320fe9a_1.conda
+  sha256: 31cce492f9f67adf499809d83089a9362f5e25556970010a6db810310cb743e0
+  md5: 5f92f46bd33917832a99d1660b4075ac
   depends:
-  - numpy >=1.21.6,<2.0a0
-  - python >=3.10,<3.11.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
   - python-dateutil >=2.8.1
   - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14711359
+  timestamp: 1688741174845
+- kind: conda
+  name: pandas
+  version: 2.0.3
+  build: py311h9e438b8_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.3-py311h9e438b8_1.conda
+  sha256: 94106f0f473eaa87d687602d632cbb4e998d79e17d211008432cb19dd2505d1b
+  md5: ab533a7ad28d13c14b1d8b136d280906
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14160285
+  timestamp: 1688741726812
+- kind: conda
+  name: pandas
+  version: 2.0.3
+  build: py311hab14417_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.3-py311hab14417_1.conda
+  sha256: 7e4a13ab90308e47d0217222a072096291cbd7b625740057623a0e1ad1697b69
+  md5: e5c7b1b1f55b11db3adb209089ab6eae
+  depends:
+  - libcxx >=15.0.7
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
+  - pytz >=2020.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 14138161
+  timestamp: 1688741719427
+- kind: conda
+  name: pandas
+  version: 2.0.3
+  build: py311hf63dbb6_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.0.3-py311hf63dbb6_1.conda
+  sha256: f8ee8eb9036e8eef21e1778dfa88503d1cdf93299070cbce1d9d32b538fdb54e
+  md5: 45c4a4b94dd2321f5d8188567263190d
+  depends:
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.8.1
+  - python-tzdata >=2022a
+  - python_abi 3.11.* *_cp311
   - pytz >=2020.1
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  size: 11000365
-  timestamp: 1688741630200
-- kind: conda
-  name: pandas
-  version: 2.0.3
-  build: py310h1cdf563_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.0.3-py310h1cdf563_1.conda
-  sha256: d2ac911bf24f39dd83a83ea15333291b175227961bf2d45bad31317243c4fdb1
-  md5: 680ece3f188b726782ef4aa84e8cca12
-  depends:
-  - numpy >=1.21.6,<2.0a0
-  - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
-  - pytz >=2020.1
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11705997
-  timestamp: 1688741660429
-- kind: conda
-  name: pandas
-  version: 2.0.3
-  build: py310h5e4fcda_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.0.3-py310h5e4fcda_1.conda
-  sha256: 797be0eff944a01ec3bbac43dbe2b860e42ae530d2f4188c05409c6f95174402
-  md5: 5b1a8f096180ca4c39ddea7ccdb9d4a7
-  depends:
-  - libcxx >=15.0.7
-  - numpy >=1.21.6,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
-  - pytz >=2020.1
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 11741378
-  timestamp: 1688741606761
-- kind: conda
-  name: pandas
-  version: 2.0.3
-  build: py310h7cbd5c2_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.0.3-py310h7cbd5c2_1.conda
-  sha256: e8937c160b6eb469c5d80971046b25ed305fd97a8b1d6880de7c4a660cd245c3
-  md5: 11e0099d4571b4974c04386e4ce679ed
-  depends:
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.21.6,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python-dateutil >=2.8.1
-  - python-tzdata >=2022a
-  - python_abi 3.10.* *_cp310
-  - pytz >=2020.1
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 12296643
-  timestamp: 1688741475871
+  size: 13434139
+  timestamp: 1688741555419
 - kind: conda
   name: pandoc
   version: 3.1.3
@@ -11969,107 +11812,103 @@ packages:
 - kind: conda
   name: pillow
   version: 9.4.0
-  build: py310h5a7539a_1
+  build: py311h627eb56_1
   build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py310h5a7539a_1.conda
-  sha256: dc1e74039820e86b876c4ad3563ab0522218dc978cf1fda34358eb640f950312
-  md5: b3c94458ef1002c937b89979c79eb486
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-9.4.0-py311h627eb56_1.conda
+  sha256: 24946fa52c4c9ec369ea6130bd7bb407372c89f91bb1f167812220cdae858e1b
+  md5: 5b9c6ff480a2689258e1621dfdb653e4
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - openjpeg >=2.5.0,<3.0a0
   - freetype >=2.12.1,<3.0a0
   - jpeg >=9e,<10a
-  - libzlib >=1.2.13,<1.3.0a0
-  - libwebp-base >=1.2.4,<2.0a0
-  - libtiff >=4.5.0,<4.6.0a0
-  - libxcb >=1.13,<1.14.0a0
   - lcms2 >=2.14,<3.0a0
+  - libtiff >=4.5.0,<4.6.0a0
+  - libwebp-base >=1.2.4,<2.0a0
+  - libxcb >=1.13,<1.14.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.0,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   - tk >=8.6.12,<8.7.0a0
-  arch: aarch64
-  platform: osx
   license: LicenseRef-PIL
-  size: 46538172
-  timestamp: 1675487797070
+  size: 46528596
+  timestamp: 1675487666061
 - kind: conda
   name: pillow
   version: 10.0.1
-  build: py310h29da1c1_1
+  build: py311h8aef010_1
   build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.1-py310h29da1c1_1.conda
-  sha256: 4c18593b1b90299e0f1f7a279ccce6dbe0aba694758ee039c0850e0119d3b3e8
-  md5: 8e93b1c69cddf89fd412178d3d418bae
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.0.1-py311h8aef010_1.conda
+  sha256: 42f21344c2fb7ee614243a632e261580408b24003d83cf34548661c2973a368a
+  md5: 4d66ee2081a7cd444ff6f30d95873eef
   depends:
   - freetype >=2.12.1,<3.0a0
   - lcms2 >=2.15,<3.0a0
   - libgcc-ng >=12
   - libjpeg-turbo >=2.1.5.1,<3.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libxcb >=1.15,<1.16.0a0
   - libzlib >=1.2.13,<2.0.0a0
   - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - tk >=8.6.12,<8.7.0a0
   license: HPND
-  size: 46384048
-  timestamp: 1695247436468
+  size: 46908609
+  timestamp: 1695247484014
 - kind: conda
   name: pillow
-  version: 10.1.0
-  build: py310h1e6a543_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.1.0-py310h1e6a543_0.conda
-  sha256: df8f9c4d830bd7a8400640bb01efa2a0675b26d1a9a82ab8b404c638d11dbe5b
-  md5: 8ce37528536360e773a0f80750e39a02
+  version: 10.3.0
+  build: py311h1b85569_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py311h1b85569_0.conda
+  sha256: ae51c9a8b900396f819840b6be0d8e72180af4e5e913cfa54a673bdaec70cc35
+  md5: 881ad821b527c802f1538347cf167449
   depends:
   - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.15,<3.0a0
+  - lcms2 >=2.16,<3.0a0
   - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
+  - libtiff >=4.6.0,<4.8.0a0
   - libwebp-base >=1.3.2,<2.0a0
   - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libzlib >=1.2.13,<2.0.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - tk >=8.6.13,<8.7.0a0
+  license: HPND
+  size: 41308782
+  timestamp: 1712154783659
+- kind: conda
+  name: pillow
+  version: 10.4.0
+  build: py311h5592be9_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pillow-10.4.0-py311h5592be9_1.conda
+  sha256: 3ab996a92e6dc6e431fe6c1600e8391ebc23899d7e32f31c211176f3a58803f3
+  md5: b14e5d0c225d357343ed7fbc4669741b
+  depends:
+  - freetype >=2.12.1,<3.0a0
+  - lcms2 >=2.16,<3.0a0
+  - libjpeg-turbo >=3.0.0,<4.0a0
+  - libtiff >=4.6.0,<4.8.0a0
+  - libwebp-base >=1.4.0,<2.0a0
+  - libxcb >=1.16,<2.0.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openjpeg >=2.5.2,<3.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - tk >=8.6.13,<8.7.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: HPND
-  size: 45101565
-  timestamp: 1697424198092
-- kind: conda
-  name: pillow
-  version: 10.1.0
-  build: py310he65384d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.1.0-py310he65384d_0.conda
-  sha256: bde2b4eca2d4b2ab33d7195867b9a369aca4727e2e4d1f17055a1507a2a825aa
-  md5: aa3e9b34eafaca521682eb48d80b80b2
-  depends:
-  - freetype >=2.12.1,<3.0a0
-  - lcms2 >=2.15,<3.0a0
-  - libjpeg-turbo >=3.0.0,<4.0a0
-  - libtiff >=4.6.0,<4.7.0a0
-  - libwebp-base >=1.3.2,<2.0a0
-  - libxcb >=1.15,<1.16.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openjpeg >=2.5.0,<3.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - tk >=8.6.13,<8.7.0a0
-  arch: x86_64
-  platform: osx
-  license: HPND
-  size: 46263448
-  timestamp: 1697423999759
+  size: 42115215
+  timestamp: 1726075618733
 - kind: conda
   name: pip
   version: 23.2.1
@@ -12257,85 +12096,86 @@ packages:
   timestamp: 1693086745921
 - kind: conda
   name: polars
-  version: 0.18.15
-  build: py310h2d36a57_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/polars-0.18.15-py310h2d36a57_1.conda
-  sha256: 348e30160c97e18d379a34c1fdc7fa1842e76fdaca8ad1291d356adecbcb818f
-  md5: 11bcff3c03198344b1573b9e42146b5f
-  depends:
-  - libgcc-ng >=12
-  - numpy >=1.16.0
-  - packaging
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  size: 16057056
-  timestamp: 1692688547644
-- kind: conda
-  name: polars
-  version: 0.18.15
-  build: py310h49106b5_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/polars-0.18.15-py310h49106b5_1.conda
-  sha256: ebc61b1e954585f492e777cd5d2caa06c2e0e28c0be364ab0c412294b72fe13b
-  md5: 51481d96d1b4c863662e81d075ad5d79
-  depends:
-  - numpy >=1.16.0
-  - packaging
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  size: 12963300
-  timestamp: 1692690752488
-- kind: conda
-  name: polars
-  version: 0.18.15
-  build: py310h95fa17d_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/polars-0.18.15-py310h95fa17d_1.conda
-  sha256: 423ebf36060323f5f145b23437dbbdf7c5735d1f5c536adcc463d2434b1812f1
-  md5: ca50abd3aa922d6d8d8f1a3ff0dda332
-  depends:
-  - numpy >=1.16.0
-  - packaging
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.0.0
-  license: MIT
-  license_family: MIT
-  size: 13970392
-  timestamp: 1692690680600
-- kind: conda
-  name: polars
-  version: 0.18.15
-  build: py310he0a9947_1
-  build_number: 1
+  version: 1.8.2
+  build: py311h445572d_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/polars-0.18.15-py310he0a9947_1.conda
-  sha256: 61019b5dccc2ed8ef9842c3e8d6c99fc05045a11ff219aa681792f59250ddd3b
-  md5: 14eed67eba855b1ddcffb7f89586875e
+  url: https://conda.anaconda.org/conda-forge/win-64/polars-1.8.2-py311h445572d_0.conda
+  sha256: e468c32ff4e05e1da0f7dd89dd0df7c22165480304bdbce263ace0283d4187cf
+  md5: 0e5b19cc78799a95a3c74bb1faae2e48
   depends:
   - numpy >=1.16.0
   - packaging
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - typing_extensions >=4.0.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vc >=14.3
+  - vc14_runtime >=14.40.33810
   license: MIT
   license_family: MIT
-  size: 14328233
-  timestamp: 1692690801422
+  size: 22147535
+  timestamp: 1727250346762
+- kind: conda
+  name: polars
+  version: 1.8.2
+  build: py311h749c62c_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/polars-1.8.2-py311h749c62c_0.conda
+  sha256: fe0adee9252eeee26a9cbf249a1b43d7564ea5561b50991ba50fbdd3b47e64b3
+  md5: 333f798203c96cc3b6dda545a25cfa5c
+  depends:
+  - __osx >=11.0
+  - numpy >=1.16.0
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  size: 18860601
+  timestamp: 1727250299443
+- kind: conda
+  name: polars
+  version: 1.8.2
+  build: py311h859c8f9_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/polars-1.8.2-py311h859c8f9_0.conda
+  sha256: d5ea63d048d71b1e4e50af0d0f3a412223ba27eaa27b776f1b943c2da58d8ec4
+  md5: 2e3f91ac685bf8b693a4dc713a996884
+  depends:
+  - __osx >=10.13
+  - numpy >=1.16.0
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 20958373
+  timestamp: 1727242824559
+- kind: conda
+  name: polars
+  version: 1.8.2
+  build: py311hcc3b33b_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/polars-1.8.2-py311hcc3b33b_0.conda
+  sha256: 103058bb0d3f1c76404ad82663bb418bf0a9f61f0ab66c9c6aba30e0655e5794
+  md5: 394c0607be1eac93bf27ae7a7cdb842f
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.16.0
+  - packaging
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 21821797
+  timestamp: 1727243582468
 - kind: conda
   name: pooch
   version: 1.7.0
@@ -12435,173 +12275,156 @@ packages:
 - kind: conda
   name: protobuf
   version: 4.23.3
-  build: py310h4e8a696_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.23.3-py310h4e8a696_0.conda
-  sha256: 28801d92d3ea66ac6f1ad961af1974479f9499cf62940616bd269ab62ca08d44
-  md5: 8da9b5d52ebad6a80785fdf5f2c57ff9
-  depends:
-  - libabseil >=20230125.3,<20230126.0a0
-  - libcxx >=15.0.7
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools *
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 304050
-  timestamp: 1688121734447
-- kind: conda
-  name: protobuf
-  version: 4.23.3
-  build: py310ha3d488f_0
+  build: py311h03b55d4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/protobuf-4.23.3-py310ha3d488f_0.conda
-  sha256: ebb697fed21b185a1b2a8611f869d517da86de007c7e814acc6d5838cd2d7b8e
-  md5: a65f902a101c1ec7bedfe48b65756379
+  url: https://conda.anaconda.org/conda-forge/win-64/protobuf-4.23.3-py311h03b55d4_0.conda
+  sha256: 3ed466e4575812c30bf0fcbe537ce0256e98c9b30bc0abf17243cedc2bb1c92c
+  md5: 0504b7f6e43cc30fc191098109022366
   depends:
+  - libabseil * cxx17*
   - libabseil >=20230125.3,<20230126.0a0
   - libprotobuf >=4.23.3,<4.23.4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools *
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  size: 305533
-  timestamp: 1688121734729
+  size: 373238
+  timestamp: 1688121651525
 - kind: conda
   name: protobuf
   version: 4.23.3
-  build: py310hb875b13_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.23.3-py310hb875b13_0.conda
-  sha256: b92f2c7728f1625003a247721af5b22c8100a92714596ce8158a07790221c40e
-  md5: 27ce7010f8821add3b955ec88f663bb6
+  build: py311h4acf6a1_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.23.3-py311h4acf6a1_0.conda
+  sha256: 36459af23c33123959fe0d0c412e1f48faf7949cf41d9862bbe015a113411b58
+  md5: 5717df9f83f8836430584a998882b8a0
   depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 375297
+  timestamp: 1688121884294
+- kind: conda
+  name: protobuf
+  version: 4.23.3
+  build: py311h700567c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/protobuf-4.23.3-py311h700567c_0.conda
+  sha256: d48cda648d739b8d904d1429286721c0c9e7ac1201d5200b13e12bae394ec8b9
+  md5: cad007051fee4511f55d3b27aae294ee
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368807
+  timestamp: 1688121675012
+- kind: conda
+  name: protobuf
+  version: 4.23.3
+  build: py311hbec7ed6_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/protobuf-4.23.3-py311hbec7ed6_0.conda
+  sha256: 0df28760cfcca97fd3076f3b75370cb1ffcd9d66e5f198ce5c06261691d0282d
+  md5: 58f90badf016d9055c71387dc6571366
+  depends:
+  - libabseil * cxx17*
   - libabseil >=20230125.3,<20230126.0a0
   - libgcc-ng >=12
   - libprotobuf >=4.23.3,<4.23.4.0a0
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools *
-  arch: x86_64
-  platform: linux
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
   license: BSD-3-Clause
   license_family: BSD
-  size: 325773
-  timestamp: 1688121366252
-- kind: conda
-  name: protobuf
-  version: 4.23.3
-  build: py310hf4e154e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/protobuf-4.23.3-py310hf4e154e_0.conda
-  sha256: 6a2bc6b6f9bba49ea6e6597316ee0cba53a5fb895358a74ac65c06e810799314
-  md5: 1380d038b8479490f5128f29c0d3cbc1
-  depends:
-  - setuptools *
-  - python >=3.10,<3.11.0a0 *_cpython
-  - libcxx >=15.0.7
-  - python_abi 3.10.* *_cp310
-  - libprotobuf >=4.23.3,<4.23.4.0a0
-  - libabseil >=20230125.3,<20230126.0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 309752
-  timestamp: 1688121806045
+  size: 388957
+  timestamp: 1688121496794
 - kind: conda
   name: psutil
   version: 5.9.5
-  build: py310h2372a71_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py310h2372a71_1.conda
-  sha256: db8a99bc41c1b0405c8e9daa92b9d4e7711f9717aff7fd3feeba407ca2a91aa2
-  md5: cb25177acf28cc35cfa6c1ac1c679e22
-  depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 361313
-  timestamp: 1695367285835
-- kind: conda
-  name: psutil
-  version: 5.9.5
-  build: py310h6729b98_1
+  build: py311h2725bcf_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py310h6729b98_1.conda
-  sha256: dc0079bc5833de86578da4d27ca7e44921a01e2da3cbb624922d2bcbc6b95876
-  md5: 941f32dc5bd1a725fbd4fd54aec75ed1
+  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.5-py311h2725bcf_1.conda
+  sha256: 2eee900e0e5a103cff0159cdd81d401b67ccfb919be6cd868fc34c22dab981f1
+  md5: 16221cd0488a32152a6b3f1a301ccf19
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 369757
-  timestamp: 1695367511232
+  size: 506611
+  timestamp: 1695367402674
 - kind: conda
   name: psutil
   version: 5.9.5
-  build: py310h8d17308_1
+  build: py311h459d7ec_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.5-py311h459d7ec_1.conda
+  sha256: e92d2120fc4b98fe838b3d52d4907fae97808bdd504fb84aa33aea8c4be7bc61
+  md5: 490d7fa8675afd1aa6f1b2332d156a45
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 498698
+  timestamp: 1695367306421
+- kind: conda
+  name: psutil
+  version: 5.9.5
+  build: py311ha68e1ae_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py310h8d17308_1.conda
-  sha256: 6c03b652b5d1488fe88ce1a20ee4a072b44277b05002d2af7d2db19643d50b3d
-  md5: bd83570cfe0ce9ccc46c9c55b0aab666
+  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.5-py311ha68e1ae_1.conda
+  sha256: e5c09eee9902e0c56d89f88210009b34d819d241ac5b7dde38266324a85fde51
+  md5: f64b2d9577e753fea9662dae11339ac2
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 380206
-  timestamp: 1695367659588
+  size: 516106
+  timestamp: 1695367685028
 - kind: conda
   name: psutil
   version: 5.9.5
-  build: py310h8e9501a_0
+  build: py311heffc1b2_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py310h8e9501a_0.conda
-  sha256: 8087d712579ac7537c5d5204c9122a2bac6ee659901df79da32a311169409e91
-  md5: 691828350ac4ddd02cb9533740a8604c
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.5-py311heffc1b2_1.conda
+  sha256: a12a525d3bcaed04e0885b2bd00f4f626c80c19d7c0ae8bb7cf7121aefb39e52
+  md5: a40123b40642b8b08b3830a3f6bc7fd9
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/psutil
-  size: 370353
-  timestamp: 1681775531641
+  size: 506971
+  timestamp: 1695367619126
 - kind: conda
   name: psygnal
   version: 0.11.0
@@ -12741,98 +12564,91 @@ packages:
 - kind: conda
   name: pyarrow
   version: 12.0.1
-  build: py310h6eef95f_12_cpu
+  build: py311h39c9aba_12_cpu
   build_number: 12
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-12.0.1-py310h6eef95f_12_cpu.conda
-  sha256: 15949bc591022780bd96bd35a76ba6368b6efcf8dcba09c7df9f36b332822216
-  md5: 9283420cc2b391fba5f9f99c6d8fb763
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-12.0.1-py311h39c9aba_12_cpu.conda
+  sha256: 668cb8e6bcfef371835e52ceb8a8b6289b7977be07d8144761ac04f850d383a6
+  md5: 4a3ee4ed52fa0d4eaa0de54ff344cd39
   depends:
-  - libarrow ==12.0.1 hca2412d_12_cpu
-  - libcxx >=15.0.7
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libarrow 12.0.1 h1ed0495_12_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  size: 3551558
-  timestamp: 1694160121359
+  size: 4021586
+  timestamp: 1694159608922
 - kind: conda
   name: pyarrow
   version: 12.0.1
-  build: py310hd0bb7c2_12_cpu
+  build: py311h6a6099b_12_cpu
   build_number: 12
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-12.0.1-py310hd0bb7c2_12_cpu.conda
-  sha256: 426148c38ad6ac29a45929aba5a50ca8213e00964c3c7cacff7914c215b77089
-  md5: 9dc45d4fa2be6f9e003e076ca15c6cad
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-12.0.1-py311h6a6099b_12_cpu.conda
+  sha256: c7ee41108ea2b737484731b7446172ba5b170063a6d9bf1952b9879ba1631fc7
+  md5: f70da919ee9b5294ccce01295d0d0781
   depends:
-  - libarrow ==12.0.1 hba3d5be_12_cpu
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libarrow 12.0.1 hba3d5be_12_cpu
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: APACHE
-  size: 2929385
-  timestamp: 1694161048581
+  size: 2992213
+  timestamp: 1694160152066
 - kind: conda
   name: pyarrow
   version: 12.0.1
-  build: py310hf9e7431_12_cpu
+  build: py311h7c6147c_12_cpu
   build_number: 12
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-12.0.1-py310hf9e7431_12_cpu.conda
-  sha256: c2e6ad199ac9ffc688a61a2bb5b557f002aea5717427680bc6d580ee8e0ce37f
-  md5: 84fadfdb42b2ca3bbf91a4e9225d0bf9
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-12.0.1-py311h7c6147c_12_cpu.conda
+  sha256: 0606e3fdbc7fa360c5e2a9d8108b2e8f82990e26d321c4a77ae4b65e069cb94b
+  md5: d100bd2c96f50ad698d23ef1dc901b86
   depends:
-  - libarrow ==12.0.1 h1ed0495_12_cpu
-  - libgcc-ng >=12
-  - libstdcxx-ng >=12
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libarrow 12.0.1 hca2412d_12_cpu
+  - libcxx >=15.0.7
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - apache-arrow-proc =*=cpu
-  arch: x86_64
-  platform: linux
   license: Apache-2.0
   license_family: APACHE
-  size: 3944912
-  timestamp: 1694159309468
+  size: 3614469
+  timestamp: 1694161399560
 - kind: conda
   name: pyarrow
   version: 12.0.1
-  build: py310hfbab16f_8_cpu
-  build_number: 8
+  build: py311hd7bc329_9_cpu
+  build_number: 9
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-12.0.1-py310hfbab16f_8_cpu.conda
-  sha256: 934f760a09c764abb001e56e7128577260050df186fd751b25d65d4763765992
-  md5: 990ceb1edd36789de511250253528fd4
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-12.0.1-py311hd7bc329_9_cpu.conda
+  sha256: e4ea4f9e7dd18a93e3ff812bd97e4c75d4806459224f78564261a40f88768227
+  md5: 85e4339d2a158d65e0cba1ae71c12ce3
   depends:
-  - numpy >=1.21.6,<2.0a0
+  - libarrow 12.0.1 h6e4acf5_9_cpu
   - libcxx >=15.0.7
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - libarrow ==12.0.1 *_8_cpu
+  - numpy >=1.23.5,<2.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   constrains:
   - apache-arrow-proc =*=cpu
-  arch: aarch64
-  platform: osx
   license: Apache-2.0
   license_family: APACHE
-  size: 3608215
-  timestamp: 1691482830525
+  size: 3656287
+  timestamp: 1692676095519
 - kind: conda
   name: pycparser
   version: '2.21'
@@ -12873,81 +12689,82 @@ packages:
   timestamp: 1691408777841
 - kind: conda
   name: pyobjc-core
-  version: '9.2'
-  build: py310hd07e440_0
+  version: 10.3.1
+  build: py311h09e6bbd_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-9.2-py310hd07e440_0.conda
-  sha256: e93831ae0eb37227e5d4025a47331c070771f1330aca9506f87226bae28b35ef
-  md5: 5f7cd107ffeef7a221721e254fd0a453
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py311h09e6bbd_1.conda
+  sha256: 698b08ca54169a744a1a087130ece9528f18da5e3be33ff6799ac6337d2a5e7f
+  md5: a0a43da9ec3ffb6195e7621fd959f430
   depends:
-  - setuptools *
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
+  - __osx >=11.0
   - libffi >=3.4,<4.0a0
-  arch: aarch64
-  platform: osx
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - setuptools
   license: MIT
   license_family: MIT
-  size: 423827
-  timestamp: 1686130163875
+  size: 485377
+  timestamp: 1725739643057
 - kind: conda
   name: pyobjc-core
-  version: '10.0'
-  build: py310hef2d279_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.0-py310hef2d279_0.conda
-  sha256: 68f246c0904266aa57b38255298710d87fb8db0b80f0e2f89b5ef488925bac80
-  md5: 9346ad035be9e76cf1184110571ab8e8
-  depends:
-  - libffi >=3.4,<4.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - setuptools *
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 418687
-  timestamp: 1695560652946
-- kind: conda
-  name: pyobjc-framework-cocoa
-  version: '9.2'
-  build: py310hd07e440_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-9.2-py310hd07e440_0.conda
-  sha256: 21b856e69059bdf805058b32a479e27bf5ce33d18f2ad060f881bd6d165aed8e
-  md5: caa99829ac1793201e034a496cad24a0
-  depends:
-  - pyobjc-core 9.2.*
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - libffi >=3.4,<4.0a0
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 330609
-  timestamp: 1686136466240
-- kind: conda
-  name: pyobjc-framework-cocoa
-  version: '10.0'
-  build: py310hef2d279_1
+  version: 10.3.1
+  build: py311hd6939f8_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.0-py310hef2d279_1.conda
-  sha256: 8784afcd959b99fba6bc7cf475141161f7fb7d8500ff8779fda645019973fe8d
-  md5: 801c23afa12fdaed4771a9e867cc794b
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py311hd6939f8_1.conda
+  sha256: 48de2a78d71e6c1a2681c1fbcf1f1503a29c58cc42cfc0fafa5c1b59a10eda94
+  md5: c8e529b8f6a408dfc6a2bc0c607e2338
   depends:
+  - __osx >=10.13
   - libffi >=3.4,<4.0a0
-  - pyobjc-core 10.0.*
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - setuptools
   license: MIT
   license_family: MIT
-  size: 328263
-  timestamp: 1695716989533
+  size: 491149
+  timestamp: 1725739585987
+- kind: conda
+  name: pyobjc-framework-cocoa
+  version: 10.3.1
+  build: py311h09e6bbd_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.3.1-py311h09e6bbd_1.conda
+  sha256: 1d9f2c68ba6c7812f0c1e4a9bf9a5ad0a691b7b7b7694cb7ec0f05f1c24906f1
+  md5: 9c3fc1bf9718d8340f41b0fab06ecdaa
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 384333
+  timestamp: 1725875205492
+- kind: conda
+  name: pyobjc-framework-cocoa
+  version: 10.3.1
+  build: py311hd6939f8_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.3.1-py311hd6939f8_1.conda
+  sha256: bf6179d71edb920cedf7ce4395f4447d5ae96a9deb5a44dcc1a6abffea0de4aa
+  md5: f3f565f99289de1cd140bdbea51b94eb
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pyobjc-core 10.3.1.*
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 381020
+  timestamp: 1725875173947
 - kind: conda
   name: pysocks
   version: 1.7.1
@@ -13067,110 +12884,115 @@ packages:
   timestamp: 1684965001294
 - kind: conda
   name: python
-  version: 3.10.12
-  build: h01493a6_0_cpython
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.10.12-h01493a6_0_cpython.conda
-  sha256: 318355582595373ee7962383b67b0386541ad13e3734c3ee11331db025613b57
-  md5: a36e753b6c8875be1242229b3eabe907
-  depends:
-  - tzdata *
-  - openssl >=3.1.1,<4.0a0
-  - readline >=8.2,<9.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.42.0,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - xz >=5.2.6,<6.0a0
-  - tk >=8.6.12,<8.7.0a0
-  - bzip2 >=1.0.8,<2.0a0
-  - ncurses >=6.4,<7.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
-  license: Python-2.0
-  size: 12503692
-  timestamp: 1687560425496
-- kind: conda
-  name: python
-  version: 3.10.13
-  build: h00d2728_0_cpython
+  version: 3.11.9
+  build: h657bba9_0_cpython
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.10.13-h00d2728_0_cpython.conda
-  sha256: 388b4f2c0e638c5e3aa927256bdae3d4aca6ee70406191df378321aea3558aa3
-  md5: d09fa6ab82a97c95d3a324d79263b980
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.9-h657bba9_0_cpython.conda
+  sha256: 3b50a5abb3b812875beaa9ab792dbd1bf44f335c64e9f9fedcf92d953995651c
+  md5: 612763bc5ede9552e4233ec518b9c9fb
   depends:
+  - __osx >=10.9
   - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
   - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.4,<4.0a0
-  - readline >=8.2,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata *
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
-  license: Python-2.0
-  size: 12998833
-  timestamp: 1698344444453
-- kind: conda
-  name: python
-  version: 3.10.13
-  build: h4de0772_0_cpython
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.10.13-h4de0772_0_cpython.conda
-  sha256: 9e55fa834ddb2c24aec8ee4d4738584fea71edc084a615facc846ce90deb58e4
-  md5: cbf696b644613f8ab6c9df6b5005c042
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libffi >=3.4,<4.0a0
-  - libsqlite >=3.43.2,<4.0a0
-  - libzlib >=1.2.13,<1.3.0a0
-  - openssl >=3.1.4,<4.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata *
-  - vc >=14.1,<15
-  - vc14_runtime >=14.16.27033
-  - xz >=5.2.6,<6.0a0
-  constrains:
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: win
-  license: Python-2.0
-  size: 15891788
-  timestamp: 1698344089500
-- kind: conda
-  name: python
-  version: 3.10.13
-  build: hd12c33a_0_cpython
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.10.13-hd12c33a_0_cpython.conda
-  sha256: a53410f459f314537b379982717b1c5911efc2f0cc26d63c4d6f831bcb31c964
-  md5: f3a8c32aa764c3e7188b4b810fc9d6ce
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-64 >=2.36.1
-  - libffi >=3.4,<4.0a0
-  - libgcc-ng >=12
-  - libnsl >=2.0.1,<2.1.0a0
-  - libsqlite >=3.43.2,<4.0a0
-  - libuuid >=2.38.1,<3.0a0
+  - libsqlite >=3.45.3,<4.0a0
   - libzlib >=1.2.13,<2.0.0a0
-  - ncurses >=6.4,<7.0a0
-  - openssl >=3.1.4,<4.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
   - readline >=8.2,<9.0a0
   - tk >=8.6.13,<8.7.0a0
   - tzdata
   - xz >=5.2.6,<6.0a0
   constrains:
-  - python_abi 3.10.* *_cp310
+  - python_abi 3.11.* *_cp311
   license: Python-2.0
-  size: 25476977
-  timestamp: 1698344640413
+  size: 15503226
+  timestamp: 1713553747073
+- kind: conda
+  name: python
+  version: 3.11.9
+  build: h932a869_0_cpython
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.9-h932a869_0_cpython.conda
+  sha256: a436ceabde1f056a0ac3e347dadc780ee2a135a421ddb6e9a469370769829e3c
+  md5: 293e0713ae804b5527a673e7605c04fc
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.2,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.45.3,<4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ncurses >=6.4.20240210,<7.0a0
+  - openssl >=3.2.1,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14644189
+  timestamp: 1713552154779
+- kind: conda
+  name: python
+  version: 3.11.10
+  build: hc5c86c4_2_cpython
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_2_cpython.conda
+  sha256: 06aef8aee7d379851df48e78eec81820817aaf7e4788dde1b945d903cd4af7ea
+  md5: 2a07cf98fe8c2f039a1ccfea22eaaad4
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30574701
+  timestamp: 1727721739918
+- kind: conda
+  name: python
+  version: 3.11.10
+  build: hce54a09_2_cpython
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.11.10-hce54a09_2_cpython.conda
+  sha256: 610da651755c30f71ba823f311f684bee693bc56ced984b477ac4e04563485c9
+  md5: 472544e6104756d9658571f40e17b5af
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.3.2,<4.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 18217527
+  timestamp: 1727718965271
 - kind: conda
   name: python-dateutil
   version: 2.8.2
@@ -13194,74 +13016,74 @@ packages:
 - kind: conda
   name: python-duckdb
   version: 1.0.0
-  build: py310h9e98ed7_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.0.0-py310h9e98ed7_0.conda
-  sha256: 23c2abb0018fdd2ee8176b33ac8eac48b6094a219b971c5fdc702285785aa4cd
-  md5: cae7ec224c706014f6e1568b3cf1cc96
+  build: py311hb9542d7_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.0.0-py311hb9542d7_0.conda
+  sha256: e4d85432a438f92038676884effdac911c7872ccb7443a14d34ff00b9bdeca4f
+  md5: 9933c9a37a08cd017b60308c31508dd4
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=11.0
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 18626682
+  timestamp: 1717686218064
+- kind: conda
+  name: python-duckdb
+  version: 1.0.0
+  build: py311hbafa61a_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.0.0-py311hbafa61a_0.conda
+  sha256: de7fcc864bebb3b49cc63f5d5e1b64d4d0ab1c08452172cfc7d19beaa638a2de
+  md5: dc9e120b8948816994f28bdf2303e9b1
+  depends:
+  - __osx >=10.13
+  - libcxx >=16
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 20136473
+  timestamp: 1717686468089
+- kind: conda
+  name: python-duckdb
+  version: 1.0.0
+  build: py311hda3d55a_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.0.0-py311hda3d55a_0.conda
+  sha256: c747911294af8fe7de438079ab092454eb599d1741461786ba43c0261a3c5e65
+  md5: 7514feff0af5c50e5d8a8ecd28a7c062
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  size: 15638825
-  timestamp: 1717687118745
+  size: 15655914
+  timestamp: 1717687917596
 - kind: conda
   name: python-duckdb
   version: 1.0.0
-  build: py310hcf9f62a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.0.0-py310hcf9f62a_0.conda
-  sha256: 720fdd1e1a34bafc4e5b671c4ab722d2953d09563ca2a4520bb6fb450510fa34
-  md5: ff23b03d25d3614a05e91d94036b94b8
-  depends:
-  - __osx >=11.0
-  - libcxx >=16
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  size: 18599847
-  timestamp: 1717686407221
-- kind: conda
-  name: python-duckdb
-  version: 1.0.0
-  build: py310he0a0c5d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-duckdb-1.0.0-py310he0a0c5d_0.conda
-  sha256: 3dd1abaa03cb511588c848b74ffdd817f576f259f5d42ad76c77358277c8ae5a
-  md5: 2c7fa91f1a5f57a72b1aec7e25f0a169
-  depends:
-  - __osx >=10.13
-  - libcxx >=16
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  size: 20190347
-  timestamp: 1717686142652
-- kind: conda
-  name: python-duckdb
-  version: 1.0.0
-  build: py310hea249c9_0
+  build: py311hf86e51f_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.0.0-py310hea249c9_0.conda
-  sha256: c85731fcd95eba6459f74c675dc6ea6a4ec31ab09607d4bb4316c701690cec20
-  md5: 630bef971bd14f61afa83422425d7f95
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.0.0-py311hf86e51f_0.conda
+  sha256: 2068d4a41bea8955650e8df4a39d4e2fb6808b2c57be7cb87b25ee4fae779be9
+  md5: 108ac6b3861091085c24a78f2cfdaf28
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc-ng >=12
   - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 22769349
-  timestamp: 1717686625369
+  size: 22852110
+  timestamp: 1717686282529
 - kind: conda
   name: python-fastjsonschema
   version: 2.18.0
@@ -13340,72 +13162,64 @@ packages:
   timestamp: 1680081272948
 - kind: conda
   name: python_abi
-  version: '3.10'
-  build: 3_cp310
-  build_number: 3
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.10-3_cp310.conda
-  sha256: 3f23b0e1656682b0ad1ded4810ba269b610299091c36cf5d516e2dc1162695de
-  md5: 3f2b2974db21a33a2f45b0c9abbb7516
-  constrains:
-  - python 3.10.* *_cpython
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 5771
-  timestamp: 1669071822684
-- kind: conda
-  name: python_abi
-  version: '3.10'
-  build: 4_cp310
-  build_number: 4
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.10-4_cp310.conda
-  sha256: 456bec815bfc2b364763084d08b412fdc4c17eb9ccc66a36cb775fa7ac3cbaec
-  md5: 26322ec5d7712c3ded99dd656142b8ce
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
   constrains:
-  - python 3.10.* *_cpython
-  arch: x86_64
-  platform: linux
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6398
-  timestamp: 1695147363189
+  size: 6211
+  timestamp: 1723823324668
 - kind: conda
   name: python_abi
-  version: '3.10'
-  build: 4_cp310
-  build_number: 4
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.10-4_cp310.conda
-  sha256: abc26b3b5a62f9c8112a2303d24b0c590d5f7fc9470521f5a520472d59c2223e
-  md5: b15c816c5a86abcc4d1458dd63aa4c65
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
   constrains:
-  - python 3.10.* *_cpython
-  arch: x86_64
-  platform: osx
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6484
-  timestamp: 1695147705581
+  size: 6303
+  timestamp: 1723823062672
 - kind: conda
   name: python_abi
-  version: '3.10'
-  build: 4_cp310
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.10-4_cp310.conda
-  sha256: 19066c462fd0e32c64503c688f77cb603beb4019b812caf855d03f2a5447960b
-  md5: b41195997c14fb7473d26637ea4c3946
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
   constrains:
-  - python 3.10.* *_cpython
-  arch: x86_64
-  platform: win
+  - python 3.11.* *_cpython
   license: BSD-3-Clause
   license_family: BSD
-  size: 6773
-  timestamp: 1695147715814
+  size: 6308
+  timestamp: 1723823096865
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b210e5807dd9c9ed71ff192a95f1872da597ddd10e7cefec93a922fe22e598a
+  md5: 895b873644c11ccc0ab7dba2d8513ae6
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6707
+  timestamp: 1723823225752
 - kind: conda
   name: pytz
   version: '2023.3'
@@ -13446,304 +13260,277 @@ packages:
   timestamp: 1693930444432
 - kind: conda
   name: pywavelets
-  version: 1.4.1
-  build: py310h1f7b6fc_1
+  version: 1.7.0
+  build: py311h0034819_1
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.4.1-py310h1f7b6fc_1.conda
-  sha256: 2aa5da771dd7e4ec8316de51edd7aefcb6f688f7e4d2a2905faac76462826cf7
-  md5: be6f0382440ccbf9fb01bb19ab1f1fc0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pywavelets-1.7.0-py311h0034819_1.conda
+  sha256: cb15f21280f619bff7b060522a5f72cee2c20e27111745764ea74c30ca3bc29f
+  md5: 3cc0b331be40746c0c3b60f80181cd76
   depends:
-  - libgcc-ng >=12
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
+  - __osx >=10.13
+  - numpy >=1.19,<3
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/pywavelets
-  size: 3689326
-  timestamp: 1695567803832
+  size: 3670514
+  timestamp: 1726814958606
 - kind: conda
   name: pywavelets
-  version: 1.4.1
-  build: py310h3e78b6c_1
+  version: 1.7.0
+  build: py311h0a17f05_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywavelets-1.4.1-py310h3e78b6c_1.conda
-  sha256: b31e156a15a8bf86313e0fd0a26ed7beaab823da9604894448e96bd7df53dcd7
-  md5: 9dfe95c9d95172e888f612aeffcb13a8
+  url: https://conda.anaconda.org/conda-forge/win-64/pywavelets-1.7.0-py311h0a17f05_1.conda
+  sha256: 81287292dd0247464f04bec4eb3094961aea1321ad89eec73e7f15b0e9a073b5
+  md5: 636ec32d9c1850a27b54a4462b8157d1
   depends:
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - numpy >=1.19,<3
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/pywavelets
-  size: 3547104
-  timestamp: 1695568130734
+  size: 3621050
+  timestamp: 1726815285550
 - kind: conda
   name: pywavelets
-  version: 1.4.1
-  build: py310hf0b6da5_1
+  version: 1.7.0
+  build: py311h0f07fe1_1
   build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pywavelets-1.4.1-py310hf0b6da5_1.conda
-  sha256: e75ecf5d9c68bf2e9fc51982f170bb5a9542c4cb777ac40889dcd29521d61907
-  md5: 6606a7e6b981c0dc578c436d3920e8e7
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pywavelets-1.7.0-py311h0f07fe1_1.conda
+  sha256: 12b8d382c314127c006962f3949b621465cff1ce06d9fa2c59cbec5215b06b6c
+  md5: 46815b5568ead0ae42a5b7bca4d6e02f
   depends:
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - __osx >=11.0
+  - numpy >=1.19,<3
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/pywavelets
-  size: 3608914
-  timestamp: 1695569899715
+  size: 3677099
+  timestamp: 1726814819624
 - kind: conda
   name: pywavelets
-  version: 1.4.1
-  build: py310hf1a086a_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pywavelets-1.4.1-py310hf1a086a_0.conda
-  sha256: c0c109d583f29d24bc749c76bb85bf3565efbeea4dd0ba0790b579bd72c98a4f
-  md5: 7a67e82c6748821185f49830ff8a1b8c
+  version: 1.7.0
+  build: py311h9f3472d_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pywavelets-1.7.0-py311h9f3472d_1.conda
+  sha256: eaa05ef07afeff85f5bfb7255322f680f2a76a0f140a5091ea1df2ef49ef267e
+  md5: be9361437b3f5b9d79ffa6b577b1dedc
   depends:
-  - numpy >=1.21.6,<2.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - numpy >=1.19,<3
+  - numpy >=1.23,<3
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/pywavelets
-  size: 3556305
-  timestamp: 1673082762893
+  size: 3752705
+  timestamp: 1726814709298
 - kind: conda
   name: pywin32
-  version: '306'
-  build: py310h00ffb61_2
-  build_number: 2
+  version: '307'
+  build: py311hda3d55a_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py310h00ffb61_2.conda
-  sha256: 24fd15c118974da18c38870380195e633d2452a7fb7dbc0ecb96b44416989b33
-  md5: a65056c5f52aa83455577958872e4776
+  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-307-py311hda3d55a_3.conda
+  sha256: 78a4ede098bbc122a3dff4e0e27255e30b236101818e8f499779c89670c58cd6
+  md5: 1bc10dbe3b8d03071070c962a2bdf65f
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: PSF-2.0
-  license_family: PSF
-  size: 5689476
-  timestamp: 1695974437046
+  size: 6023110
+  timestamp: 1728636767562
 - kind: conda
   name: pywinpty
-  version: 2.0.12
-  build: py310h00ffb61_0
+  version: 2.0.13
+  build: py311hda3d55a_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py310h00ffb61_0.conda
-  sha256: a9fafd16ef160c9c11ac45f932b53916c5ad4c7c06ba0fb96b4859a8af879358
-  md5: 3cc562064a5d055f371ccc281b8e6396
+  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.13-py311hda3d55a_1.conda
+  sha256: 3a92acf4e678c357d7cea42000e9a77b0a420d16d4c9b2745452200690ac7645
+  md5: ad3dc83fc4598a791652338f5b306156
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - winpty *
-  arch: x86_64
-  platform: win
+  - winpty
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/pywinpty
-  size: 209900
-  timestamp: 1696657831046
+  size: 213169
+  timestamp: 1724951443134
 - kind: conda
   name: pyyaml
-  version: '6.0'
-  build: py310h8e9501a_5
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0-py310h8e9501a_5.tar.bz2
-  sha256: 9f5b55141e51d64bcd235eeda8d191ba9adde888b33e8bc338229718304f23a5
-  md5: 51d03e61fad9a0703bece80e471e95d3
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - yaml >=0.2.5,<0.3.0a0
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 162676
-  timestamp: 1666772867901
-- kind: conda
-  name: pyyaml
-  version: 6.0.1
-  build: py310h2372a71_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py310h2372a71_1.conda
-  sha256: aa78ccddb0a75fa722f0f0eb3537c73ee1219c9dd46cea99d6b9eebfdd780f3d
-  md5: bb010e368de4940771368bc3dc4c63e7
-  depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: linux
-  license: MIT
-  license_family: MIT
-  size: 170627
-  timestamp: 1695373587159
-- kind: conda
-  name: pyyaml
-  version: 6.0.1
-  build: py310h6729b98_1
+  version: 6.0.2
+  build: py311h3336109_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py310h6729b98_1.conda
-  sha256: 00567f2cb2d1c8fede8fe7727f7bbd1c38cbca886814d612e162d5c936d8db1b
-  md5: d964cec3e7972e44bc4a328134b9eaf1
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.2-py311h3336109_1.conda
+  sha256: d8f4513c53a7c0be9f1cdb9d1af31ac85cf8a6f0e4194715e36e915c03104662
+  md5: b0132bec7165a53403dcc393ff761a9e
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: osx
   license: MIT
   license_family: MIT
-  size: 160097
-  timestamp: 1695373947773
+  size: 193941
+  timestamp: 1725456465818
 - kind: conda
   name: pyyaml
-  version: 6.0.1
-  build: py310h8d17308_1
+  version: 6.0.2
+  build: py311h460d6c5_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py311h460d6c5_1.conda
+  sha256: 9ae182eef4e96a7c2f46cc9add19496276612663e17429500432631dce31a831
+  md5: d32590e7bd388f18b036c6fc402a0cb1
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 192321
+  timestamp: 1725456528007
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py311h9ecbd09_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py311h9ecbd09_1.conda
+  sha256: e721e5ff389a7b2135917c04b27391be3d3382e261bb60a369b1620655365c3d
+  md5: abeb54d40f439b86f75ea57045ab8496
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - yaml >=0.2.5,<0.3.0a0
+  license: MIT
+  license_family: MIT
+  size: 212644
+  timestamp: 1725456264282
+- kind: conda
+  name: pyyaml
+  version: 6.0.2
+  build: py311he736701_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py310h8d17308_1.conda
-  sha256: ea51291e477b44c5bb9d91cc095db0dfe07b9576831e9682100d68c820c43ae3
-  md5: ce279186f68d0f12812dc9955ea909a4
+  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.2-py311he736701_1.conda
+  sha256: 86608f1b4f6b1819a74b6b1344c34304745fd7e84bfc9900269f57cf28178d31
+  md5: d0c5f3c595039890be0c9af47d23b9ba
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - yaml >=0.2.5,<0.3.0a0
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  size: 146195
-  timestamp: 1695374085323
+  size: 187901
+  timestamp: 1725456808581
 - kind: conda
   name: pyzmq
-  version: 25.1.1
-  build: py310h2849c00_2
-  build_number: 2
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.1-py310h2849c00_2.conda
-  sha256: 5643d7efaf8cc714a1dd7f4c4a1fea36bd9d12665af40bb10137ad0ee99e956d
-  md5: 4ef6bc04df33ba9a13145bc2ac254346
+  version: 26.2.0
+  build: py311h137d824_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-26.2.0-py311h137d824_0.conda
+  sha256: b276e7e031fea37d761fe2bc7bd0667798e6514c08eb1a18890071d101c06eef
+  md5: 95502a31573bfb073c5f11039b87ada1
   depends:
+  - __osx >=11.0
+  - libcxx >=17
   - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - zeromq >=4.3.5,<4.4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 366105
+  timestamp: 1724399640109
+- kind: conda
+  name: pyzmq
+  version: 26.2.0
+  build: py311h484c95c_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-26.2.0-py311h484c95c_3.conda
+  sha256: 4d3fc4cfac284efb83a903601586cc6ee18fb556d4bf84d3bd66af76517c463e
+  md5: 4836b00658e11b466b823216f6df2424
+  depends:
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - zeromq >=4.3.5,<4.3.6.0a0
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 409451
-  timestamp: 1698063170421
+  license: BSD-3-Clause
+  size: 371084
+  timestamp: 1728642713666
 - kind: conda
   name: pyzmq
-  version: 25.1.1
-  build: py310h30b7201_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.1-py310h30b7201_0.conda
-  sha256: aeb1f07995d2b8316405cc2591a303cc42b5299e87adde6fec7121c00cb70809
-  md5: 8d763946acb208fedc0a386e8cb63abf
-  depends:
-  - zeromq >=4.3.4,<4.4.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - libcxx >=15.0.7
-  - python_abi 3.10.* *_cp310
-  - libsodium >=1.0.18,<1.0.19.0a0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 429622
-  timestamp: 1691667985563
-- kind: conda
-  name: pyzmq
-  version: 25.1.1
-  build: py310h795f18f_2
-  build_number: 2
+  version: 26.2.0
+  build: py311h7deb3e3_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.1-py310h795f18f_2.conda
-  sha256: 68fa979d6e92ddef0a93d22a4e902383b89db7ca77aab0682272bdeb4b14881a
-  md5: 6391ac95effeebc612023b9507b558b3
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py311h7deb3e3_0.conda
+  sha256: c2ac0bf749bef13439ffb56f198800e971f55bfc65e44107c39e9320154e06c5
+  md5: 536c998639c24ff56b79e86f9e422272
   depends:
-  - libgcc-ng >=12
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=13
   - libsodium >=1.0.18,<1.0.19.0a0
-  - libstdcxx-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libstdcxx-ng >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - zeromq >=4.3.5,<4.4.0a0
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 456635
-  timestamp: 1698062566269
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 388768
+  timestamp: 1724399265600
 - kind: conda
   name: pyzmq
-  version: 25.1.1
-  build: py310hd8b4af3_2
-  build_number: 2
+  version: 26.2.0
+  build: py311h95f92fe_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.1-py310hd8b4af3_2.conda
-  sha256: 286fd63ef90774f93956b36941487107b9e7f76807642454c4ff6d13ffd0ae83
-  md5: 077bc5af9c68c245eca66f927f93aaf1
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-26.2.0-py311h95f92fe_0.conda
+  sha256: 5b6ab9eb2ec2a73d8adb52bb2647d23daec70105aa09bd227db7d3ce5cd1db5a
+  md5: c7af3b7958225e23c475dcc483787f54
   depends:
+  - __osx >=10.13
+  - libcxx >=17
   - libsodium >=1.0.18,<1.0.19.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - zeromq >=4.3.5,<4.4.0a0
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause AND LGPL-3.0-or-later
-  purls:
-  - pkg:pypi/pyzmq
-  size: 416671
-  timestamp: 1698062738767
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 367476
+  timestamp: 1724399307300
 - kind: conda
   name: rav1e
   version: 0.6.6
@@ -14020,159 +13807,157 @@ packages:
   timestamp: 1598024297745
 - kind: conda
   name: rpds-py
-  version: 0.9.2
-  build: py310had9acf8_0
+  version: 0.20.0
+  build: py311h481aa64_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.9.2-py310had9acf8_0.conda
-  sha256: a458e7345c1b31192c3f3b930b353a5b43d2adf089dfbb9b2c78e82275330050
-  md5: 73d2888505be588eeef1e9177992348d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.20.0-py311h481aa64_1.conda
+  sha256: c79a6db2a50644ad07e85038f00b2d6bcadde0702d6eab805b0cf2d124717966
+  md5: 2d9afb942738fa684a01323d53ecf6f8
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 273681
-  timestamp: 1689705841669
+  size: 290831
+  timestamp: 1725327425929
 - kind: conda
   name: rpds-py
-  version: 0.10.6
-  build: py310h0e083fb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.10.6-py310h0e083fb_0.conda
-  sha256: 5b1adacfa3c7f32bd871d31f8688e289385cd8974dcf352cdf91e9670cda458e
-  md5: 1d43921c3f2bbab79b4ba4e65a2499ab
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 289733
-  timestamp: 1697072688742
-- kind: conda
-  name: rpds-py
-  version: 0.10.6
-  build: py310h87d50f1_0
+  version: 0.20.0
+  build: py311h533ab2d_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.10.6-py310h87d50f1_0.conda
-  sha256: 59c08da9235fcea135bc35205c95079cdb86e2197a54d223db8efe2818dea1b5
-  md5: 97b168f58652c59e954611962e47cd5c
+  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.20.0-py311h533ab2d_1.conda
+  sha256: e4f10706f4b30f0ebcc3ed1ccc7b13b127d2bf43a43961fa0911fd199df7fe85
+  md5: ce65b053e6b59808fe42f1f0e84a925a
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 186246
-  timestamp: 1697073096998
+  size: 208679
+  timestamp: 1725327961461
 - kind: conda
   name: rpds-py
-  version: 0.10.6
-  build: py310hcb5633a_0
+  version: 0.20.0
+  build: py311h95688db_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.20.0-py311h95688db_1.conda
+  sha256: 8cd75a394aea88873df33fce27865bd8a40c9ebb13e08ceb15a77f720a0b7664
+  md5: 725a2cae824df9c489c72dc9b02bf86d
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 297046
+  timestamp: 1725327351207
+- kind: conda
+  name: rpds-py
+  version: 0.20.0
+  build: py311h9e33e62_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.10.6-py310hcb5633a_0.conda
-  sha256: a23d2f15c48cc689d26dc3f50ee91be9ed2925c5fbae7bc5d93e49db7517b847
-  md5: 43c12d8f7891a87378eb5339c49ef051
+  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.20.0-py311h9e33e62_1.conda
+  sha256: efcd140e5655816ce813c6e510db734bfa00c520e2d7fcc104d4402a33c48a0a
+  md5: 3989f9a93796221aff20be94300e3b93
   depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/rpds-py
-  size: 992400
-  timestamp: 1697072452949
+  size: 331891
+  timestamp: 1725327207078
 - kind: conda
   name: ruff
   version: 0.6.9
-  build: py310h11b6ba5_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.9-py310h11b6ba5_0.conda
-  sha256: 1b1255aaf7b07e7cf55778a82756a432c9f54afb0850d888cc5f27b072c5e41c
-  md5: 245c3025ee5063b8a95bab2035be42eb
+  build: py311h2cf8269_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.6.9-py311h2cf8269_0.conda
+  sha256: 69a38ee04fa5e32111cd0d8a9e0733231d79e4cd5fc7fa5b2f52c88288220199
+  md5: b5dbeca40a99bc7a9d7cc92dbaeb29d6
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - __osx >=11.0
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  size: 6867904
-  timestamp: 1728068781085
+  size: 6341522
+  timestamp: 1728067391058
 - kind: conda
   name: ruff
   version: 0.6.9
-  build: py310h4f26fa7_0
+  build: py311h8c6096b_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.9-py310h4f26fa7_0.conda
-  sha256: 7ba20d6fefbdb0bfc7aa20df205bb37ba5e6cf5ea6c919ddd52e121c761bc61a
-  md5: 3bd4e0fed3227341d2e101966f0e686a
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.6.9-py311h8c6096b_0.conda
+  sha256: dbe1273eb134fd0774041d479ca1c71e17593ce97282d31b924da6f735933411
+  md5: 60bcd3edd40a676dbb247cf9e8b3c5d3
   depends:
   - __osx >=10.13
   - libcxx >=17
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=10.12
   license: MIT
   license_family: MIT
-  size: 6709143
-  timestamp: 1728067364164
+  size: 6709499
+  timestamp: 1728067423159
 - kind: conda
   name: ruff
   version: 0.6.9
-  build: py310h624018c_0
+  build: py311heeab51b_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/ruff-0.6.9-py311heeab51b_0.conda
+  sha256: 94d03bff42ba685d04e83225324861e0304ab7a1f1d1e7f8715bc53215ff71b5
+  md5: 53cbe785349118d9b8fb5bcfb44f6dd6
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 6869319
+  timestamp: 1728068595978
+- kind: conda
+  name: ruff
+  version: 0.6.9
+  build: py311hef32070_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py310h624018c_0.conda
-  sha256: 5fefd28dd467bc6d84cacc122c7d551db1ca29aebdb7d418447ef0670c66da25
-  md5: 16502945d34d2dae72dd9b1c290b80e2
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py311hef32070_0.conda
+  sha256: a068c6d5e92b3e8bf7c40dab21e7e8b821333e3f4a6c62ef6c9355b49d31d026
+  md5: 5da462652e30bbedd97a8ea04d9a0cff
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=13
   - libstdcxx >=13
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 6970904
-  timestamp: 1728067124093
-- kind: conda
-  name: ruff
-  version: 0.6.9
-  build: py310he174661_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.6.9-py310he174661_0.conda
-  sha256: 8852e16b9819e8ff51aa7dc8363ed0fb2c9fd5a1074e87e0e719c9c2dc489da5
-  md5: 7282b9b4370bf099b98cbc7c58bcc2c1
-  depends:
-  - __osx >=11.0
-  - libcxx >=17
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - __osx >=11.0
-  license: MIT
-  license_family: MIT
-  size: 6341227
-  timestamp: 1728067442525
+  size: 6951306
+  timestamp: 1728067308475
 - kind: conda
   name: rust
   version: 1.80.1
@@ -14314,20 +14099,20 @@ packages:
 - kind: conda
   name: scikit-image
   version: 0.21.0
-  build: py310h00ffb61_0
+  build: py311h12c1d0e_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-image-0.21.0-py310h00ffb61_0.conda
-  sha256: 8eb9b713975b5b37fa8732d2cbf37ba5f9a2d5ad521567b3dd26200a021a1fbc
-  md5: 780c8f82b13f0bc4563ee38074ef4a2a
+  url: https://conda.anaconda.org/conda-forge/win-64/scikit-image-0.21.0-py311h12c1d0e_0.conda
+  sha256: 797550a30a5460c9e0756ee20ac9c63761079598d6bef984d2c238dbac1ac7e6
+  md5: d92d8466f4cb90486bdd863d1a81b62a
   depends:
   - imageio >=2.27
   - lazy_loader >=0.2
   - networkx >=2.8
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
   - packaging >=21
   - pillow >=9.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - pywavelets >=1.1.1
   - scipy >=1.8
   - tifffile >=2022.8.12
@@ -14335,238 +14120,224 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - astropy >=5.0
-  - dask-core >=2021.1.0
-  - cytoolz >=0.11.0
   - pooch >=1.6.0
-  - cloudpickle >=0.2.1
   - toolz >=0.10.0
-  - matplotlib-base >=3.5
   - scikit-learn >=1.0
-  arch: x86_64
-  platform: win
+  - dask-core >=2021.1.0
+  - cloudpickle >=0.2.1
+  - cytoolz >=0.11.0
+  - matplotlib-base >=3.5
+  - astropy >=5.0
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/scikit-image
-  size: 9726295
-  timestamp: 1688805432229
+  size: 10079358
+  timestamp: 1688805629626
 - kind: conda
   name: scikit-image
   version: 0.21.0
-  build: py310h1253130_0
+  build: py311ha891d26_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-image-0.21.0-py310h1253130_0.conda
-  sha256: 2a3736a1d50aa3dccbb8b8a02490f1bba70f05a2c1101d3304cdb17a3ecacdf0
-  md5: a1903e7cab3f9eeb38b28bee7923cb68
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - lazy_loader >=0.2
-  - python_abi 3.10.* *_cp310
-  - scipy >=1.8
-  - networkx >=2.8
-  - tifffile >=2022.8.12
-  - pywavelets >=1.1.1
-  - imageio >=2.27
-  - libcxx >=15.0.7
-  - numpy >=1.22.4,<2.0a0
-  - pillow >=9.0.1
-  - packaging >=21
-  constrains:
-  - dask-core >=2021.1.0
-  - cytoolz >=0.11.0
-  - toolz >=0.10.0
-  - matplotlib-base >=3.5
-  - cloudpickle >=0.2.1
-  - scikit-learn >=1.0
-  - pooch >=1.6.0
-  - astropy >=5.0
-  arch: aarch64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/scikit-image
-  size: 10331071
-  timestamp: 1688805562760
-- kind: conda
-  name: scikit-image
-  version: 0.21.0
-  build: py310h9e9d8ca_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-image-0.21.0-py310h9e9d8ca_0.conda
-  sha256: 7722bc1d22bcbbdcdd81f1182c63a3f80821c411c9098f1b5aab31d6a65fa337
-  md5: 02cd5afda6e66a31f409a7534f84a8bf
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-image-0.21.0-py311ha891d26_0.conda
+  sha256: a1425bb294b3d06235c0a18a0ec6be45ab8c218665106313a8db5a4260df0a06
+  md5: b217185dcafff1325299d61034546460
   depends:
   - imageio >=2.27
   - lazy_loader >=0.2
   - libcxx >=15.0.7
   - networkx >=2.8
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
   - packaging >=21
   - pillow >=9.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   - pywavelets >=1.1.1
   - scipy >=1.8
   - tifffile >=2022.8.12
   constrains:
-  - cytoolz >=0.11.0
-  - cloudpickle >=0.2.1
   - scikit-learn >=1.0
-  - astropy >=5.0
-  - matplotlib-base >=3.5
-  - pooch >=1.6.0
   - toolz >=0.10.0
+  - cloudpickle >=0.2.1
+  - astropy >=5.0
+  - pooch >=1.6.0
+  - matplotlib-base >=3.5
+  - cytoolz >=0.11.0
   - dask-core >=2021.1.0
-  arch: x86_64
-  platform: osx
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/scikit-image
-  size: 10142624
-  timestamp: 1688805257633
+  size: 10612625
+  timestamp: 1688805642862
 - kind: conda
   name: scikit-image
   version: 0.21.0
-  build: py310hc6cd4ac_0
+  build: py311hb755f60_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.21.0-py310hc6cd4ac_0.conda
-  sha256: 33bffcb895c9659a774894fe146b9aec69131d90bc07aa838e160b7bd96be93b
-  md5: f310b59965f43c9d875553f9b08b0dfb
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.21.0-py311hb755f60_0.conda
+  sha256: ea8f443a59897c5447f3e14bdf33d2ad88f8b44ae88aee53eace270439d2ff6d
+  md5: 0a8cbf18f7e57e43b8e106630a0ca7df
   depends:
   - imageio >=2.27
   - lazy_loader >=0.2
   - libgcc-ng >=12
   - libstdcxx-ng >=12
   - networkx >=2.8
-  - numpy >=1.22.4,<2.0a0
+  - numpy >=1.23.5,<2.0a0
   - packaging >=21
   - pillow >=9.0.1
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - pywavelets >=1.1.1
   - scipy >=1.8
   - tifffile >=2022.8.12
   constrains:
-  - cytoolz >=0.11.0
-  - dask-core >=2021.1.0
+  - scikit-learn >=1.0
   - astropy >=5.0
-  - matplotlib-base >=3.5
+  - dask-core >=2021.1.0
+  - pooch >=1.6.0
+  - cytoolz >=0.11.0
   - cloudpickle >=0.2.1
   - toolz >=0.10.0
-  - pooch >=1.6.0
-  - scikit-learn >=1.0
-  arch: x86_64
-  platform: linux
+  - matplotlib-base >=3.5
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/scikit-image
-  size: 10516342
-  timestamp: 1688804932797
+  size: 10839081
+  timestamp: 1688804944260
+- kind: conda
+  name: scikit-image
+  version: 0.21.0
+  build: py311hdf8f085_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-image-0.21.0-py311hdf8f085_0.conda
+  sha256: 6f4ec7efd11722e4c14ed15f2a8f679cad032de758eb11c3df4cd91635a327ae
+  md5: 9e0625e7beb9bdaa462942f4b56c1ee2
+  depends:
+  - imageio >=2.27
+  - lazy_loader >=0.2
+  - libcxx >=15.0.7
+  - networkx >=2.8
+  - numpy >=1.23.5,<2.0a0
+  - packaging >=21
+  - pillow >=9.0.1
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - pywavelets >=1.1.1
+  - scipy >=1.8
+  - tifffile >=2022.8.12
+  constrains:
+  - pooch >=1.6.0
+  - cloudpickle >=0.2.1
+  - toolz >=0.10.0
+  - matplotlib-base >=3.5
+  - dask-core >=2021.1.0
+  - astropy >=5.0
+  - cytoolz >=0.11.0
+  - scikit-learn >=1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 10475573
+  timestamp: 1688805369885
 - kind: conda
   name: scipy
   version: 1.11.1
-  build: py310h0975f3d_0
+  build: py311h93d07a4_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.1-py310h0975f3d_0.conda
-  sha256: 75c3cbf6d4152506bac2d16e14e0f7d67f318d09688039f110e870f60aa4b33f
-  md5: 60f18e4bdb777452d491f0fc1ec19302
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.11.1-py311h93d07a4_0.conda
+  sha256: f9b3fcc7c6d87d6603a7d7d6698c7ae8a0172b73241f2f13d16551a135643c84
+  md5: a62203d2445e563437b3d80327dee0eb
   depends:
-  - libgfortran 5.*
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
   - libblas >=3.9.0,<4.0a0
-  - pooch *
   - libcblas >=3.9.0,<4.0a0
   - libcxx >=15.0.7
+  - libgfortran 5.*
   - libgfortran5 >=12.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.21.6,<2.0a0
-  arch: aarch64
-  platform: osx
+  - numpy >=1.23.5,<1.28
+  - numpy >=1.23.5,<2.0a0
+  - pooch
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libopenblas <0.3.26
   license: BSD-3-Clause
   license_family: BSD
-  size: 14254504
-  timestamp: 1687997398824
+  size: 14968676
+  timestamp: 1687997669337
 - kind: conda
   name: scipy
-  version: 1.11.3
-  build: py310h2db466d_1
-  build_number: 1
+  version: 1.14.1
+  build: py311hb3ed397_0
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.11.3-py310h2db466d_1.conda
-  sha256: 9db6844496303ff8b788b36798073d5135d73b53bf37bc17a954de47e8a82fed
-  md5: 875c5e9c67f522102bd943351b463294
+  url: https://conda.anaconda.org/conda-forge/osx-64/scipy-1.14.1-py311hb3ed397_0.conda
+  sha256: b295c8c7984da0bf910d6e55ec5def15ba21d287a3606ed4310ad5f6639de8c7
+  md5: ad59f76d9b7b02fbcdddf741bb4d531a
   depends:
+  - __osx >=10.13
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
-  - libcxx >=15.0.7
+  - libcxx >=17
   - libgfortran 5.*
   - libgfortran5 >=13.2.0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  size: 15347225
-  timestamp: 1696469010531
+  size: 16255436
+  timestamp: 1724327987128
 - kind: conda
   name: scipy
-  version: 1.11.3
-  build: py310hb13e2d6_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.11.3-py310hb13e2d6_1.conda
-  sha256: bb8cdaf0869979ef58b3c10491f235c0fabf0b091e591361d25a4ffd47d6aded
-  md5: 4260b359d8fbeab4f789a8b0f968079f
-  depends:
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - libgcc-ng >=12
-  - libgfortran-ng *
-  - libgfortran5 >=12.3.0
-  - liblapack >=3.9.0,<4.0a0
-  - libstdcxx-ng >=12
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 14983190
-  timestamp: 1696468679504
-- kind: conda
-  name: scipy
-  version: 1.11.3
-  build: py310hf667824_1
-  build_number: 1
+  version: 1.14.1
+  build: py311hd4686c6_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.11.3-py310hf667824_1.conda
-  sha256: f51267072791bfda871b947b43efd73f0d3c5a5e581e4f47a611000c5c34d4e5
-  md5: 1325302e74eb18b8666f53559844bf44
+  url: https://conda.anaconda.org/conda-forge/win-64/scipy-1.14.1-py311hd4686c6_0.conda
+  sha256: f91a6d034e7f1560f35bd75d6733b2b1cf3997e78de74c21c671e688bc6c98d0
+  md5: 54c36e5548d5f9aa7b6944a6b5d45983
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
   - liblapack >=3.9.0,<4.0a0
-  - numpy >=1.22.4,<2.0a0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  size: 14064238
-  timestamp: 1696469923075
+  size: 16267830
+  timestamp: 1724329250657
+- kind: conda
+  name: scipy
+  version: 1.14.1
+  build: py311he1f765f_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py311he1f765f_0.conda
+  sha256: 36fd14d01a746bad1f9bc56045aa4fcfcdfe7b064a6d0c5a415dcdc8c0056983
+  md5: eb7e2a849cd47483d7e9eeb728c7a8c5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - libgcc-ng >=13
+  - libgfortran-ng
+  - libgfortran5 >=13.3.0
+  - liblapack >=3.9.0,<4.0a0
+  - libstdcxx-ng >=13
+  - numpy <2.3
+  - numpy >=1.19,<3
+  - numpy >=1.23.5
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 17723918
+  timestamp: 1724328196061
 - kind: conda
   name: selenium
   version: 4.11.2
@@ -15264,20 +15035,19 @@ packages:
   timestamp: 1666100385187
 - kind: conda
   name: tk
-  version: 8.6.12
-  build: he1e0b03_0
+  version: 8.6.13
+  build: h5083fa2_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.12-he1e0b03_0.tar.bz2
-  sha256: 9e43ec80045892e28233e4ca4d974e09d5837392127702fb952f3935b5e985a4
-  md5: 2cb3d18eac154109107f093860bd545f
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
+  sha256: 72457ad031b4c048e5891f3f6cb27a53cb479db68a52d965f796910e71a403a8
+  md5: b50a57ba89c32b62428b71a875291c9b
   depends:
-  - libzlib >=1.2.11,<1.3.0a0
-  arch: aarch64
-  platform: osx
+  - libzlib >=1.2.13,<2.0.0a0
   license: TCL
   license_family: BSD
-  size: 3382710
-  timestamp: 1645032642101
+  size: 3145523
+  timestamp: 1699202432999
 - kind: conda
   name: tk
   version: 8.6.13
@@ -15368,87 +15138,76 @@ packages:
   timestamp: 1644342331069
 - kind: conda
   name: tornado
-  version: 6.3.2
-  build: py310h2aa6e3c_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.2-py310h2aa6e3c_0.conda
-  sha256: fdefc999f2490eadaf44ac67d239b77d9b75a0b65d52d0e1e385d2642d859073
-  md5: bc542ba2516fe2d6bba7f34af040aec6
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 639535
-  timestamp: 1684150775828
-- kind: conda
-  name: tornado
-  version: 6.3.3
-  build: py310h2372a71_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py310h2372a71_1.conda
-  sha256: 209b6788b81739d3cdc2f04ad3f6f323efd85b1a30f2edce98ab76d98079fac8
-  md5: b23e0147fa5f7a9380e06334c7266ad5
-  depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
-  license: Apache-2.0
-  license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 641597
-  timestamp: 1695373710038
-- kind: conda
-  name: tornado
-  version: 6.3.3
-  build: py310h6729b98_1
+  version: 6.4.1
+  build: py311h3336109_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py310h6729b98_1.conda
-  sha256: 04262bf61f3d36b6607ae233abcbed7edaaf5d6ca4539cf9c1b322bb465809f2
-  md5: 87e772235e713ab972ecdad6c3066ff3
+  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.4.1-py311h3336109_1.conda
+  sha256: 2e54c0d478b8d0793f89b855749aa74acaa185d08d353d8e5aa95f8e89eb6123
+  md5: 5e051c4c2b80c381173b2c1719265617
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: Apache-2.0
   license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 642837
-  timestamp: 1695373842662
+  size: 856251
+  timestamp: 1724956238423
 - kind: conda
   name: tornado
-  version: 6.3.3
-  build: py310h8d17308_1
+  version: 6.4.1
+  build: py311h460d6c5_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.4.1-py311h460d6c5_1.conda
+  sha256: bba4940ef7522c3b4ae6eacd296e5e110de3659f7e4c3654d4fc2bb213c2091c
+  md5: 8ba6d177509dc4fac7af09749556eed0
+  depends:
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 859139
+  timestamp: 1724956356600
+- kind: conda
+  name: tornado
+  version: 6.4.1
+  build: py311h9ecbd09_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.4.1-py311h9ecbd09_1.conda
+  sha256: 21390d0c5708581959ebd89702433c1d06a56ddd834797a194b217f98e38df53
+  md5: 616fed0b6f5c925250be779b05d1d7f7
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: Apache
+  size: 856725
+  timestamp: 1724956239832
+- kind: conda
+  name: tornado
+  version: 6.4.1
+  build: py311he736701_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py310h8d17308_1.conda
-  sha256: 60b864e7cf17737055016e1754534316a0234d83f15eb454b983ee1b5151f982
-  md5: 0d14d73d94d679e2fa753ea8c7f75926
+  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.4.1-py311he736701_1.conda
+  sha256: 8e448bc682a6540a0aadc1f821c0d60f03d70272350caa2af519316fd1753f68
+  md5: f361535f90629358e3ea8f2161b239f3
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: Apache-2.0
   license_family: Apache
-  purls:
-  - pkg:pypi/tornado
-  size: 644644
-  timestamp: 1695373991492
+  size: 860730
+  timestamp: 1724956581349
 - kind: conda
   name: traitlets
   version: 5.9.0
@@ -15489,108 +15248,90 @@ packages:
   timestamp: 1698671281969
 - kind: conda
   name: trio
-  version: 0.21.0
-  build: py310hbe9552e_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/trio-0.21.0-py310hbe9552e_0.tar.bz2
-  sha256: 0026b0cdd67f3b0c083631611b8774de29f43bea8940c35eb480ea344bec673c
-  md5: 00569832aef5959a8f92672f9bac1938
-  depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  - sniffio *
-  - async_generator >=1.9
-  - sortedcontainers *
-  - attrs >=19.2.0
-  - idna *
-  - outcome *
-  arch: aarch64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/trio
-  size: 512151
-  timestamp: 1654688803862
-- kind: conda
-  name: trio
-  version: 0.22.2
-  build: py310h2ec42d9_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/trio-0.22.2-py310h2ec42d9_1.conda
-  sha256: 1c299d1e297950499264a077f09aff09dd20a40669e1ed00f313183706e18845
-  md5: 93ebd11e94e887a341b60b690d76cff0
-  depends:
-  - attrs >=20.1.0
-  - exceptiongroup >=1.0.0rc9
-  - idna *
-  - outcome *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - sniffio *
-  - sortedcontainers *
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/trio
-  size: 560032
-  timestamp: 1696378170787
-- kind: conda
-  name: trio
-  version: 0.22.2
-  build: py310h5588dad_1
+  version: 0.26.2
+  build: py311h1ea47a8_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/trio-0.22.2-py310h5588dad_1.conda
-  sha256: da8fdf527ba46125e65607a4ba4ad3bb4ee684ccc462d808a337116cecf41fb0
-  md5: 4dbd57c5a717be035fdb95124b997eb8
+  url: https://conda.anaconda.org/conda-forge/win-64/trio-0.26.2-py311h1ea47a8_1.conda
+  sha256: d1293dcbba7558b3e94ae9915a3250e6aa5f1e278ace399e46647547cf0044c6
+  md5: 2c3e9986c332ccb64ca04fb105d691cd
   depends:
-  - attrs >=20.1.0
+  - attrs >=23.2.0
   - cffi >=1.14
-  - exceptiongroup >=1.0.0rc9
-  - idna *
-  - outcome *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - sniffio *
-  - sortedcontainers *
-  arch: x86_64
-  platform: win
+  - idna
+  - outcome
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - sniffio >=1.3.0
+  - sortedcontainers
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/trio
-  size: 559697
-  timestamp: 1696378606601
+  size: 870092
+  timestamp: 1725302584736
 - kind: conda
   name: trio
-  version: 0.22.2
-  build: py310hff52083_1
+  version: 0.26.2
+  build: py311h267d04e_1
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/trio-0.22.2-py310hff52083_1.conda
-  sha256: 6127636adace6685f5f0984b0e685901486a06e40f11f0132b3b975dd7d9e675
-  md5: 8fd779e58f348366f73a705d25567c1b
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/trio-0.26.2-py311h267d04e_1.conda
+  sha256: ef679bebd42ad2fccb93d2b5958986846eeec630fb689a17dc6e7436e98f17a5
+  md5: e8f752e3c8ea00ed02cd58cd06cf3e3d
   depends:
-  - attrs >=20.1.0
-  - exceptiongroup >=1.0.0rc9
-  - idna *
-  - outcome *
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  - sniffio *
-  - sortedcontainers *
-  arch: x86_64
-  platform: linux
+  - attrs >=23.2.0
+  - idna
+  - outcome
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - sniffio >=1.3.0
+  - sortedcontainers
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/trio
-  size: 558160
-  timestamp: 1696378425392
+  size: 871724
+  timestamp: 1725302574116
+- kind: conda
+  name: trio
+  version: 0.26.2
+  build: py311h38be061_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/trio-0.26.2-py311h38be061_1.conda
+  sha256: 65411caae6fb10ca150da7e09baabe72edb63e0041804f86e9a4625d11c7f588
+  md5: c374e44a6971de0ff4b644dc819c36d2
+  depends:
+  - attrs >=23.2.0
+  - idna
+  - outcome
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - sniffio >=1.3.0
+  - sortedcontainers
+  license: MIT
+  license_family: MIT
+  size: 870691
+  timestamp: 1725302487838
+- kind: conda
+  name: trio
+  version: 0.26.2
+  build: py311h6eed73b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/trio-0.26.2-py311h6eed73b_1.conda
+  sha256: 3b615c3a85ddad02ca188da972658705ea2c95ebd9dea223bb9eb73078e36b93
+  md5: 44cdc8acb5615bb8431a6736abbe634b
+  depends:
+  - attrs >=23.2.0
+  - idna
+  - outcome
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - sniffio >=1.3.0
+  - sortedcontainers
+  license: MIT
+  license_family: MIT
+  size: 873676
+  timestamp: 1725302490751
 - kind: conda
   name: trio-websocket
   version: 0.10.3
@@ -15866,81 +15607,81 @@ packages:
 - kind: conda
   name: vl-convert-python
   version: 1.7.0
-  build: py310h493c2e1_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-1.7.0-py310h493c2e1_1.conda
-  sha256: ab58104d2748cf58e4932bcd9e0c848bf32eae7c845a71ef94273045ec9cb123
-  md5: d5fa3689362e4da635af4b350d73c6ff
-  depends:
-  - __osx >=11.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  constrains:
-  - __osx >=10.13
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 20936659
-  timestamp: 1728157975980
-- kind: conda
-  name: vl-convert-python
-  version: 1.7.0
-  build: py310h837254d_1
+  build: py311h3336109_1
   build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-1.7.0-py310h837254d_1.conda
-  sha256: 15f90c3399e5cc82f260892c286781b8352c3501a6ac2b6f58af528a14dee1a3
-  md5: af4b5450186271598fdd027049d19db8
+  url: https://conda.anaconda.org/conda-forge/osx-64/vl-convert-python-1.7.0-py311h3336109_1.conda
+  sha256: ea5924e0c8dada341998d71214fb67093032c00dbd1ee44fa52556e62ad9a6b4
+  md5: e6d252a565836ba52bab483451bd6a28
   depends:
   - __osx >=10.13
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   constrains:
   - __osx >=10.13
   license: BSD-3-Clause
   license_family: BSD
-  size: 21704033
-  timestamp: 1728158827629
+  size: 21693661
+  timestamp: 1728158930146
 - kind: conda
   name: vl-convert-python
   version: 1.7.0
-  build: py310ha75aee5_1
+  build: py311h460d6c5_1
   build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-1.7.0-py310ha75aee5_1.conda
-  sha256: f12e36c2787ab902f40268a17b35846bf842105329083de78ec78bb19d8c7621
-  md5: 120c480ae62b2f896b87195197f47d48
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/vl-convert-python-1.7.0-py311h460d6c5_1.conda
+  sha256: 7d514d4d9f149d580ee4a1c8de80081bd44cb761c173886133df2ee475f07f02
+  md5: 7995607a2bfa8fc95fc5b4736dbabcac
   depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   constrains:
-  - __glibc >=2.17
+  - __osx >=10.13
   license: BSD-3-Clause
   license_family: BSD
-  size: 23182077
-  timestamp: 1728158798404
+  size: 20935582
+  timestamp: 1728157953084
 - kind: conda
   name: vl-convert-python
   version: 1.7.0
-  build: py310hdfd1e6a_1
+  build: py311h7b6d46a_1
   build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/vl-convert-python-1.7.0-py310hdfd1e6a_1.conda
-  sha256: 14b8983c1b0d69a441ce1546c9d17674e7ef9471adcd4cc143f468fc6eba7802
-  md5: e38de8dc3950940b624ba1b3117801ab
+  url: https://conda.anaconda.org/conda-forge/win-64/vl-convert-python-1.7.0-py311h7b6d46a_1.conda
+  sha256: 22c8cffe7d652b6345e08355c6c33d85b2afba15e7e0b3358ab8a8024389562f
+  md5: bf7221ab248d6f405b671357f8159adb
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.40.33810
   license: BSD-3-Clause
   license_family: BSD
-  size: 22858430
-  timestamp: 1728160711471
+  size: 22858306
+  timestamp: 1728160308769
+- kind: conda
+  name: vl-convert-python
+  version: 1.7.0
+  build: py311h9ecbd09_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/vl-convert-python-1.7.0-py311h9ecbd09_1.conda
+  sha256: f1a665c7f1a7d52c264ebd00d08dc22846dc94b4a9a6a64b38d027335345f102
+  md5: 517fd131e76b129711800d9234ac3a22
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 23180005
+  timestamp: 1728158867244
 - kind: conda
   name: voila
   version: 0.5.0
@@ -15987,81 +15728,86 @@ packages:
   timestamp: 1717709043353
 - kind: conda
   name: watchfiles
-  version: 0.21.0
-  build: py310h0e083fb_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.21.0-py310h0e083fb_0.conda
-  sha256: 2a95d12f09a39d3912b6af972fbe4f65eee0d4266d9d021eec66b77761e35503
-  md5: e17c7a13e76bd8d81ce7a94eb6ea1491
+  version: 0.24.0
+  build: py311h481aa64_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.24.0-py311h481aa64_1.conda
+  sha256: 30e96f05cd579b3a4f86378e2eddfc0caf62edd9b4938765d5dbfbbc262bf65f
+  md5: b3c447b6418c567f3726ade082f54f42
   depends:
+  - __osx >=11.0
   - anyio >=3.0.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=11.0
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/watchfiles
-  size: 363020
-  timestamp: 1701078481116
+  size: 345348
+  timestamp: 1725347436809
 - kind: conda
   name: watchfiles
-  version: 0.21.0
-  build: py310h87d50f1_0
+  version: 0.24.0
+  build: py311h533ab2d_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.21.0-py310h87d50f1_0.conda
-  sha256: 8bce1877c4dcdc498d36d393bc70cbec3a2e52c6a8cd84cbab39c3ac1e27c5f9
-  md5: 46edf6e3ad11949a3059ae65f064417f
+  url: https://conda.anaconda.org/conda-forge/win-64/watchfiles-0.24.0-py311h533ab2d_1.conda
+  sha256: 3c8654bd8badeb92d5ec01c07da5a72b63745e1b833b7ea55ec4a356e0905570
+  md5: 07f16628bc87b0f4dd7d91677a18a0d5
   depends:
   - anyio >=3.0.0
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/watchfiles
-  size: 281299
-  timestamp: 1701078950174
+  size: 295158
+  timestamp: 1725347753797
 - kind: conda
   name: watchfiles
-  version: 0.21.0
-  build: py310hcb5633a_0
+  version: 0.24.0
+  build: py311h95688db_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/watchfiles-0.24.0-py311h95688db_1.conda
+  sha256: 4e797fc4897bf4c08ee9b5dbb4d34227baa1364baafcd87374d9bb9beabf0d57
+  md5: e2a4ae720df79f3ec83f6a1e4f9df6c5
+  depends:
+  - __osx >=10.13
+  - anyio >=3.0.0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  size: 351308
+  timestamp: 1725347133092
+- kind: conda
+  name: watchfiles
+  version: 0.24.0
+  build: py311h9e33e62_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.21.0-py310hcb5633a_0.conda
-  sha256: 72cfe33e98fbf3190e6ac89e457a389c86eb741f84fafa7c74ec2b55658f46be
-  md5: 0433430adbafa9f3a37f9f8d82d45df8
+  url: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-0.24.0-py311h9e33e62_1.conda
+  sha256: ad31508aba4c726e95949a66a65605146dbc8aaccce3091617162da87f857cdb
+  md5: 31c07a7fc0a2bf4a34808a686bf3de19
   depends:
+  - __glibc >=2.17,<3.0.a0
   - anyio >=3.0.0
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
   license: MIT
   license_family: MIT
-  purls:
-  - pkg:pypi/watchfiles
-  size: 1090822
-  timestamp: 1701078030960
-- kind: conda
-  name: watchfiles
-  version: 0.21.0
-  build: py310hd442715_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/watchfiles-0.21.0-py310hd442715_0.conda
-  sha256: 080a50156598a840a7ec90549938f7146df34f2c21cae0de25b03e1b2afaa83b
-  md5: b5e8c0fb13fe4261337deee35320e912
-  depends:
-  - anyio >=3.0.0
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/watchfiles
-  size: 359037
-  timestamp: 1701078432934
+  size: 395778
+  timestamp: 1725347224229
 - kind: conda
   name: wcwidth
   version: 0.2.6
@@ -16197,84 +15943,72 @@ packages:
   timestamp: 1696770282111
 - kind: conda
   name: websockets
-  version: 11.0.3
-  build: py310h2aa6e3c_0
+  version: '13.1'
+  build: py311h3336109_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/websockets-13.1-py311h3336109_0.conda
+  sha256: 4a3c045c4c7b94e81b21a79584654f9b2a42c195310b08e51ab9daaca4f13a10
+  md5: e1b5d70a1b2822cd1816d09572546e33
+  depends:
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 236444
+  timestamp: 1727013477338
+- kind: conda
+  name: websockets
+  version: '13.1'
+  build: py311h460d6c5_0
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-11.0.3-py310h2aa6e3c_0.conda
-  sha256: 805b2e1cba560a232ce39752928f086e18cae857770f915e3e925a7437b53715
-  md5: 6901a3ba39a88a922479c0e0f43f9701
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/websockets-13.1-py311h460d6c5_0.conda
+  sha256: ba7da465a80d57d4d0f0d1402747156564fc6e82dfe2a229bef37baa21bd3b24
+  md5: 39650b49d5f4236fdd140a81a3ea8a0a
   depends:
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  arch: aarch64
-  platform: osx
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/websockets
-  size: 160055
-  timestamp: 1683550836283
+  size: 237533
+  timestamp: 1727013542785
 - kind: conda
   name: websockets
-  version: '12.0'
-  build: py310h2372a71_0
+  version: '13.1'
+  build: py311h9ecbd09_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/websockets-12.0-py310h2372a71_0.conda
-  sha256: 9d99b58e2eb349124198a41a254bedd3543f43522f51bf086bfe3e87a2a6647b
-  md5: a2d6cc6969e6ad501584d0d6c6762fab
+  url: https://conda.anaconda.org/conda-forge/linux-64/websockets-13.1-py311h9ecbd09_0.conda
+  sha256: 531d6bf60ef0238a9143b28c732c42dc9787caac8204803c834423f5e483b9f5
+  md5: 764e663b48ba5560f3c633384a35ea4d
   depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: linux
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/websockets
-  size: 158640
-  timestamp: 1697914848325
+  size: 236892
+  timestamp: 1727013475465
 - kind: conda
   name: websockets
-  version: '12.0'
-  build: py310h8d17308_0
+  version: '13.1'
+  build: py311he736701_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/websockets-12.0-py310h8d17308_0.conda
-  sha256: 289cd2c31b120e7a92234dc8b974afc9bfb7defc3bb7fdeaa6cef4bb049fc678
-  md5: deeaffde8a9eb39babee835eff6c32b8
+  url: https://conda.anaconda.org/conda-forge/win-64/websockets-13.1-py311he736701_0.conda
+  sha256: fa900853b0811ec4cc5ed911fcb40c9ee4aac65279708a480652c704c9e33c0d
+  md5: ec8ca6cc770c527787e4b285e194c72e
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
   license: BSD-3-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/websockets
-  size: 161802
-  timestamp: 1697915120385
-- kind: conda
-  name: websockets
-  version: '12.0'
-  build: py310hb372a2b_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/websockets-12.0-py310hb372a2b_0.conda
-  sha256: 7ca257b4015a844e1243e3cf2622577093f1e2fa897ba1cef2b9a7e64ebe88b6
-  md5: 910b943243f502a7b3d77cbce4b489a6
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  arch: x86_64
-  platform: osx
-  license: BSD-3-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/websockets
-  size: 159383
-  timestamp: 1697914931990
+  size: 240074
+  timestamp: 1727013802558
 - kind: conda
   name: wheel
   version: 0.41.1
@@ -16388,76 +16122,75 @@ packages:
 - kind: conda
   name: wrapt
   version: 1.16.0
-  build: py310h2372a71_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py310h2372a71_0.conda
-  sha256: 2adc15cd1e66845c1ab498735e2f828003e2d5fe20eed1febddb712f58793c31
-  md5: d9dc9c45bdc2b38403e6b388581e92f0
+  build: py311h3336109_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py311h3336109_1.conda
+  sha256: b27b52c77fc29c42923a82480f3cc19dffc95139ce418f47a9463c7b23f46c3b
+  md5: acb599cfd03298bd560740fee0d1609e
   depends:
-  - libgcc-ng >=12
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=10.13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: BSD-2-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/wrapt
-  size: 55415
-  timestamp: 1699533000763
+  size: 59864
+  timestamp: 1724958037718
 - kind: conda
   name: wrapt
   version: 1.16.0
-  build: py310h8d17308_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py310h8d17308_0.conda
-  sha256: 2de005b8199cf5cc19a4547b9aa3ebd7b756c7e8c898dfea9d96283dc2b6745d
-  md5: 80326d84a304f866ddc5c49caf7ab3ae
+  build: py311h460d6c5_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py311h460d6c5_1.conda
+  sha256: 5667c48efd5e19e2754660293f00899dfd92b9228e19e7140cc46efcd0af8784
+  md5: ff3535f6abd3ec8e0589ead32a8c86fc
   depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
+  - __osx >=11.0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 60435
+  timestamp: 1724958101626
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py311h9ecbd09_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.16.0-py311h9ecbd09_1.conda
+  sha256: 426ee582e676e15a85846743060710fc4dbe4dd562b21d80d751694ffa263e41
+  md5: 810ae646bcc50a017380336d874e4014
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 63403
+  timestamp: 1724958070675
+- kind: conda
+  name: wrapt
+  version: 1.16.0
+  build: py311he736701_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/wrapt-1.16.0-py311he736701_1.conda
+  sha256: b5d845acf27a2c4f236c905ac8366938a03ca292e58567236432c99462db9371
+  md5: 8d03f171fdeadfee26e33374274c702f
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  purls:
-  - pkg:pypi/wrapt
-  size: 54038
-  timestamp: 1699533408150
-- kind: conda
-  name: wrapt
-  version: 1.16.0
-  build: py310hb372a2b_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/wrapt-1.16.0-py310hb372a2b_0.conda
-  sha256: 27c9c05285f7405b1084681822686c3ef9e3ae45dff544a83636c1b669efb228
-  md5: 7efc437e30061a48eeb60e4ce515ad77
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python_abi 3.10.* *_cp310
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/wrapt
-  size: 51650
-  timestamp: 1699533356448
-- kind: conda
-  name: wrapt
-  version: 1.16.0
-  build: py310hd125d64_0
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/wrapt-1.16.0-py310hd125d64_0.conda
-  sha256: 4509076b945781cd445b5418502e8c8e4befee3349364e613e0c60ab3d8c9e99
-  md5: d1cdb4037779fcef0c824bc790c5ee57
-  depends:
-  - python >=3.10,<3.11.0a0
-  - python >=3.10,<3.11.0a0 *_cpython
-  - python_abi 3.10.* *_cp310
-  license: BSD-2-Clause
-  license_family: BSD
-  purls:
-  - pkg:pypi/wrapt
-  size: 52698
-  timestamp: 1699533350125
+  size: 62417
+  timestamp: 1724958420987
 - kind: conda
   name: wsproto
   version: 1.2.0
@@ -17053,24 +16786,6 @@ packages:
   timestamp: 1688182120492
 - kind: conda
   name: zeromq
-  version: 4.3.4
-  build: hbdafb3b_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.4-hbdafb3b_1.tar.bz2
-  sha256: b65624f1e22f095223462807c417001b18ec17ef33a3c7065a19429f4cd42193
-  md5: 49132c08da6545dc68351ff8b659ac8e
-  depends:
-  - libcxx >=11.1.0
-  - libsodium >=1.0.18,<1.0.19.0a0
-  arch: aarch64
-  platform: osx
-  license: LGPL-3.0-or-later
-  license_family: LGPL
-  size: 318091
-  timestamp: 1629967291905
-- kind: conda
-  name: zeromq
   version: 4.3.5
   build: h59595ed_0
   subdir: linux-64
@@ -17090,25 +16805,6 @@ packages:
 - kind: conda
   name: zeromq
   version: 4.3.5
-  build: h63175ca_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
-  sha256: f8377793c36e19da17bbb8cf517f1a969b89e1cc7cb9622dc6d60c3d1383c919
-  md5: e954e1881091405f36416f772292b396
-  depends:
-  - libsodium >=1.0.18,<1.0.19.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: MPL-2.0
-  license_family: MOZILLA
-  size: 4210250
-  timestamp: 1697057168534
-- kind: conda
-  name: zeromq
-  version: 4.3.5
   build: h93d8f39_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
@@ -17124,6 +16820,43 @@ packages:
   license_family: MOZILLA
   size: 294253
   timestamp: 1697057208271
+- kind: conda
+  name: zeromq
+  version: 4.3.5
+  build: ha9f60a1_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
+  sha256: c37130692742cc43eedf4e23270c7d1634235acff50760025e9583f8b46b64e6
+  md5: 33a78bbc44d6550c361abb058a0556e2
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libsodium >=1.0.20,<1.0.21.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 2701749
+  timestamp: 1728364260886
+- kind: conda
+  name: zeromq
+  version: 4.3.5
+  build: hcc0f68c_4
+  build_number: 4
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-hcc0f68c_4.conda
+  sha256: c22520d6d66a80f17c5f2b3719ad4a6ee809b210b8ac87d6f05ab98b94b3abda
+  md5: 39fb79e7a7a880a03f82c1f2eb7f7c73
+  depends:
+  - __osx >=11.0
+  - krb5 >=1.21.2,<1.22.0a0
+  - libcxx >=16
+  - libsodium >=1.0.18,<1.0.19.0a0
+  license: MPL-2.0
+  license_family: MOZILLA
+  size: 298555
+  timestamp: 1715607628741
 - kind: conda
   name: zfp
   version: 1.0.0
@@ -17146,25 +16879,6 @@ packages:
 - kind: conda
   name: zfp
   version: 1.0.0
-  build: h63175ca_4
-  build_number: 4
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zfp-1.0.0-h63175ca_4.conda
-  sha256: eb9924342d3d92f52e96ab0dbdf35eba23051cd06e19b5f0d9bbd68e4964bbbf
-  md5: 6815aea2add93c4c2b084c5456e7e5e9
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 237116
-  timestamp: 1696181277794
-- kind: conda
-  name: zfp
-  version: 1.0.0
   build: hb6e4faa_3
   build_number: 3
   subdir: osx-arm64
@@ -17182,22 +16896,38 @@ packages:
   timestamp: 1666811112845
 - kind: conda
   name: zfp
-  version: 1.0.0
-  build: hf3d7188_4
-  build_number: 4
+  version: 1.0.1
+  build: h469392a_2
+  build_number: 2
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zfp-1.0.0-hf3d7188_4.conda
-  sha256: 04b06696df37ce481d0b217fb45f07ceb3da28946c1a6524366298bc40aeb53e
-  md5: 1e9e26329672eefd5a977bb093d09fad
+  url: https://conda.anaconda.org/conda-forge/osx-64/zfp-1.0.1-h469392a_2.conda
+  sha256: aa7cd8353640b4187dcc1e322b79f6b5c8450a036761208fb68a44f592337b6b
+  md5: 2c03b469587f7a2222e4879ccca3dcb4
   depends:
-  - libcxx >=15.0.7
-  - llvm-openmp >=15.0.7
-  arch: x86_64
-  platform: osx
+  - __osx >=10.13
+  - libcxx >=17
+  - llvm-openmp >=17.0.6
   license: BSD-3-Clause
   license_family: BSD
-  size: 223526
-  timestamp: 1696181020186
+  size: 210590
+  timestamp: 1726925557854
+- kind: conda
+  name: zfp
+  version: 1.0.1
+  build: he0c23c2_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zfp-1.0.1-he0c23c2_2.conda
+  sha256: 8fa0491c8ce89b3a37dd3f84b7a670e260e8f8eae3c70a861f80e85e35456b09
+  md5: 66b2e227c0d5c78df52e62390b71032d
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 235412
+  timestamp: 1726926095834
 - kind: conda
   name: zipp
   version: 3.16.2
@@ -17368,25 +17098,6 @@ packages:
 - kind: conda
   name: zstd
   version: 1.5.5
-  build: h12be248_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.5-h12be248_0.conda
-  sha256: d540dd56c5ec772b60e4ce7d45f67f01c6614942225885911964ea1e70bb99e3
-  md5: 792bb5da68bf0a6cac6a6072ecb8dbeb
-  depends:
-  - libzlib >=1.2.13,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  arch: x86_64
-  platform: win
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 343428
-  timestamp: 1693151615801
-- kind: conda
-  name: zstd
-  version: 1.5.5
   build: h829000d_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.5-h829000d_0.conda
@@ -17400,6 +17111,23 @@ packages:
   license_family: BSD
   size: 499383
   timestamp: 1693151312586
+- kind: conda
+  name: zstd
+  version: 1.5.6
+  build: h0ea2cb4_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
+  sha256: 768e30dc513568491818fb068ee867c57c514b553915536da09e5d10b4ebf3c3
+  md5: 9a17230f95733c04dc40a2b1e5491d74
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 349143
+  timestamp: 1714723445995
 - kind: conda
   name: zstd
   version: 1.5.6

--- a/pixi.toml
+++ b/pixi.toml
@@ -103,7 +103,7 @@ cargo publish -p vegafusion-server
 
 # Build dependencies are those required to build and test all packages
 [build-dependencies]
-python = "3.10.*"
+python = "3.11.*"
 nodejs = "20.5.1.*"
 maturin = "1.2.3.*"
 yarn = "3.6.1.*"
@@ -117,7 +117,6 @@ click = "8.1.6.*"
 python-duckdb = "1.0"
 pip = "23.2.1.*"
 voila = "0.5.0.*"
-polars = "0.18.15.*"
 tenacity = "8.2.3.*"
 pytest-cov = "4.1.0.*"
 flaky = "3.7.0.*"

--- a/vegafusion-common/Cargo.toml
+++ b/vegafusion-common/Cargo.toml
@@ -6,13 +6,16 @@ description = "Common components required by multiple VegaFusion crates"
 license = "BSD-3-Clause"
 
 [features]
-pyarrow = ["pyo3", "arrow/pyarrow"]
+pyarrow = ["pyo3", "arrow/pyarrow", "pyo3-arrow"]
 json = ["serde_json/preserve_order", "arrow/json", "chrono"]
 prettyprint = ["arrow/prettyprint"]
 proto = ["datafusion-proto", "datafusion-proto-common"]
 
 [dependencies]
 thiserror = "^1.0.29"
+
+[dependencies.deterministic-hash]
+workspace = true
 
 [dependencies.chrono]
 workspace = true
@@ -49,6 +52,10 @@ workspace = true
 optional = true
 
 [dependencies.pyo3]
+workspace = true
+optional = true
+
+[dependencies.pyo3-arrow]
 workspace = true
 optional = true
 

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -17,11 +17,13 @@ lazy_static = "^1.4.0"
 regex = "^1.5.5"
 ordered-float = "3.6.0"
 petgraph = "0.6.0"
-deterministic-hash = "1.0.1"
 chrono = "0.4.23"
 num-complex = "0.4.2"
 rand = "0.8.5"
 json-patch = "1.0.0"
+
+[dependencies.deterministic-hash]
+ workspace = true
 
 [dependencies.prost]
 workspace = true

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -71,4 +71,4 @@ features = ["macros", "rt-multi-thread"]
 
 [dependencies.pyo3]
 workspace = true
-features = ["extension-module", "abi3-py38"]
+features = ["extension-module", "abi3-py311"]

--- a/vegafusion-python/src/lib.rs
+++ b/vegafusion-python/src/lib.rs
@@ -181,6 +181,10 @@ impl PyVegaFusionRuntime {
                                     .scan_py_datasource(inline_dataset.to_object(py)),
                             )?;
                             VegaFusionDataset::DataFrame(df)
+                        } else if inline_dataset.hasattr("__arrow_c_stream__")? {
+                            // Import via Arrow PyCapsule Interface
+                            let table = VegaFusionTable::from_pyarrow(inline_dataset)?;
+                            VegaFusionDataset::from_table(table)?
                         } else {
                             // Assume PyArrow Table
                             // We convert to ipc bytes for two reasons:

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -328,6 +328,9 @@ class VegaFusionRuntime:
                         pass
 
                 imported_inline_datasets[name] = PandasDatasource(value)
+            elif hasattr(value, "__arrow_c_stream__"):
+                # Arrow PyCapsule interface
+                imported_inline_datasets[name] = value
             elif hasattr(value, "__dataframe__"):
                 # Let polars convert to pyarrow since it has broader support than the
                 # raw dataframe interchange protocol, and "This operation is mostly

--- a/vegafusion-runtime/src/data/dataset.rs
+++ b/vegafusion-runtime/src/data/dataset.rs
@@ -19,6 +19,11 @@ impl VegaFusionDataset {
         }
     }
 
+    pub fn from_table(table: VegaFusionTable) -> Result<Self> {
+        let hash = table.get_hash();
+        Ok(Self::Table { table, hash })
+    }
+
     pub fn from_table_ipc_bytes(ipc_bytes: &[u8]) -> Result<Self> {
         // Hash ipc bytes
         let mut hasher = deterministic_hash::DeterministicHasher::new(DefaultHasher::new());


### PR DESCRIPTION
Supersedes #501 now that everything needed has been updated.

This bumps the minimum Python version to 3.11 due to [what I'm seeing](https://github.com/vega/vegafusion/pull/501#issuecomment-2408554180) in pyo3-arrow 0.5.0. Hopefully this can be lowered in the future, but I don't want to block continued development on v2 on this.