### PR TITLE
Trim Python dependencies

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -297,7 +297,7 @@ jobs:
           python -m pip install vegafusion-*manylinux_2_17_x86_64*.whl
 
           # Optional dependencies
-          python -m pip install polars-lts-cpu "duckdb>=1.0" "vl-convert-python>=1.0.1rc1" scikit-image "pandas>=2.2" jupytext voila anywidget ipywidgets chromedriver-binary-auto
+          python -m pip install pyarrow pandas polars-lts-cpu "duckdb>=1.0" "vl-convert-python>=1.0.1rc1" scikit-image "pandas>=2.2" jupytext voila anywidget ipywidgets chromedriver-binary-auto
 
           # Test dependencies
           python -m pip install pytest altair vega-datasets scikit-image jupytext voila ipykernel anywidget ipywidgets selenium flaky tenacity chromedriver-binary-auto 
@@ -339,7 +339,7 @@ jobs:
           python -m pip install vegafusion-*macosx_11_*_arm64.whl
 
           # Optional dependencies
-          python -m pip install polars "duckdb>=1.0" vl-convert-python "pandas>=2.2"
+          python -m pip install pyarrow pandas polars "duckdb>=1.0" vl-convert-python "pandas>=2.2"
 
           # Test dependencies
           python -m pip install pytest altair vega-datasets scikit-image
@@ -377,7 +377,7 @@ jobs:
           python -m pip install $vegafusion
 
           # Optional dependencies
-          python -m pip install "numpy<2" polars[timezone] "duckdb>=1.0" vl-convert-python 
+          python -m pip install pyarrow pandas "numpy<2" polars[timezone] "duckdb>=1.0" vl-convert-python 
           
           # Test dependencies
           python -m pip install pytest altair vega-datasets scikit-image

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2293,7 +2293,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2793,6 +2793,15 @@ name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "ntapi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "num"
@@ -4337,6 +4346,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ae3f4f7d64646c46c4cae4e3f01d1c5d255c7406fdd7c7f999a94e488791"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4901,6 +4924,7 @@ dependencies = [
  "datafusion-proto",
  "deterministic-hash",
  "env_logger",
+ "lazy_static",
  "log",
  "prost 0.12.6",
  "pyo3",
@@ -4908,6 +4932,7 @@ dependencies = [
  "pythonize",
  "serde",
  "serde_json",
+ "sysinfo",
  "tokio",
  "uuid",
  "vegafusion-common",
@@ -5352,6 +5377,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5361,13 +5396,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
  "windows-targets 0.52.6",
 ]
 
@@ -5386,7 +5464,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
 dependencies = [
- "windows-result",
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ pyo3-arrow = { version = "0.5.1", default-features = false }
 prost = { version = "0.12.3" }
 prost-types = { version = "0.12.3" }
 object_store = { version = "0.11.0" }
+lazy_static = { version = "1.5" }
 
 [workspace.dependencies.datafusion]
 version = "42.0.0"

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -13,7 +13,6 @@ py = ["pyo3", "vegafusion-common/py"]
 thiserror = "^1.0.29"
 bytes = "1.1.0"
 itertools = "0.10.3"
-lazy_static = "^1.4.0"
 regex = "^1.5.5"
 ordered-float = "3.6.0"
 petgraph = "0.6.0"
@@ -21,6 +20,9 @@ chrono = "0.4.23"
 num-complex = "0.4.2"
 rand = "0.8.5"
 json-patch = "1.0.0"
+
+[dependencies.lazy_static]
+workspace = true
 
 [dependencies.deterministic-hash]
  workspace = true

--- a/vegafusion-datafusion-udfs/Cargo.toml
+++ b/vegafusion-datafusion-udfs/Cargo.toml
@@ -7,8 +7,10 @@ description = "Custom DataFusion UDFs used by VegaFusion"
 
 [dependencies]
 ordered-float = "3.6.0"
-lazy_static = "^1.4.0"
 regex = "^1.5.5"
+
+[dependencies.lazy_static]
+workspace = true
 
 [dependencies.chrono]
 workspace = true

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -17,6 +17,10 @@ log = "0.4.17"
 env_logger = "0.10.0"
 async-trait = "0.1.73"
 uuid = "1.3.0"
+sysinfo = "0.32.0"
+
+[dependencies.lazy_static]
+workspace = true
 
 [dependencies.pythonize]
 workspace = true

--- a/vegafusion-python/checks/check_lazy_imports.py
+++ b/vegafusion-python/checks/check_lazy_imports.py
@@ -1,5 +1,45 @@
 import sys
-import vegafusion as vf
+from pathlib import Path
 
-for mod in ["polars", "pandas", "pyarrow", "duckdb", "altair"]:
-    assert mod not in sys.modules, f"{mod} module should be imported lazily"
+root = Path(__file__).parent.parent.parent
+
+
+if __name__ == "__main__":
+    # Make sure the prominant dependencies are not loaded on import
+    import vegafusion as vf  # noqa: F401
+
+    for mod in ["polars", "pandas", "pyarrow", "duckdb", "altair"]:
+        assert mod not in sys.modules, f"{mod} module should be imported lazily"
+
+    # Create an altair chart with polars and check that pandas and pyarrow are
+    # not loaded
+    import altair as alt
+    import polars as pl
+
+    cars = pl.read_json(
+        root / "vegafusion-runtime/tests/util/vegajs_runtime/data/cars.json"
+    )
+
+    # Build a histogram of horsepower
+    chart = (
+        alt.Chart(cars)
+        .mark_bar()
+        .encode(
+            alt.X("Horsepower:Q", bin=True),
+            y="count()",
+        )
+    )
+
+    # Check that the transformed data is a polars DataFrame
+    transformed = chart.transformed_data()
+    assert isinstance(transformed, pl.DataFrame)
+    assert len(transformed["bin_maxbins_10_Horsepower"]) == 10
+
+    # Do a full pre-transform of the spec
+    transformed_spec = chart.to_dict(format="vega")
+    assert isinstance(transformed_spec, dict)
+    assert "data" in transformed_spec
+
+    # Make sure that pandas and pyarrow were not loaded when using polars
+    for mod in ["pandas", "pyarrow", "duckdb"]:
+        assert mod not in sys.modules, f"{mod} module should be imported lazily"

--- a/vegafusion-python/pyproject.toml
+++ b/vegafusion-python/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Topic :: Scientific/Engineering :: Visualization",
 ]
-dependencies = ["pyarrow>=16", "arro3-core", "pandas", "psutil", "protobuf", "packaging", "narwhals>=1.9"]
+dependencies = ["arro3-core", "packaging", "narwhals>=1.9"]
 [[project.authors]]
 name = "VegaFusion Contributors"
 

--- a/vegafusion-python/ruff.toml
+++ b/vegafusion-python/ruff.toml
@@ -1,7 +1,7 @@
 line-length = 88
 indent-width = 4
-include = ["vegafusion/**/*.py", "tests/**/*.py"]
-exclude = ["vegafusion/datasource/_dfi_types.py", "tests/altair_mocks/**/*.py"]
+include = ["vegafusion/**/*.py", "tests/**/*.py", "checks/**/*.py"]
+exclude = ["tests/altair_mocks/**/*.py"]
 target-version = "py39"
 
 [lint]

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -6,9 +6,9 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union, cast
 
 import narwhals as nw
-import psutil
 from arro3.core import Table
 
+from vegafusion._vegafusion import get_cpu_count, get_virtual_memory
 from vegafusion.transformer import DataFrameLike
 from vegafusion.utils import get_column_usage
 
@@ -1072,4 +1072,4 @@ def get_inline_column_usage(
     }
 
 
-runtime = VegaFusionRuntime(64, psutil.virtual_memory().total // 2, psutil.cpu_count())
+runtime = VegaFusionRuntime(64, get_virtual_memory() // 2, get_cpu_count())

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -335,8 +335,7 @@ class VegaFusionRuntime:
             columns = inline_dataset_usage.get(name)
             if isinstance(value, SqlDataset):
                 imported_inline_datasets[name] = value
-            # elif pd is not None and isinstance(value, pd.DataFrame):
-            elif isinstance(value, pd.DataFrame):
+            elif pd is not None and isinstance(value, pd.DataFrame):
                 # rename to help mypy
                 inner_value: pd.DataFrame = value
                 del value

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -15,7 +15,6 @@ protobuf-src = ["vegafusion-core/protobuf-src"]
 
 [dependencies]
 regex = "^1.5.5"
-lazy_static = "^1.4.0"
 serde_json = "1.0.91"
 num-traits = "0.2.15"
 itertools = "0.11.0"
@@ -44,6 +43,9 @@ base64 = "0.21.0"
 pixelmatch = "0.1.0"
 rgb = "0.8.32"
 lodepng = "3.6.1"
+
+[dependencies.lazy_static]
+workspace = true
 
 [dependencies.object_store]
 workspace = true

--- a/vegafusion-sql/Cargo.toml
+++ b/vegafusion-sql/Cargo.toml
@@ -28,8 +28,10 @@ uuid = "1.4.1"
 [dev-dependencies]
 rstest = "0.18.2"
 rstest_reuse = "0.6.0"
-lazy_static = "^1.4.0"
 toml = "0.7.2"
+
+[dev-dependencies.lazy_static]
+workspace = true
 
 [dependencies.chrono]
 workspace = true


### PR DESCRIPTION
This PR drops the hard dependencies on pandas and pyarrow, and adds a test that using Altair+VegaFusion with polars does not trigger an import of pandas or pyarrow.

I also removed the psutil dependency by implementing the system lookup info in rust using the [`sysinfo`](https://docs.rs/sysinfo/latest/sysinfo/) crate.  Now the `vegafusion` Python library has only three dependencies.

 - `narwhals` for abstracting over DataFrames (185.3 kB wheel, pure Python)
 - `arro3-core` for basic Arrow processing in Python (2-4MB, compiled with wheels available for more platforms that VegaFusion currently builds for. In contrast, the `pyarrow` wheel sizes vary across platforms from 25MB to 40MB).
 - `packaging` for the `Version` object (54.0 kB wheel, pure Python)

`narwhals` and `packaging` are also dependencies of Altair, so VegaFusion will now add only itself and `arro3-core` as deps.