### PR TITLE
Use ChartState in vegafusion-wasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ __pycache__
 /minio_data/
 
 /.ipynb_checkpoints/
+
+# Examples
+examples/**/node_modules

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5149,8 +5149,10 @@ dependencies = [
 name = "vegafusion-wasm"
 version = "1.6.9"
 dependencies = [
+ "async-trait",
  "chrono",
  "console_error_panic_hook",
+ "futures",
  "getrandom",
  "indexmap 1.9.3",
  "js-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4968,8 +4968,10 @@ dependencies = [
 name = "vegafusion-core"
 version = "1.6.9"
 dependencies = [
+ "async-trait",
  "bytes",
  "chrono",
+ "chrono-tz 0.9.0",
  "datafusion-common",
  "deterministic-hash",
  "itertools 0.10.5",
@@ -4992,6 +4994,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "vegafusion-common",
+ "vegafusion-dataframe",
 ]
 
 [[package]]
@@ -5020,6 +5023,7 @@ dependencies = [
  "ordered-float 3.9.2",
  "regex",
  "vegafusion-common",
+ "vegafusion-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ prost = { version = "0.12.3" }
 prost-types = { version = "0.12.3" }
 object_store = { version = "0.11.0" }
 lazy_static = { version = "1.5" }
+async-trait = "0.1.73"
 
 [workspace.dependencies.datafusion]
 version = "42.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ prost-types = { version = "0.12.3" }
 object_store = { version = "0.11.0" }
 lazy_static = { version = "1.5" }
 async-trait = "0.1.73"
+futures = "0.3.21"
 
 [workspace.dependencies.datafusion]
 version = "42.0.0"

--- a/examples/editor-demo/README.md
+++ b/examples/editor-demo/README.md
@@ -1,0 +1,15 @@
+### Chart Editor
+
+This example is a simple chart editor that relies on the vegafusion-wasm package, and connects to the 
+vegafusion server over gRPC-Web 
+
+Launch gRPC-Web server with:
+```
+./vegafusion-server --port 50051 --web
+```
+
+Build and launch editor with
+```
+npm install
+npm run start
+```

--- a/examples/editor-demo/package-lock.json
+++ b/examples/editor-demo/package-lock.json
@@ -1,0 +1,7860 @@
+{
+  "name": "create-wasm-app",
+  "version": "1.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "create-wasm-app",
+      "version": "1.1.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bootstrap": "^5.1.3",
+        "follow-redirects": ">=1.14.7",
+        "grpc-web": "^1.3.1",
+        "lodash": "^4.17.21",
+        "monaco-editor-webpack-plugin": "^6.0.0",
+        "node-forge": ">=1.0.0",
+        "vega": "^5.24.0",
+        "vega-lite": "^5.6.1",
+        "vega-tooltip": "^0.27.0",
+        "vegafusion-embed": "../../javascript/vegafusion-embed/lib",
+        "vegafusion-wasm": "../../vegafusion-wasm/pkg"
+      },
+      "bin": {
+        "create-wasm-app": ".bin/create-wasm-app.js"
+      },
+      "devDependencies": {
+        "copy-webpack-plugin": "^10.0.0",
+        "css-loader": "^6.5.1",
+        "file-loader": "^6.2.0",
+        "postcss-loader": "^6.2.0",
+        "sass-loader": "^12.3.0",
+        "style-loader": "^3.3.1",
+        "svg-inline-loader": "^0.8.2",
+        "webpack": "^5.64.2",
+        "webpack-cli": "^4.9.1",
+        "webpack-dev-server": "^4.5.0"
+      }
+    },
+    "../../../javascript/vegafusion-embed/lib": {
+      "extraneous": true
+    },
+    "../../../vegafusion-wasm/pkg": {
+      "extraneous": true
+    },
+    "../../javascript/vegafusion-embed/lib": {},
+    "../../vegafusion-wasm/pkg": {
+      "name": "vegafusion-wasm",
+      "version": "1.6.9",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "bootstrap": "^5.1.3",
+        "grpc-web": "^1.3.1",
+        "lodash": "^4.17.21",
+        "vega": "^5.22.1",
+        "vega-tooltip": "^0.27.0",
+        "vega-util": "^1.17.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.16.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.16.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.16.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.2",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/bonjour": {
+      "version": "3.5.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/clone": {
+      "version": "2.1.1",
+      "license": "MIT"
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+      "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.27",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.9",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.8",
+      "license": "MIT"
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/serve-index": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.13.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/sockjs": {
+      "version": "0.3.33",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.5.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-api-error": {
+      "version": "1.11.1",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-buffer": {
+      "version": "1.11.1",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "node_modules/@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webassemblyjs/utf8": {
+      "version": "1.11.1",
+      "license": "MIT"
+    },
+    "node_modules/@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "node_modules/@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "license": "MIT",
+      "dependencies": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "node_modules/@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/info": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "node_modules/@webpack-cli/serve": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xtuc/ieee754": {
+      "version": "1.2.0",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xtuc/long": {
+      "version": "4.2.2",
+      "license": "Apache-2.0"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-assertions": {
+      "version": "1.8.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.8.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/ansi-html-community": {
+      "version": "0.0.8",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "license": "Apache-2.0",
+      "bin": {
+        "ansi-html": "bin/ansi-html"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/array-union": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/batch": {
+      "version": "0.6.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.19.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
+        "type-is": "~1.6.18"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/body-parser/node_modules/bytes": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bonjour-service": {
+      "version": "1.0.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-flatten": "^2.1.2",
+        "dns-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.4"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.1.3",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap"
+      },
+      "peerDependencies": {
+        "@popperjs/core": "^2.10.2"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.19.1",
+      "license": "MIT",
+      "dependencies": {
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001297",
+      "license": "CC-BY-4.0",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "3.5.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/chrome-trace-event": {
+      "version": "1.0.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-deep": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/colorette": {
+      "version": "2.0.16",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "license": "MIT"
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.7.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/connect-history-api-fallback": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-webpack-plugin": {
+      "version": "10.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.2.7",
+        "glob-parent": "^6.0.1",
+        "globby": "^12.0.2",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 12.20.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css-loader": {
+      "version": "6.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.2.15",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "dependencies": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "bin": {
+        "geo2svg": "bin/geo2svg.js",
+        "geograticule": "bin/geograticule.js",
+        "geoproject": "bin/geoproject.js",
+        "geoquantize": "bin/geoquantize.js",
+        "geostitch": "bin/geostitch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo-projection/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/default-gateway": {
+      "version": "6.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dns-equal": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dns-packet": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+      "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+      "dev": true,
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.4.37",
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/envinfo": {
+      "version": "7.8.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "envinfo": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "0.9.3",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "4.3.0",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.17.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.2",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.7",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express/node_modules/array-flatten": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "license": "MIT"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/file-loader": {
+      "version": "6.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/file-loader/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/file-loader/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/file-loader/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-loader/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs-monkey": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
+    "node_modules/globby": {
+      "version": "12.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^3.0.1",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.7",
+        "ignore": "^5.1.8",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.9",
+      "license": "ISC"
+    },
+    "node_modules/grpc-web": {
+      "version": "1.3.1",
+      "license": "Apache-2.0"
+    },
+    "node_modules/handle-thing": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hpack.js": {
+      "version": "2.1.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      }
+    },
+    "node_modules/hpack.js/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hpack.js/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hpack.js/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/html-entities": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-deceiver": {
+      "version": "1.2.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "1.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "@types/express": "^4.17.13"
+      },
+      "peerDependenciesMeta": {
+        "@types/express": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-local": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isobject": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-worker": {
+      "version": "27.4.6",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jest-worker/node_modules/has-flag": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/klona": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loader-runner": {
+      "version": "4.2.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.11.5"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memfs": {
+      "version": "3.4.1",
+      "dev": true,
+      "license": "Unlicense",
+      "dependencies": {
+        "fs-monkey": "1.0.3"
+      },
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.51.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.34",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.51.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.30.1",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/monaco-editor-webpack-plugin": {
+      "version": "6.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": "0.30.x",
+        "webpack": "^4.5.0 || 5.x"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/multicast-dns": {
+      "version": "7.2.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-forge": {
+      "version": "1.3.1",
+      "license": "(BSD-3-Clause OR GPL-2.0)",
+      "engines": {
+        "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.1",
+      "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.28",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/portfinder/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      }
+    },
+    "node_modules/postcss-loader": {
+      "version": "6.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cosmiconfig": "^7.0.0",
+        "klona": "^2.0.5",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "postcss": "^7.0.0 || ^8.0.1",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.9.7",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/bytes": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.7.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-cwd/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "license": "MIT"
+    },
+    "node_modules/sass-loader": {
+      "version": "12.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "sass": "^1.3.0",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/schema-utils": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/select-hose": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/selfsigned": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-forge": "^1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.5",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.17.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-index": {
+      "version": "1.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-index/node_modules/http-errors": {
+      "version": "1.6.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/inherits": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/serve-index/node_modules/setprototypeof": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/serve-static": {
+      "version": "1.14.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shallow-clone": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kind-of": "^6.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.6",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-html-tokenizer": {
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/slash": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sockjs": {
+      "version": "0.3.24",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^8.3.2",
+        "websocket-driver": "^0.7.4"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spdy": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/spdy-transport": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      }
+    },
+    "node_modules/spdy-transport/node_modules/debug": {
+      "version": "4.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/spdy-transport/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/spdy/node_modules/debug": {
+      "version": "4.3.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/spdy/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "3.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svg-inline-loader": {
+      "version": "0.8.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "simple-html-tokenizer": "^0.1.1"
+      }
+    },
+    "node_modules/svg-inline-loader/node_modules/json5": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/svg-inline-loader/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.16.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser-webpack-plugin": {
+      "version": "5.3.0",
+      "license": "MIT",
+      "dependencies": {
+        "jest-worker": "^27.4.1",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^5.7.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "uglify-js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv": {
+      "version": "6.12.6",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "license": "MIT"
+    },
+    "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "dependencies": {
+        "commander": "2"
+      },
+      "bin": {
+        "topo2geo": "bin/topo2geo",
+        "topomerge": "bin/topomerge",
+        "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vega": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
+      "dependencies": {
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
+      }
+    },
+    "node_modules/vega-canvas": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
+    },
+    "node_modules/vega-crossfilter": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-dataflow": {
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
+      "dependencies": {
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-encode": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-event-selector": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
+    },
+    "node_modules/vega-expression": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-force": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
+      "dependencies": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-format": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-functions": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-geo": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-hierarchy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
+      "dependencies": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-label": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
+      "dependencies": {
+        "vega-canvas": "^1.2.6",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-lite": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
+      "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+      "dependencies": {
+        "@types/clone": "~2.1.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.3",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~3.0.0",
+        "tslib": "~2.5.0",
+        "vega-event-selector": "~3.0.0",
+        "vega-expression": "~5.0.0",
+        "vega-util": "~1.17.0",
+        "yargs": "~17.6.2"
+      },
+      "bin": {
+        "vl2pdf": "bin/vl2pdf",
+        "vl2png": "bin/vl2png",
+        "vl2svg": "bin/vl2svg",
+        "vl2vg": "bin/vl2vg"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "vega": "^5.22.0"
+      }
+    },
+    "node_modules/vega-loader": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
+      "dependencies": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-parser": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-projection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
+      "dependencies": {
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
+      }
+    },
+    "node_modules/vega-regression": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "node_modules/vega-runtime": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-scale": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-scenegraph": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
+      "dependencies": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
+      "dependencies": {
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-selections/node_modules/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vega-statistics": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
+      "dependencies": {
+        "d3-array": "^3.2.2"
+      }
+    },
+    "node_modules/vega-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-tooltip": {
+      "version": "0.27.0",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "node_modules/vega-transforms": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-typings": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
+      "dependencies": {
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-util": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+    },
+    "node_modules/vega-view": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
+      "dependencies": {
+        "d3-array": "^3.2.2",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-view-transforms": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
+      "dependencies": {
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-voronoi": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
+      "dependencies": {
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vega-wordcloud": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
+      "dependencies": {
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "node_modules/vegafusion-embed": {
+      "resolved": "../../javascript/vegafusion-embed/lib",
+      "link": true
+    },
+    "node_modules/vegafusion-wasm": {
+      "resolved": "../../vegafusion-wasm/pkg",
+      "link": true
+    },
+    "node_modules/watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "dependencies": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/wbuf": {
+      "version": "1.7.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/webpack": {
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
+      "dependencies": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.7.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
+      },
+      "bin": {
+        "webpack": "bin/webpack.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli": {
+      "version": "4.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-cli/node_modules/commander": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-dev-middleware": {
+      "version": "5.3.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "colorette": "^2.0.10",
+        "memfs": "^3.4.1",
+        "mime-types": "^2.1.31",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/webpack-dev-server": {
+      "version": "4.8.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/bonjour": "^3.5.9",
+        "@types/connect-history-api-fallback": "^1.3.5",
+        "@types/express": "^4.17.13",
+        "@types/serve-index": "^1.9.1",
+        "@types/sockjs": "^0.3.33",
+        "@types/ws": "^8.5.1",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.0.11",
+        "chokidar": "^3.5.3",
+        "colorette": "^2.0.10",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "default-gateway": "^6.0.3",
+        "express": "^4.17.3",
+        "graceful-fs": "^4.2.6",
+        "html-entities": "^2.3.2",
+        "http-proxy-middleware": "^2.0.3",
+        "ipaddr.js": "^2.0.1",
+        "open": "^8.0.9",
+        "p-retry": "^4.5.0",
+        "portfinder": "^1.0.28",
+        "rimraf": "^3.0.2",
+        "schema-utils": "^4.0.0",
+        "selfsigned": "^2.0.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.21",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^5.3.1",
+        "ws": "^8.4.2"
+      },
+      "bin": {
+        "webpack-dev-server": "bin/webpack-dev-server.js"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.37.0 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-cli": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webpack-merge": {
+      "version": "5.8.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack/node_modules/@types/estree": {
+      "version": "0.0.51",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+      "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
+    },
+    "node_modules/webpack/node_modules/ajv": {
+      "version": "6.12.6",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/webpack/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/webpack/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "license": "MIT"
+    },
+    "node_modules/webpack/node_modules/schema-utils": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.8",
+        "ajv": "^6.12.5",
+        "ajv-keywords": "^3.5.2"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wildcard": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  },
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.16.7",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.16.7"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.16.7",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.16.7",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@discoveryjs/json-ext": {
+      "version": "0.5.6",
+      "dev": true
+    },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/resolve-uri": {
+      "version": "3.1.0"
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2"
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "@jridgewell/sourcemap-codec": {
+      "version": "1.4.14"
+    },
+    "@jridgewell/trace-mapping": {
+      "version": "0.3.17",
+      "requires": {
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "@leichtgewicht/ip-codec": {
+      "version": "2.0.3",
+      "dev": true
+    },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
+    "@popperjs/core": {
+      "version": "2.11.2",
+      "peer": true
+    },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/bonjour": {
+      "version": "3.5.10",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/clone": {
+      "version": "2.1.1"
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/connect-history-api-fallback": {
+      "version": "1.3.5",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/eslint": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.3.tgz",
+      "integrity": "sha512-fa7GkppZVEByMWGbTtE5MbmXWJTVbrjjaS8K6uQj+XtuuUv1fsuPAxhygfqLmsb/Ufb3CV8deFCpiMfAgi00Sw==",
+      "requires": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "@types/eslint-scope": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
+      "integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+      "requires": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
+    "@types/estree": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+    },
+    "@types/express": {
+      "version": "4.17.13",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.27",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA=="
+    },
+    "@types/http-proxy": {
+      "version": "1.17.8",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/json-schema": {
+      "version": "7.0.9"
+    },
+    "@types/mime": {
+      "version": "1.3.2",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "17.0.8"
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "dev": true
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "dev": true
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "dev": true
+    },
+    "@types/serve-index": {
+      "version": "1.9.1",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/serve-static": {
+      "version": "1.13.10",
+      "dev": true,
+      "requires": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "@types/sockjs": {
+      "version": "0.3.33",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "8.5.3",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@webassemblyjs/ast": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/helper-numbers": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1"
+      }
+    },
+    "@webassemblyjs/floating-point-hex-parser": {
+      "version": "1.11.1"
+    },
+    "@webassemblyjs/helper-api-error": {
+      "version": "1.11.1"
+    },
+    "@webassemblyjs/helper-buffer": {
+      "version": "1.11.1"
+    },
+    "@webassemblyjs/helper-numbers": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/floating-point-hex-parser": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/helper-wasm-bytecode": {
+      "version": "1.11.1"
+    },
+    "@webassemblyjs/helper-wasm-section": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1"
+      }
+    },
+    "@webassemblyjs/ieee754": {
+      "version": "1.11.1",
+      "requires": {
+        "@xtuc/ieee754": "^1.2.0"
+      }
+    },
+    "@webassemblyjs/leb128": {
+      "version": "1.11.1",
+      "requires": {
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webassemblyjs/utf8": {
+      "version": "1.11.1"
+    },
+    "@webassemblyjs/wasm-edit": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/helper-wasm-section": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-opt": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "@webassemblyjs/wast-printer": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-gen": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-opt": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-buffer": "1.11.1",
+        "@webassemblyjs/wasm-gen": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wasm-parser": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/helper-api-error": "1.11.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.11.1",
+        "@webassemblyjs/ieee754": "1.11.1",
+        "@webassemblyjs/leb128": "1.11.1",
+        "@webassemblyjs/utf8": "1.11.1"
+      }
+    },
+    "@webassemblyjs/wast-printer": {
+      "version": "1.11.1",
+      "requires": {
+        "@webassemblyjs/ast": "1.11.1",
+        "@xtuc/long": "4.2.2"
+      }
+    },
+    "@webpack-cli/configtest": {
+      "version": "1.1.0",
+      "dev": true,
+      "requires": {}
+    },
+    "@webpack-cli/info": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "envinfo": "^7.7.3"
+      }
+    },
+    "@webpack-cli/serve": {
+      "version": "1.6.0",
+      "dev": true,
+      "requires": {}
+    },
+    "@xtuc/ieee754": {
+      "version": "1.2.0"
+    },
+    "@xtuc/long": {
+      "version": "4.2.2"
+    },
+    "accepts": {
+      "version": "1.3.8",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      }
+    },
+    "acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
+    },
+    "acorn-import-assertions": {
+      "version": "1.8.0",
+      "requires": {}
+    },
+    "ajv": {
+      "version": "8.8.2",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.0"
+      }
+    },
+    "ajv-keywords": {
+      "version": "5.1.0",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "ansi-html-community": {
+      "version": "0.0.8",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
+    "array-flatten": {
+      "version": "2.1.2",
+      "dev": true
+    },
+    "array-union": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.4",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "batch": {
+      "version": "0.6.1",
+      "dev": true
+    },
+    "big.js": {
+      "version": "5.2.2"
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "body-parser": {
+      "version": "1.19.2",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "on-finished": "~2.3.0",
+        "qs": "6.9.7",
+        "raw-body": "2.4.3",
+        "type-is": "~1.6.18"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.2",
+          "dev": true
+        }
+      }
+    },
+    "bonjour-service": {
+      "version": "1.0.11",
+      "dev": true,
+      "requires": {
+        "array-flatten": "^2.1.2",
+        "dns-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "multicast-dns": "^7.2.4"
+      }
+    },
+    "bootstrap": {
+      "version": "5.1.3",
+      "requires": {}
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browserslist": {
+      "version": "4.19.1",
+      "requires": {
+        "caniuse-lite": "^1.0.30001286",
+        "electron-to-chromium": "^1.4.17",
+        "escalade": "^3.1.1",
+        "node-releases": "^2.0.1",
+        "picocolors": "^1.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2"
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001297"
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chokidar": {
+      "version": "3.5.3",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "chrome-trace-event": {
+      "version": "1.0.3"
+    },
+    "cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "clone": {
+      "version": "2.1.2"
+    },
+    "clone-deep": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "is-plain-object": "^2.0.4",
+        "kind-of": "^6.0.2",
+        "shallow-clone": "^3.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "dev": true
+    },
+    "colorette": {
+      "version": "2.0.16",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3"
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "dev": true,
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.7.4",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "bytes": "3.0.0",
+        "compressible": "~2.0.16",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.1.2",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "dev": true
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "dev": true
+    },
+    "connect-history-api-fallback": {
+      "version": "1.6.0",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.4",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.2.1"
+      }
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.4.2",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "dev": true
+    },
+    "copy-webpack-plugin": {
+      "version": "10.2.0",
+      "dev": true,
+      "requires": {
+        "fast-glob": "^3.2.7",
+        "glob-parent": "^6.0.1",
+        "globby": "^12.0.2",
+        "normalize-path": "^3.0.0",
+        "schema-utils": "^4.0.0",
+        "serialize-javascript": "^6.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
+    "css-loader": {
+      "version": "6.5.1",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.2.15",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.1.0",
+        "semver": "^7.3.5"
+      }
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "d3-array": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.3.tgz",
+      "integrity": "sha512-JRHwbQQ84XuAESWhvIPaUV4/1UYTBOLiOPGWqgFDHZS1D5QN9c57FbH3QpEnQMYiOXNzKUQyGTZf+EVO7RT5TQ==",
+      "requires": {
+        "internmap": "1 - 2"
+      }
+    },
+    "d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+    },
+    "d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "requires": {
+        "delaunator": "5"
+      }
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "requires": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        },
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
+    "d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+    },
+    "d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==",
+      "requires": {
+        "d3-array": "2.5.0 - 3"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-4.0.0.tgz",
+      "integrity": "sha512-p0bK60CEzph1iqmnxut7d/1kyTmm3UWtPlwdkM31AU+LW+BXazd5zJdoCn7VFxNCHXRngPHRnsNn5uGjLRGndg==",
+      "requires": {
+        "commander": "7",
+        "d3-array": "1 - 3",
+        "d3-geo": "1.12.0 - 3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+          "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+        }
+      }
+    },
+    "d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
+    },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="
+    },
+    "d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "requires": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      }
+    },
+    "d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "requires": {
+        "d3-path": "^3.1.0"
+      }
+    },
+    "d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "requires": {
+        "d3-array": "2 - 3"
+      }
+    },
+    "d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "requires": {
+        "d3-time": "1 - 3"
+      }
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "default-gateway": {
+      "version": "6.0.3",
+      "dev": true,
+      "requires": {
+        "execa": "^5.0.0"
+      }
+    },
+    "define-lazy-prop": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "requires": {
+        "robust-predicates": "^3.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "detect-node": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
+    },
+    "dns-equal": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "dns-packet": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+      "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
+      "dev": true,
+      "requires": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.4.37"
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "emojis-list": {
+      "version": "3.0.0"
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "enhanced-resolve": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
+      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
+      "requires": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.2.0"
+      }
+    },
+    "envinfo": {
+      "version": "7.8.1",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-module-lexer": {
+      "version": "0.9.3"
+    },
+    "escalade": {
+      "version": "3.1.1"
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0"
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0"
+    },
+    "etag": {
+      "version": "1.8.1",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "dev": true
+    },
+    "events": {
+      "version": "3.3.0"
+    },
+    "execa": {
+      "version": "5.1.1",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      }
+    },
+    "express": {
+      "version": "4.17.3",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.19.2",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.4.2",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.1.2",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.9.7",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.17.2",
+        "serve-static": "1.14.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~1.5.0",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "array-flatten": {
+          "version": "1.1.1",
+          "dev": true
+        }
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3"
+    },
+    "fast-glob": {
+      "version": "3.2.8",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0"
+    },
+    "fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "dev": true,
+      "requires": {
+        "websocket-driver": ">=0.5.1"
+      }
+    },
+    "file-loader": {
+      "version": "6.2.0",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "dev": true,
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "dev": true
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.2",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.3",
+        "statuses": "~1.5.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.14.9"
+    },
+    "forwarded": {
+      "version": "0.2.0",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "dev": true
+    },
+    "fs-monkey": {
+      "version": "1.0.3",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-stream": {
+      "version": "6.0.1",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.3"
+      }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+    },
+    "globby": {
+      "version": "12.0.2",
+      "dev": true,
+      "requires": {
+        "array-union": "^3.0.1",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.7",
+        "ignore": "^5.1.8",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.9"
+    },
+    "grpc-web": {
+      "version": "1.3.1"
+    },
+    "handle-thing": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "hpack.js": {
+      "version": "2.1.6",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "obuf": "^1.0.0",
+        "readable-stream": "^2.0.1",
+        "wbuf": "^1.1.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "html-entities": {
+      "version": "2.3.2",
+      "dev": true
+    },
+    "http-deceiver": {
+      "version": "1.2.7",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.8.1",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      }
+    },
+    "http-parser-js": {
+      "version": "0.5.5",
+      "dev": true
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-proxy-middleware": {
+      "version": "2.0.4",
+      "dev": true,
+      "requires": {
+        "@types/http-proxy": "^1.17.8",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.1",
+        "is-plain-obj": "^3.0.0",
+        "micromatch": "^4.0.2"
+      }
+    },
+    "human-signals": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "icss-utils": {
+      "version": "5.1.0",
+      "dev": true,
+      "requires": {}
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "import-local": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "dev": true
+    },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+    },
+    "interpret": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "dev": true
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-core-module": {
+      "version": "2.8.1",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-docker": {
+      "version": "2.2.1",
+      "dev": true
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "is-wsl": {
+      "version": "2.2.0",
+      "dev": true,
+      "requires": {
+        "is-docker": "^2.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "dev": true
+    },
+    "jest-worker": {
+      "version": "27.4.6",
+      "requires": {
+        "@types/node": "*",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0"
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.1"
+    },
+    "json-schema-traverse": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "json-stringify-pretty-compact": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
+      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA=="
+    },
+    "json5": {
+      "version": "2.2.3"
+    },
+    "kind-of": {
+      "version": "6.0.3",
+      "dev": true
+    },
+    "klona": {
+      "version": "2.0.5",
+      "dev": true
+    },
+    "lines-and-columns": {
+      "version": "1.2.4",
+      "dev": true
+    },
+    "loader-runner": {
+      "version": "4.2.0"
+    },
+    "loader-utils": {
+      "version": "2.0.4",
+      "requires": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21"
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "dev": true
+    },
+    "memfs": {
+      "version": "3.4.1",
+      "dev": true,
+      "requires": {
+        "fs-monkey": "1.0.3"
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "merge-stream": {
+      "version": "2.0.0"
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
+    },
+    "mime": {
+      "version": "1.6.0",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.51.0"
+    },
+    "mime-types": {
+      "version": "2.1.34",
+      "requires": {
+        "mime-db": "1.51.0"
+      }
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "dev": true
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "monaco-editor": {
+      "version": "0.30.1",
+      "peer": true
+    },
+    "monaco-editor-webpack-plugin": {
+      "version": "6.0.0",
+      "requires": {
+        "loader-utils": "^2.0.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "multicast-dns": {
+      "version": "7.2.4",
+      "dev": true,
+      "requires": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      }
+    },
+    "nanoid": {
+      "version": "3.3.2",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.3",
+      "dev": true
+    },
+    "neo-async": {
+      "version": "2.6.2"
+    },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-forge": {
+      "version": "1.3.1"
+    },
+    "node-releases": {
+      "version": "2.0.1"
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "npm-run-path": {
+      "version": "4.0.1",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "dev": true
+    },
+    "obuf": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.2",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "open": {
+      "version": "8.4.0",
+      "dev": true,
+      "requires": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-retry": {
+      "version": "4.6.1",
+      "dev": true,
+      "requires": {
+        "@types/retry": "^0.12.0",
+        "retry": "^0.13.1"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "5.2.0",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.3",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.7",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "dev": true
+    },
+    "path-type": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "picocolors": {
+      "version": "1.0.0"
+    },
+    "picomatch": {
+      "version": "2.3.1",
+      "dev": true
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "portfinder": {
+      "version": "1.0.28",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "dev": true
+        }
+      }
+    },
+    "postcss": {
+      "version": "8.4.5",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.1.30",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.1"
+      }
+    },
+    "postcss-loader": {
+      "version": "6.2.1",
+      "dev": true,
+      "requires": {
+        "cosmiconfig": "^7.0.0",
+        "klona": "^2.0.5",
+        "semver": "^7.3.5"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {}
+    },
+    "postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.8",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.7",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "dependencies": {
+        "ipaddr.js": {
+          "version": "1.9.1",
+          "dev": true
+        }
+      }
+    },
+    "punycode": {
+      "version": "2.1.1"
+    },
+    "qs": {
+      "version": "6.9.7",
+      "dev": true
+    },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.1",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.4.3",
+      "dev": true,
+      "requires": {
+        "bytes": "3.1.2",
+        "http-errors": "1.8.1",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "3.1.2",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdirp": {
+      "version": "3.6.0",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.7.1",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.9.0"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
+    "require-from-string": {
+      "version": "2.0.2",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.21.0",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.8.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      }
+    },
+    "resolve-cwd": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "5.0.0",
+          "dev": true
+        }
+      }
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "retry": {
+      "version": "0.13.1",
+      "dev": true
+    },
+    "reusify": {
+      "version": "1.0.4",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "safe-buffer": {
+      "version": "5.2.1"
+    },
+    "safer-buffer": {
+      "version": "2.1.2"
+    },
+    "sass-loader": {
+      "version": "12.4.0",
+      "dev": true,
+      "requires": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      }
+    },
+    "schema-utils": {
+      "version": "4.0.0",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.8.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.0.0"
+      }
+    },
+    "select-hose": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "selfsigned": {
+      "version": "2.0.1",
+      "dev": true,
+      "requires": {
+        "node-forge": "^1"
+      }
+    },
+    "semver": {
+      "version": "7.3.5",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "send": {
+      "version": "0.17.2",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.8.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.1",
+        "statuses": "~1.5.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "dev": true
+        }
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
+    },
+    "serve-index": {
+      "version": "1.9.1",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.4",
+        "batch": "0.6.1",
+        "debug": "2.6.9",
+        "escape-html": "~1.0.3",
+        "http-errors": "~1.6.2",
+        "mime-types": "~2.1.17",
+        "parseurl": "~1.3.2"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.6.3",
+          "dev": true,
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.0",
+            "statuses": ">= 1.4.0 < 2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "dev": true
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "dev": true
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.14.2",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.17.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.2.0",
+      "dev": true
+    },
+    "shallow-clone": {
+      "version": "3.0.1",
+      "dev": true,
+      "requires": {
+        "kind-of": "^6.0.2"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.6",
+      "dev": true
+    },
+    "simple-html-tokenizer": {
+      "version": "0.1.1",
+      "dev": true
+    },
+    "slash": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "sockjs": {
+      "version": "0.3.24",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "^0.11.3",
+        "uuid": "^8.3.2",
+        "websocket-driver": "^0.7.4"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1"
+    },
+    "source-map-js": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "spdy": {
+      "version": "4.0.2",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "handle-thing": "^2.0.0",
+        "http-deceiver": "^1.2.7",
+        "select-hose": "^2.0.0",
+        "spdy-transport": "^3.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "dev": true
+        }
+      }
+    },
+    "spdy-transport": {
+      "version": "3.0.0",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "hpack.js": "^2.1.6",
+        "obuf": "^1.1.2",
+        "readable-stream": "^3.0.6",
+        "wbuf": "^1.7.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "dev": true
+        }
+      }
+    },
+    "statuses": {
+      "version": "1.5.0",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "style-loader": {
+      "version": "3.3.1",
+      "dev": true,
+      "requires": {}
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "svg-inline-loader": {
+      "version": "0.8.2",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "simple-html-tokenizer": "^0.1.1"
+      },
+      "dependencies": {
+        "json5": {
+          "version": "1.0.2",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.2",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
+    },
+    "tapable": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+    },
+    "terser": {
+      "version": "5.16.1",
+      "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      }
+    },
+    "terser-webpack-plugin": {
+      "version": "5.3.0",
+      "requires": {
+        "jest-worker": "^27.4.1",
+        "schema-utils": "^3.1.1",
+        "serialize-javascript": "^6.0.0",
+        "source-map": "^0.6.1",
+        "terser": "^5.7.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1"
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "thunky": {
+      "version": "1.1.0",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
+    "toidentifier": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "topojson-client": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
+      "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
+      "requires": {
+        "commander": "2"
+      }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "type-is": {
+      "version": "1.6.18",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.4.1",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "dev": true
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "dev": true
+    },
+    "vega": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/vega/-/vega-5.24.0.tgz",
+      "integrity": "sha512-eahZ+4eryPywLuq9BpgcwWMyqiuVD3FAh7eMB3koOp7peQ4scPxAZxWdLwnh0t0kah+oE2QcXi2EHS4BabsMPg==",
+      "requires": {
+        "vega-crossfilter": "~4.1.1",
+        "vega-dataflow": "~5.7.5",
+        "vega-encode": "~4.9.1",
+        "vega-event-selector": "~3.0.1",
+        "vega-expression": "~5.0.1",
+        "vega-force": "~4.2.0",
+        "vega-format": "~1.1.1",
+        "vega-functions": "~5.13.1",
+        "vega-geo": "~4.4.1",
+        "vega-hierarchy": "~4.1.1",
+        "vega-label": "~1.2.1",
+        "vega-loader": "~4.5.1",
+        "vega-parser": "~6.2.0",
+        "vega-projection": "~1.6.0",
+        "vega-regression": "~1.1.1",
+        "vega-runtime": "~6.1.4",
+        "vega-scale": "~7.3.0",
+        "vega-scenegraph": "~4.10.2",
+        "vega-statistics": "~1.8.1",
+        "vega-time": "~2.1.1",
+        "vega-transforms": "~4.10.1",
+        "vega-typings": "~0.24.0",
+        "vega-util": "~1.17.1",
+        "vega-view": "~5.11.1",
+        "vega-view-transforms": "~4.5.9",
+        "vega-voronoi": "~4.2.1",
+        "vega-wordcloud": "~4.1.4"
+      }
+    },
+    "vega-canvas": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vega-canvas/-/vega-canvas-1.2.7.tgz",
+      "integrity": "sha512-OkJ9CACVcN9R5Pi9uF6MZBF06pO6qFpDYHWSKBJsdHP5o724KrsgR6UvbnXFH82FdsiTOff/HqjuaG8C7FL+9Q=="
+    },
+    "vega-crossfilter": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-crossfilter/-/vega-crossfilter-4.1.1.tgz",
+      "integrity": "sha512-yesvlMcwRwxrtAd9IYjuxWJJuAMI0sl7JvAFfYtuDkkGDtqfLXUcCzHIATqW6igVIE7tWwGxnbfvQLhLNgK44Q==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-dataflow": {
+      "version": "5.7.5",
+      "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-5.7.5.tgz",
+      "integrity": "sha512-EdsIl6gouH67+8B0f22Owr2tKDiMPNNR8lEvJDcxmFw02nXd8juimclpLvjPQriqn6ta+3Dn5txqfD117H04YA==",
+      "requires": {
+        "vega-format": "^1.1.1",
+        "vega-loader": "^4.5.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-encode": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/vega-encode/-/vega-encode-4.9.1.tgz",
+      "integrity": "sha512-05JB47UZaqIBS9t6rtHI/aKjEuH4EsSIH+wJWItht4BFj33eIl4XRNtlXdE31uuQT2pXWz5ZWW3KboMuaFzKLw==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-event-selector": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-3.0.1.tgz",
+      "integrity": "sha512-K5zd7s5tjr1LiOOkjGpcVls8GsH/f2CWCrWcpKy74gTCp+llCdwz0Enqo013ZlGaRNjfgD/o1caJRt3GSaec4A=="
+    },
+    "vega-expression": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vega-expression/-/vega-expression-5.0.1.tgz",
+      "integrity": "sha512-atfzrMekrcsuyUgZCMklI5ki8cV763aeo1Y6YrfYU7FBwcQEoFhIV/KAJ1vae51aPDGtfzvwbtVIo3WShFCP2Q==",
+      "requires": {
+        "@types/estree": "^1.0.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-force": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-4.2.0.tgz",
+      "integrity": "sha512-aE2TlP264HXM1r3fl58AvZdKUWBNOGkIvn4EWyqeJdgO2vz46zSU7x7TzPG4ZLuo44cDRU5Ng3I1eQk23Asz6A==",
+      "requires": {
+        "d3-force": "^3.0.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-format": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-format/-/vega-format-1.1.1.tgz",
+      "integrity": "sha512-Rll7YgpYbsgaAa54AmtEWrxaJqgOh5fXlvM2wewO4trb9vwM53KBv4Q/uBWCLK3LLGeBXIF6gjDt2LFuJAUtkQ==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-format": "^3.1.0",
+        "d3-time-format": "^4.1.0",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-functions": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/vega-functions/-/vega-functions-5.13.1.tgz",
+      "integrity": "sha512-0LhntimnvBl4VzRO/nkCwCTbtaP8bE552galKQbCg88GDxdmcmlsoTCwUzG0vZ/qmNM3IbqnP5k5/um3zwFqLw==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-dataflow": "^5.7.5",
+        "vega-expression": "^5.0.1",
+        "vega-scale": "^7.3.0",
+        "vega-scenegraph": "^4.10.2",
+        "vega-selections": "^5.4.1",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-geo": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-4.4.1.tgz",
+      "integrity": "sha512-s4WeZAL5M3ZUV27/eqSD3v0FyJz3PlP31XNSLFy4AJXHxHUeXT3qLiDHoVQnW5Om+uBCPDtTT1ROx1smGIf2aA==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-color": "^3.1.0",
+        "d3-geo": "^3.1.0",
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-projection": "^1.6.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-hierarchy": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-4.1.1.tgz",
+      "integrity": "sha512-h5mbrDtPKHBBQ9TYbvEb/bCqmGTlUX97+4CENkyH21tJs7naza319B15KRK0NWOHuhbGhFmF8T0696tg+2c8XQ==",
+      "requires": {
+        "d3-hierarchy": "^3.1.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-label": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/vega-label/-/vega-label-1.2.1.tgz",
+      "integrity": "sha512-n/ackJ5lc0Xs9PInCaGumYn2awomPjJ87EMVT47xNgk2bHmJoZV1Ve/1PUM6Eh/KauY211wPMrNp/9Im+7Ripg==",
+      "requires": {
+        "vega-canvas": "^1.2.6",
+        "vega-dataflow": "^5.7.3",
+        "vega-scenegraph": "^4.9.2",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-lite": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/vega-lite/-/vega-lite-5.6.1.tgz",
+      "integrity": "sha512-Dij2OkJcmK+/2pIcLambjV/vWmhP11ypL3YqDVryBfJxP1m+ZgZU+8/SOEP3B2R1MhmmT7JDYQUtiNcGi1/2ig==",
+      "requires": {
+        "@types/clone": "~2.1.1",
+        "clone": "~2.1.2",
+        "fast-deep-equal": "~3.1.3",
+        "fast-json-stable-stringify": "~2.1.0",
+        "json-stringify-pretty-compact": "~3.0.0",
+        "tslib": "~2.5.0",
+        "vega-event-selector": "~3.0.0",
+        "vega-expression": "~5.0.0",
+        "vega-util": "~1.17.0",
+        "yargs": "~17.6.2"
+      }
+    },
+    "vega-loader": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-4.5.1.tgz",
+      "integrity": "sha512-qy5x32SaT0YkEujQM2yKqvLGV9XWQ2aEDSugBFTdYzu/1u4bxdUSRDREOlrJ9Km3RWIOgFiCkobPmFxo47SKuA==",
+      "requires": {
+        "d3-dsv": "^3.0.1",
+        "node-fetch": "^2.6.7",
+        "topojson-client": "^3.1.0",
+        "vega-format": "^1.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-parser": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-6.2.0.tgz",
+      "integrity": "sha512-as+QnX8Qxe9q51L1C2sVBd+YYYctP848+zEvkBT2jlI2g30aZ6Uv7sKsq7QTL6DUbhXQKR0XQtzlanckSFdaOQ==",
+      "requires": {
+        "vega-dataflow": "^5.7.5",
+        "vega-event-selector": "^3.0.1",
+        "vega-functions": "^5.13.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-projection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vega-projection/-/vega-projection-1.6.0.tgz",
+      "integrity": "sha512-LGUaO/kpOEYuTlul+x+lBzyuL9qmMwP1yShdUWYLW+zXoeyGbs5OZW+NbPPwLYqJr5lpXDr/vGztFuA/6g2xvQ==",
+      "requires": {
+        "d3-geo": "^3.1.0",
+        "d3-geo-projection": "^4.0.0",
+        "vega-scale": "^7.3.0"
+      }
+    },
+    "vega-regression": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vega-regression/-/vega-regression-1.1.1.tgz",
+      "integrity": "sha512-98i/z0vdDhOIEhJUdYoJ2nlfVdaHVp2CKB39Qa7G/XyRw0+QwDFFrp8ZRec2xHjHfb6bYLGNeh1pOsC13FelJg==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.3",
+        "vega-statistics": "^1.7.9",
+        "vega-util": "^1.15.2"
+      }
+    },
+    "vega-runtime": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-6.1.4.tgz",
+      "integrity": "sha512-0dDYXyFLQcxPQ2OQU0WuBVYLRZnm+/CwVu6i6N4idS7R9VXIX5581EkCh3pZ20pQ/+oaA7oJ0pR9rJgJ6rukRQ==",
+      "requires": {
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-scale": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/vega-scale/-/vega-scale-7.3.0.tgz",
+      "integrity": "sha512-pMOAI2h+e1z7lsqKG+gMfR6NKN2sTcyjZbdJwntooW0uFHwjLGjMSY7kSd3nSEquF0HQ8qF7zR6gs1eRwlGimw==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-scenegraph": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-4.10.2.tgz",
+      "integrity": "sha512-R8m6voDZO5+etwNMcXf45afVM3XAtokMqxuDyddRl9l1YqSJfS+3u8hpolJ50c2q6ZN20BQiJwKT1o0bB7vKkA==",
+      "requires": {
+        "d3-path": "^3.1.0",
+        "d3-shape": "^3.2.0",
+        "vega-canvas": "^1.2.7",
+        "vega-loader": "^4.5.1",
+        "vega-scale": "^7.3.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-selections": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/vega-selections/-/vega-selections-5.4.1.tgz",
+      "integrity": "sha512-EtYc4DvA+wXqBg9tq+kDomSoVUPCmQfS7hUxy2qskXEed79YTimt3Hcl1e1fW226I4AVDBEqTTKebmKMzbSgAA==",
+      "requires": {
+        "d3-array": "3.2.2",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      },
+      "dependencies": {
+        "d3-array": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.2.tgz",
+          "integrity": "sha512-yEEyEAbDrF8C6Ob2myOBLjwBLck1Z89jMGFee0oPsn95GqjerpaOA4ch+vc2l0FNFFwMD5N7OCSEN5eAlsUbgQ==",
+          "requires": {
+            "internmap": "1 - 2"
+          }
+        }
+      }
+    },
+    "vega-statistics": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/vega-statistics/-/vega-statistics-1.8.1.tgz",
+      "integrity": "sha512-eRR3LZBusnTXUkc/uunAvWi1PjCJK+Ba4vFvEISc5Iv5xF4Aw2cBhEz1obEt6ID5fGVCTAl0E1LOSFxubS89hQ==",
+      "requires": {
+        "d3-array": "^3.2.2"
+      }
+    },
+    "vega-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/vega-time/-/vega-time-2.1.1.tgz",
+      "integrity": "sha512-z1qbgyX0Af2kQSGFbApwBbX2meenGvsoX8Nga8uyWN8VIbiySo/xqizz1KrP6NbB6R+x5egKmkjdnyNThPeEWA==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-time": "^3.1.0",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-tooltip": {
+      "version": "0.27.0",
+      "requires": {
+        "vega-util": "^1.16.0"
+      }
+    },
+    "vega-transforms": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/vega-transforms/-/vega-transforms-4.10.1.tgz",
+      "integrity": "sha512-0uWrUZaYl8kjWrGbvPOQSKk6kcNXQFY9moME+bUmkADAvFptphCGbaEIn/nSsG6uCxj8E3rqKmKfjSWdU5yOqA==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-statistics": "^1.8.1",
+        "vega-time": "^2.1.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-typings": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-0.24.0.tgz",
+      "integrity": "sha512-FFYf67Dn5VNPbYoYHgO2T9Z1I81qcwrXjwKEe0rlJk0MX7CNWPJr9Y3VZEWfxyEx7J9anAm69hGIv0Ehb2G85A==",
+      "requires": {
+        "@types/geojson": "^7946.0.10",
+        "vega-event-selector": "^3.0.1",
+        "vega-expression": "^5.0.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-util": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.1.tgz",
+      "integrity": "sha512-ToPkWoBdP6awoK+bnYaFhgdqZhsNwKxWbuMnFell+4K/Cb6Q1st5Pi9I7iI5Y6n5ZICDDsd6eL7/IhBjEg1NUQ=="
+    },
+    "vega-view": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/vega-view/-/vega-view-5.11.1.tgz",
+      "integrity": "sha512-RoWxuoEMI7xVQJhPqNeLEHCezudsf3QkVMhH5tCovBqwBADQGqq9iWyax3ZzdyX1+P3eBgm7cnLvpqtN2hU8kA==",
+      "requires": {
+        "d3-array": "^3.2.2",
+        "d3-timer": "^3.0.1",
+        "vega-dataflow": "^5.7.5",
+        "vega-format": "^1.1.1",
+        "vega-functions": "^5.13.1",
+        "vega-runtime": "^6.1.4",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-view-transforms": {
+      "version": "4.5.9",
+      "resolved": "https://registry.npmjs.org/vega-view-transforms/-/vega-view-transforms-4.5.9.tgz",
+      "integrity": "sha512-NxEq4ZD4QwWGRrl2yDLnBRXM9FgCI+vvYb3ZC2+nVDtkUxOlEIKZsMMw31op5GZpfClWLbjCT3mVvzO2xaTF+g==",
+      "requires": {
+        "vega-dataflow": "^5.7.5",
+        "vega-scenegraph": "^4.10.2",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-voronoi": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-4.2.1.tgz",
+      "integrity": "sha512-zzi+fxU/SBad4irdLLsG3yhZgXWZezraGYVQfZFWe8kl7W/EHUk+Eqk/eetn4bDeJ6ltQskX+UXH3OP5Vh0Q0Q==",
+      "requires": {
+        "d3-delaunay": "^6.0.2",
+        "vega-dataflow": "^5.7.5",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vega-wordcloud": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vega-wordcloud/-/vega-wordcloud-4.1.4.tgz",
+      "integrity": "sha512-oeZLlnjiusLAU5vhk0IIdT5QEiJE0x6cYoGNq1th+EbwgQp153t4r026fcib9oq15glHFOzf81a8hHXHSJm1Jw==",
+      "requires": {
+        "vega-canvas": "^1.2.7",
+        "vega-dataflow": "^5.7.5",
+        "vega-scale": "^7.3.0",
+        "vega-statistics": "^1.8.1",
+        "vega-util": "^1.17.1"
+      }
+    },
+    "vegafusion-embed": {
+      "version": "file:../../javascript/vegafusion-embed/lib"
+    },
+    "vegafusion-wasm": {
+      "version": "file:../../vegafusion-wasm/pkg",
+      "requires": {
+        "bootstrap": "^5.1.3",
+        "grpc-web": "^1.3.1",
+        "lodash": "^4.17.21",
+        "vega": "^5.22.1",
+        "vega-tooltip": "^0.27.0",
+        "vega-util": "^1.17.0"
+      }
+    },
+    "watchpack": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
+      "integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+      "requires": {
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "wbuf": {
+      "version": "1.7.3",
+      "dev": true,
+      "requires": {
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "webpack": {
+      "version": "5.76.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
+      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
+      "requires": {
+        "@types/eslint-scope": "^3.7.3",
+        "@types/estree": "^0.0.51",
+        "@webassemblyjs/ast": "1.11.1",
+        "@webassemblyjs/wasm-edit": "1.11.1",
+        "@webassemblyjs/wasm-parser": "1.11.1",
+        "acorn": "^8.7.1",
+        "acorn-import-assertions": "^1.7.6",
+        "browserslist": "^4.14.5",
+        "chrome-trace-event": "^1.0.2",
+        "enhanced-resolve": "^5.10.0",
+        "es-module-lexer": "^0.9.0",
+        "eslint-scope": "5.1.1",
+        "events": "^3.2.0",
+        "glob-to-regexp": "^0.4.1",
+        "graceful-fs": "^4.2.9",
+        "json-parse-even-better-errors": "^2.3.1",
+        "loader-runner": "^4.2.0",
+        "mime-types": "^2.1.27",
+        "neo-async": "^2.6.2",
+        "schema-utils": "^3.1.0",
+        "tapable": "^2.1.1",
+        "terser-webpack-plugin": "^5.1.3",
+        "watchpack": "^2.4.0",
+        "webpack-sources": "^3.2.3"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.51",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
+          "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "requires": {}
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1"
+        },
+        "schema-utils": {
+          "version": "3.1.1",
+          "requires": {
+            "@types/json-schema": "^7.0.8",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
+        }
+      }
+    },
+    "webpack-cli": {
+      "version": "4.9.1",
+      "dev": true,
+      "requires": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.1.0",
+        "@webpack-cli/info": "^1.4.0",
+        "@webpack-cli/serve": "^1.6.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "execa": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "7.2.0",
+          "dev": true
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "5.3.1",
+      "dev": true,
+      "requires": {
+        "colorette": "^2.0.10",
+        "memfs": "^3.4.1",
+        "mime-types": "^2.1.31",
+        "range-parser": "^1.2.1",
+        "schema-utils": "^4.0.0"
+      }
+    },
+    "webpack-dev-server": {
+      "version": "4.8.1",
+      "dev": true,
+      "requires": {
+        "@types/bonjour": "^3.5.9",
+        "@types/connect-history-api-fallback": "^1.3.5",
+        "@types/express": "^4.17.13",
+        "@types/serve-index": "^1.9.1",
+        "@types/sockjs": "^0.3.33",
+        "@types/ws": "^8.5.1",
+        "ansi-html-community": "^0.0.8",
+        "bonjour-service": "^1.0.11",
+        "chokidar": "^3.5.3",
+        "colorette": "^2.0.10",
+        "compression": "^1.7.4",
+        "connect-history-api-fallback": "^1.6.0",
+        "default-gateway": "^6.0.3",
+        "express": "^4.17.3",
+        "graceful-fs": "^4.2.6",
+        "html-entities": "^2.3.2",
+        "http-proxy-middleware": "^2.0.3",
+        "ipaddr.js": "^2.0.1",
+        "open": "^8.0.9",
+        "p-retry": "^4.5.0",
+        "portfinder": "^1.0.28",
+        "rimraf": "^3.0.2",
+        "schema-utils": "^4.0.0",
+        "selfsigned": "^2.0.1",
+        "serve-index": "^1.9.1",
+        "sockjs": "^0.3.21",
+        "spdy": "^4.0.2",
+        "webpack-dev-middleware": "^5.3.1",
+        "ws": "^8.4.2"
+      }
+    },
+    "webpack-merge": {
+      "version": "5.8.0",
+      "dev": true,
+      "requires": {
+        "clone-deep": "^4.0.1",
+        "wildcard": "^2.0.0"
+      }
+    },
+    "webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "dev": true,
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "dev": true
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "which": {
+      "version": "2.0.2",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wildcard": {
+      "version": "2.0.0",
+      "dev": true
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "ws": {
+      "version": "8.5.0",
+      "dev": true,
+      "requires": {}
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "dev": true
+    },
+    "yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+      "requires": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      }
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    }
+  }
+}

--- a/examples/editor-demo/package.json
+++ b/examples/editor-demo/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "create-wasm-app",
+  "version": "1.1.0",
+  "description": "create an app to consume rust-generated wasm packages",
+  "main": "src/index.js",
+  "bin": {
+    "create-wasm-app": ".bin/create-wasm-app.js"
+  },
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack-dev-server"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rustwasm/create-wasm-app.git"
+  },
+  "keywords": [
+    "webassembly",
+    "wasm",
+    "rust",
+    "webpack"
+  ],
+  "author": "Jon Mease <jonmmease@gmail.com>",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/rustwasm/create-wasm-app/issues"
+  },
+  "homepage": "https://github.com/rustwasm/create-wasm-app#readme",
+  "dependencies": {
+    "bootstrap": "^5.1.3",
+    "follow-redirects": ">=1.14.7",
+    "grpc-web": "^1.3.1",
+    "lodash": "^4.17.21",
+    "monaco-editor-webpack-plugin": "^6.0.0",
+    "node-forge": ">=1.0.0",
+    "vega": "^5.24.0",
+    "vega-lite": "^5.6.1",
+    "vega-tooltip": "^0.27.0",
+    "vegafusion-embed": "../../javascript/vegafusion-embed/lib",
+    "vegafusion-wasm": "../../vegafusion-wasm/pkg"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^10.0.0",
+    "css-loader": "^6.5.1",
+    "file-loader": "^6.2.0",
+    "postcss-loader": "^6.2.0",
+    "sass-loader": "^12.3.0",
+    "style-loader": "^3.3.1",
+    "svg-inline-loader": "^0.8.2",
+    "webpack": "^5.64.2",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.5.0"
+  }
+}

--- a/examples/editor-demo/src/bootstrap.js
+++ b/examples/editor-demo/src/bootstrap.js
@@ -1,0 +1,5 @@
+// A dependency graph that contains any wasm must all be imported
+// asynchronously. This `bootstrap.js` file does the single async import, so
+// that no one else needs to worry about it again.
+import("./index.js")
+  .catch(e => console.error("Error importing `index.js`:", e));

--- a/examples/editor-demo/src/index.html
+++ b/examples/editor-demo/src/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Hello wasm-pack!</title>
+</head>
+<body>
+
+<div class="container">
+  <div class="col">
+    <h1>VegaFusion</h1>
+    <div class="card">
+      <div class="card-body">
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a href="#editor" class="nav-link active" data-bs-toggle="tab">Editor</a>
+          </li>
+          <li class="nav-item">
+            <a href="#server-spec" class="nav-link" data-bs-toggle="tab">Server</a>
+          </li>
+          <li class="nav-item">
+            <a href="#client-spec" class="nav-link" data-bs-toggle="tab">Client</a>
+          </li>
+          <li class="nav-item">
+            <a href="#comm-plan" class="nav-link" data-bs-toggle="tab">Comm Plan</a>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div class="tab-pane show active" id="editor">
+            <div id="editor-monaco" class="monaco-editor"></div>
+          </div>
+          <div class="tab-pane" id="server-spec">
+            <div id="server-spec-monaco" class="monaco-editor"></div>
+          </div>
+          <div class="tab-pane" id="client-spec">
+            <div id="client-spec-monaco" class="monaco-editor"></div>
+          </div>
+          <div class="tab-pane" id="comm-plan">
+            <div id="comm-plan-monaco" class="monaco-editor"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="card">
+      <div class="card-body">
+        <div id="vega-chart" class="vega-chart"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<noscript>This page contains webassembly and javascript content, please enable javascript in your browser.</noscript>
+<script src="bootstrap.js"></script>
+</body>
+</html>

--- a/examples/editor-demo/src/index.js
+++ b/examples/editor-demo/src/index.js
@@ -1,0 +1,1430 @@
+import * as vfEmbed from "vegafusion-embed";
+import * as Monaco from 'monaco-editor/esm/vs/editor/editor.api';
+import _ from "lodash"
+import * as grpcWeb from 'grpc-web';
+import 'bootstrap';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './style.css';
+
+async function init() {
+    monaco_init()
+
+    let initial_spec = JSON.stringify(flights_spec, null, 2);
+
+    let editor = Monaco.editor.create(document.getElementById('editor-monaco'), {
+        value: initial_spec,
+        language: 'json',
+        theme: 'vs-dark',
+        automaticLayout: true,
+        fixedOverflowWidgets: true,
+    });
+    let spec_model = editor.getModel();
+
+    let server_spec_monaco = Monaco.editor.create(document.getElementById('server-spec-monaco'), {
+        value: "",
+        language: 'json',
+        theme: 'vs-dark',
+        automaticLayout: true,
+        readOnly: true,
+    });
+
+    let client_spec_monaco = Monaco.editor.create(document.getElementById('client-spec-monaco'), {
+        value: "",
+        language: 'json',
+        theme: 'vs-dark',
+        automaticLayout: true,
+        readOnly: true,
+    });
+
+    let comm_plan_monaco = Monaco.editor.create(document.getElementById('comm-plan-monaco'), {
+        value: "",
+        language: 'json',
+        theme: 'vs-dark',
+        automaticLayout: true,
+        readOnly: true,
+    });
+
+    const hostname = 'http://127.0.0.1:50051';
+    let client = new grpcWeb.GrpcWebClientBase({format: "binary"});
+    let send_message_grpc = vfEmbed.makeGrpcSendMessageFn(client, hostname);
+
+    async function update_chart() {
+        let msg_receiver;
+        try {
+            let element = document.getElementById("vega-chart");
+            let config = {
+                verbose: false,
+                debounce_wait: 30,
+                debounce_max_wait: 60,
+            };
+            msg_receiver = await vfEmbed.embedVegaFusion(
+                element,
+                editor.getValue(),
+                send_message_grpc,
+                config
+            );
+            server_spec_monaco.setValue(msg_receiver.server_spec_json());
+            client_spec_monaco.setValue(msg_receiver.client_spec_json());
+            comm_plan_monaco.setValue(msg_receiver.comm_plan_json());
+        } catch (e) {
+            console.error("Failed to render spec");
+            server_spec_monaco.setValue("");
+            client_spec_monaco.setValue("");
+            comm_plan_monaco.setValue("");
+            console.log(e);
+            return
+        }
+    }
+
+    // Update chart (with debounce) when editor value changes
+    await update_chart()
+    let content_change_listener = _.debounce(async (content) => {
+        await update_chart()
+    }, 750);
+
+    spec_model.onDidChangeContent(content_change_listener)
+}
+
+function monaco_init() {
+    Monaco.languages.json.jsonDefaults.setDiagnosticsOptions(
+        {
+            validate: true,
+            allowComments: true,
+            trailingCommas: true,
+            schemas: [],
+            enableSchemaRequest: true
+        }
+    );
+}
+
+let flights_spec = {
+    "$schema": "https://vega.github.io/schema/vega/v5.json",
+    "background": "white",
+    "padding": 5,
+    "data": [
+        {"name": "brush_store"},
+        {
+            "name": "source_0",
+            "url": "https://raw.githubusercontent.com/vega/vega-datasets/main/data/flights-2k.json",
+            "format": {"type": "json", "parse": {"date": "date"}},
+            "transform": [
+                {
+                    "type": "extent",
+                    "field": "delay",
+                    "signal": "child__column_delay_layer_1_bin_maxbins_20_delay_extent"
+                },
+                {
+                    "type": "bin",
+                    "field": "delay",
+                    "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+                    "signal": "child__column_delay_layer_1_bin_maxbins_20_delay_bins",
+                    "extent": {
+                        "signal": "child__column_delay_layer_1_bin_maxbins_20_delay_extent"
+                    },
+                    "maxbins": 20
+                },
+                {
+                    "type": "extent",
+                    "field": "distance",
+                    "signal": "child__column_distance_layer_0_bin_maxbins_20_distance_extent"
+                },
+                {
+                    "type": "bin",
+                    "field": "distance",
+                    "as": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+                    "signal": "child__column_distance_layer_0_bin_maxbins_20_distance_bins",
+                    "extent": {
+                        "signal": "child__column_distance_layer_0_bin_maxbins_20_distance_extent"
+                    },
+                    "maxbins": 20
+                },
+                {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
+            ]
+        },
+        {
+            "name": "data_0",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "extent",
+                    "field": "time",
+                    "signal": "child__column_time_layer_1_bin_maxbins_20_time_extent"
+                },
+                {
+                    "type": "bin",
+                    "field": "time",
+                    "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "signal": "child__column_time_layer_1_bin_maxbins_20_time_bins",
+                    "extent": {
+                        "signal": "child__column_time_layer_1_bin_maxbins_20_time_extent"
+                    },
+                    "maxbins": 20
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "data_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_time\"]) && isFinite(+datum[\"bin_maxbins_20_time\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_2",
+            "source": "data_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_time\"]) && isFinite(+datum[\"bin_maxbins_20_time\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_3",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "!length(data(\"brush_store\")) || vlSelectionTest(\"brush_store\", datum)"
+                }
+            ]
+        },
+        {
+            "name": "data_4",
+            "source": "data_3",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_delay\"]) && isFinite(+datum[\"bin_maxbins_20_delay\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_5",
+            "source": "data_3",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_distance\"]) && isFinite(+datum[\"bin_maxbins_20_distance\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_6",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_distance\"]) && isFinite(+datum[\"bin_maxbins_20_distance\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_7",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+                    "ops": ["count"],
+                    "fields": [null],
+                    "as": ["__count"]
+                },
+                {
+                    "type": "filter",
+                    "expr": "isValid(datum[\"bin_maxbins_20_delay\"]) && isFinite(+datum[\"bin_maxbins_20_delay\"])"
+                }
+            ]
+        }
+    ],
+    "signals": [
+        {"name": "childWidth", "value": 200},
+        {"name": "childHeight", "value": 200},
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {"events": "mousemove", "update": "isTuple(group()) ? group() : unit"}
+            ]
+        },
+        {
+            "name": "brush",
+            "update": "vlSelectionResolve(\"brush_store\", \"union\")"
+        }
+    ],
+    "layout": {"padding": 20, "columns": 3, "bounds": "full", "align": "all"},
+    "marks": [
+        {
+            "type": "group",
+            "name": "child__column_distance_group",
+            "style": "cell",
+            "encode": {
+                "update": {
+                    "width": {"signal": "childWidth"},
+                    "height": {"signal": "childHeight"}
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {"source": "window", "type": "mouseup"}
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, childWidth)]"
+                        },
+                        {
+                            "events": {"signal": "brush_scale_trigger"},
+                            "update": "[scale(\"child__column_distance_x\", brush_distance[0]), scale(\"child__column_distance_x\", brush_distance[1])]"
+                        },
+                        {
+                            "events": [{"source": "view", "type": "dblclick"}],
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {"signal": "brush_translate_delta"},
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, childWidth)"
+                        },
+                        {
+                            "events": {"signal": "brush_zoom_delta"},
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, childWidth)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_distance",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_x"},
+                            "update": "brush_x[0] === brush_x[1] ? null : invert(\"child__column_distance_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [{"scale": "child__column_distance_x"}],
+                            "update": "(!isArray(brush_distance) || (+invert(\"child__column_distance_x\", brush_x)[0] === +brush_distance[0] && +invert(\"child__column_distance_x\", brush_x)[1] === +brush_distance[1])) ? brush_scale_trigger : {}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple",
+                    "on": [
+                        {
+                            "events": [{"signal": "brush_distance"}],
+                            "update": "brush_distance ? {unit: \"child__column_distance_layer_0\", fields: brush_tuple_fields, values: [brush_distance]} : null"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple_fields",
+                    "value": [{"field": "distance", "channel": "x", "type": "R"}]
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {"source": "window", "type": "mouseup"}
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_tuple"},
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "name": "brush_brush_bg",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {
+                            "fill": {"value": "#333"},
+                            "fillOpacity": {"value": 0.125}
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_distance_layer_0_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": true,
+                    "from": {"data": "data_6"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#ddd"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"distance (binned): \" + (!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"]) ? \"null\" : format(datum[\"bin_maxbins_20_distance\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_distance_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance_end"
+                            },
+                            "y": {"scale": "child__column_distance_y", "field": "__count"},
+                            "y2": {"scale": "child__column_distance_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_distance_layer_1_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": false,
+                    "from": {"data": "data_5"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#4c78a8"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"distance (binned): \" + (!isValid(datum[\"bin_maxbins_20_distance\"]) || !isFinite(+datum[\"bin_maxbins_20_distance\"]) ? \"null\" : format(datum[\"bin_maxbins_20_distance\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_distance_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_distance_x",
+                                "field": "bin_maxbins_20_distance_end"
+                            },
+                            "y": {"scale": "child__column_distance_y", "field": "__count"},
+                            "y2": {"scale": "child__column_distance_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {"fill": {"value": "transparent"}},
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_distance_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
+                            "stroke": [
+                                {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
+                                {"value": null}
+                            ]
+                        }
+                    }
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "child__column_distance_y",
+                    "orient": "left",
+                    "gridScale": "child__column_distance_x",
+                    "grid": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "domain": false,
+                    "labels": false,
+                    "aria": false,
+                    "maxExtent": 0,
+                    "minExtent": 0,
+                    "ticks": false,
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_distance_x",
+                    "orient": "bottom",
+                    "grid": false,
+                    "title": "distance (binned)",
+                    "labelFlush": true,
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childWidth/10)"},
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_distance_y",
+                    "orient": "left",
+                    "grid": false,
+                    "title": "Count of Records",
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "zindex": 0
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "child__column_delay_group",
+            "style": "cell",
+            "encode": {
+                "update": {
+                    "width": {"signal": "childWidth"},
+                    "height": {"signal": "childHeight"}
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {"source": "window", "type": "mouseup"}
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, childWidth)]"
+                        },
+                        {
+                            "events": {"signal": "brush_scale_trigger"},
+                            "update": "[scale(\"child__column_delay_x\", brush_delay[0]), scale(\"child__column_delay_x\", brush_delay[1])]"
+                        },
+                        {
+                            "events": [{"source": "view", "type": "dblclick"}],
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {"signal": "brush_translate_delta"},
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, childWidth)"
+                        },
+                        {
+                            "events": {"signal": "brush_zoom_delta"},
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, childWidth)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_delay",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_x"},
+                            "update": "brush_x[0] === brush_x[1] ? null : invert(\"child__column_delay_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [{"scale": "child__column_delay_x"}],
+                            "update": "(!isArray(brush_delay) || (+invert(\"child__column_delay_x\", brush_x)[0] === +brush_delay[0] && +invert(\"child__column_delay_x\", brush_x)[1] === +brush_delay[1])) ? brush_scale_trigger : {}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple",
+                    "on": [
+                        {
+                            "events": [{"signal": "brush_delay"}],
+                            "update": "brush_delay ? {unit: \"child__column_delay_layer_0\", fields: brush_tuple_fields, values: [brush_delay]} : null"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple_fields",
+                    "value": [{"field": "delay", "channel": "x", "type": "R"}]
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {"source": "window", "type": "mouseup"}
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_tuple"},
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "name": "brush_brush_bg",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {
+                            "fill": {"value": "#333"},
+                            "fillOpacity": {"value": 0.125}
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_delay_layer_0_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": true,
+                    "from": {"data": "data_7"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#ddd"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"delay (binned): \" + (!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"]) ? \"null\" : format(datum[\"bin_maxbins_20_delay\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_delay_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay_end"
+                            },
+                            "y": {"scale": "child__column_delay_y", "field": "__count"},
+                            "y2": {"scale": "child__column_delay_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_delay_layer_1_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": false,
+                    "from": {"data": "data_4"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#4c78a8"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"delay (binned): \" + (!isValid(datum[\"bin_maxbins_20_delay\"]) || !isFinite(+datum[\"bin_maxbins_20_delay\"]) ? \"null\" : format(datum[\"bin_maxbins_20_delay\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_delay_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_delay_x",
+                                "field": "bin_maxbins_20_delay_end"
+                            },
+                            "y": {"scale": "child__column_delay_y", "field": "__count"},
+                            "y2": {"scale": "child__column_delay_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {"fill": {"value": "transparent"}},
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_delay_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
+                            "stroke": [
+                                {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
+                                {"value": null}
+                            ]
+                        }
+                    }
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "child__column_delay_y",
+                    "orient": "left",
+                    "gridScale": "child__column_delay_x",
+                    "grid": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "domain": false,
+                    "labels": false,
+                    "aria": false,
+                    "maxExtent": 0,
+                    "minExtent": 0,
+                    "ticks": false,
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_delay_x",
+                    "orient": "bottom",
+                    "grid": false,
+                    "title": "delay (binned)",
+                    "labelFlush": true,
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childWidth/10)"},
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_delay_y",
+                    "orient": "left",
+                    "grid": false,
+                    "title": "Count of Records",
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "zindex": 0
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "child__column_time_group",
+            "style": "cell",
+            "encode": {
+                "update": {
+                    "width": {"signal": "childWidth"},
+                    "height": {"signal": "childHeight"}
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {"source": "window", "type": "mouseup"}
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, childWidth)]"
+                        },
+                        {
+                            "events": {"signal": "brush_scale_trigger"},
+                            "update": "[scale(\"child__column_time_x\", brush_time[0]), scale(\"child__column_time_x\", brush_time[1])]"
+                        },
+                        {
+                            "events": [{"source": "view", "type": "dblclick"}],
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {"signal": "brush_translate_delta"},
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, childWidth)"
+                        },
+                        {
+                            "events": {"signal": "brush_zoom_delta"},
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, childWidth)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_time",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_x"},
+                            "update": "brush_x[0] === brush_x[1] ? null : invert(\"child__column_time_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [{"scale": "child__column_time_x"}],
+                            "update": "(!isArray(brush_time) || (+invert(\"child__column_time_x\", brush_x)[0] === +brush_time[0] && +invert(\"child__column_time_x\", brush_x)[1] === +brush_time[1])) ? brush_scale_trigger : {}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple",
+                    "on": [
+                        {
+                            "events": [{"signal": "brush_time"}],
+                            "update": "brush_time ? {unit: \"child__column_time_layer_0\", fields: brush_tuple_fields, values: [brush_time]} : null"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple_fields",
+                    "value": [{"field": "time", "channel": "x", "type": "R"}]
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {"source": "window", "type": "mouseup"}
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "consume": true,
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {"signal": "brush_tuple"},
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "name": "brush_brush_bg",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {
+                            "fill": {"value": "#333"},
+                            "fillOpacity": {"value": 0.125}
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_time_layer_0_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": true,
+                    "from": {"data": "data_2"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#ddd"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"time (binned): \" + (!isValid(datum[\"bin_maxbins_20_time\"]) || !isFinite(+datum[\"bin_maxbins_20_time\"]) ? \"null\" : format(datum[\"bin_maxbins_20_time\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_time_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time_end"
+                            },
+                            "y": {"scale": "child__column_time_y", "field": "__count"},
+                            "y2": {"scale": "child__column_time_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "child__column_time_layer_1_marks",
+                    "type": "rect",
+                    "style": ["bar"],
+                    "interactive": false,
+                    "from": {"data": "data_1"},
+                    "encode": {
+                        "update": {
+                            "fill": {"value": "#4c78a8"},
+                            "ariaRoleDescription": {"value": "bar"},
+                            "description": {
+                                "signal": "\"time (binned): \" + (!isValid(datum[\"bin_maxbins_20_time\"]) || !isFinite(+datum[\"bin_maxbins_20_time\"]) ? \"null\" : format(datum[\"bin_maxbins_20_time\"], \"\") + \" – \" + format(datum[\"bin_maxbins_20_time_end\"], \"\")) + \"; Count of Records: \" + (format(datum[\"__count\"], \"\"))"
+                            },
+                            "x2": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "child__column_time_x",
+                                "field": "bin_maxbins_20_time_end"
+                            },
+                            "y": {"scale": "child__column_time_y", "field": "__count"},
+                            "y2": {"scale": "child__column_time_y", "value": 0}
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "clip": true,
+                    "encode": {
+                        "enter": {"fill": {"value": "transparent"}},
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "value": 0
+                                },
+                                {"value": 0}
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {"value": 0}
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child__column_time_layer_0\"",
+                                    "field": {"group": "height"}
+                                },
+                                {"value": 0}
+                            ],
+                            "stroke": [
+                                {"test": "brush_x[0] !== brush_x[1]", "value": "white"},
+                                {"value": null}
+                            ]
+                        }
+                    }
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "child__column_time_y",
+                    "orient": "left",
+                    "gridScale": "child__column_time_x",
+                    "grid": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "domain": false,
+                    "labels": false,
+                    "aria": false,
+                    "maxExtent": 0,
+                    "minExtent": 0,
+                    "ticks": false,
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_time_x",
+                    "orient": "bottom",
+                    "grid": false,
+                    "title": "time (binned)",
+                    "labelFlush": true,
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childWidth/10)"},
+                    "zindex": 0
+                },
+                {
+                    "scale": "child__column_time_y",
+                    "orient": "left",
+                    "grid": false,
+                    "title": "Count of Records",
+                    "labelOverlap": true,
+                    "tickCount": {"signal": "ceil(childHeight/40)"},
+                    "zindex": 0
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "child__column_distance_x",
+            "type": "linear",
+            "domain": {
+                "signal": "[child__column_distance_layer_0_bin_maxbins_20_distance_bins.start, child__column_distance_layer_0_bin_maxbins_20_distance_bins.stop]"
+            },
+            "range": [0, {"signal": "childWidth"}],
+            "bins": {
+                "signal": "child__column_distance_layer_0_bin_maxbins_20_distance_bins"
+            },
+            "zero": false
+        },
+        {
+            "name": "child__column_distance_y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {"data": "data_6", "field": "__count"},
+                    {"data": "data_5", "field": "__count"}
+                ]
+            },
+            "range": [{"signal": "childHeight"}, 0],
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "child__column_delay_x",
+            "type": "linear",
+            "domain": {
+                "signal": "[child__column_delay_layer_1_bin_maxbins_20_delay_bins.start, child__column_delay_layer_1_bin_maxbins_20_delay_bins.stop]"
+            },
+            "range": [0, {"signal": "childWidth"}],
+            "bins": {
+                "signal": "child__column_delay_layer_1_bin_maxbins_20_delay_bins"
+            },
+            "zero": false
+        },
+        {
+            "name": "child__column_delay_y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {"data": "data_7", "field": "__count"},
+                    {"data": "data_4", "field": "__count"}
+                ]
+            },
+            "range": [{"signal": "childHeight"}, 0],
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "child__column_time_x",
+            "type": "linear",
+            "domain": {
+                "signal": "[child__column_time_layer_1_bin_maxbins_20_time_bins.start, child__column_time_layer_1_bin_maxbins_20_time_bins.stop]"
+            },
+            "range": [0, {"signal": "childWidth"}],
+            "bins": {"signal": "child__column_time_layer_1_bin_maxbins_20_time_bins"},
+            "zero": false
+        },
+        {
+            "name": "child__column_time_y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {"data": "data_2", "field": "__count"},
+                    {"data": "data_1", "field": "__count"}
+                ]
+            },
+            "range": [{"signal": "childHeight"}, 0],
+            "nice": true,
+            "zero": true
+        }
+    ]
+}
+
+await init();

--- a/examples/editor-demo/src/style.css
+++ b/examples/editor-demo/src/style.css
@@ -1,0 +1,3 @@
+.tab-pane .monaco-editor {
+    height: 500px;
+}

--- a/examples/editor-demo/webpack.config.js
+++ b/examples/editor-demo/webpack.config.js
@@ -1,0 +1,33 @@
+const CopyWebpackPlugin = require("copy-webpack-plugin");
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const path = require('path');
+
+module.exports = {
+  entry: "./src/bootstrap.js",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "bootstrap.js",
+  },
+  mode: "development",
+  module: {
+    rules: [
+      {
+        test: /\.css$/,
+        use: ['style-loader', 'css-loader']
+      }, {
+        test: /\.svg$/,
+        loader: 'svg-inline-loader'
+      },
+    ]
+  },
+  plugins: [
+    new CopyWebpackPlugin({patterns: ['src/index.html']}),
+    new MonacoWebpackPlugin({
+      languages: ['typescript', 'javascript', 'css', "json"]
+    })
+  ],
+  experiments: {
+    topLevelAwait: true,
+    asyncWebAssembly: true,
+  }
+};

--- a/javascript/vegafusion-embed/package-lock.json
+++ b/javascript/vegafusion-embed/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "vegafusion-embed",
-      "version": "1.5.0",
+      "version": "1.6.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "grpc-web": "^1.3.1",
@@ -40,7 +40,7 @@
     },
     "../../vegafusion-wasm/pkg": {
       "name": "vegafusion-wasm",
-      "version": "1.5.0",
+      "version": "1.6.9",
       "license": "BSD-3-Clause",
       "dependencies": {
         "bootstrap": "^5.1.3",

--- a/javascript/vegafusion-embed/src/grpc.ts
+++ b/javascript/vegafusion-embed/src/grpc.ts
@@ -1,9 +1,8 @@
 import grpcWeb, {GrpcWebClientBase} from "grpc-web"
-import {MsgReceiver} from "./index";
 
 // Other utility functions
 export function makeGrpcSendMessageFn(client: GrpcWebClientBase, hostname: string) {
-    let sendMessageGrpc = (send_msg_bytes: Uint8Array, receiver: MsgReceiver) => {
+    let sendMessageGrpc = async (send_msg_bytes: Uint8Array) => {
         let grpc_route = '/services.VegaFusionRuntime/TaskGraphQuery'
 
         // Make custom MethodDescriptor that does not perform serialization
@@ -16,15 +15,12 @@ export function makeGrpcSendMessageFn(client: GrpcWebClientBase, hostname: strin
             (v: any) => v,
         );
 
-        let promise = client.thenableCall(
+        return await client.thenableCall(
             hostname + grpc_route,
             send_msg_bytes,
             {},
             methodDescriptor,
         );
-        promise.then((response: any) => {
-            receiver.receive(response)
-        })
     }
     return sendMessageGrpc
 }

--- a/javascript/vegafusion-embed/src/index.ts
+++ b/javascript/vegafusion-embed/src/index.ts
@@ -1,6 +1,3 @@
-import {MsgReceiver as MsgReceiver2} from "vegafusion-wasm";
-export type MsgReceiver = MsgReceiver2;
-
 export * from './version';
 export * from './embed';
 export * from './grpc';

--- a/pixi.lock
+++ b/pixi.lock
@@ -19,6 +19,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.4-hc8144f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.2-h09139f6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.3-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h184a658_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hd6ebb48_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.13-hc690213_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.32-h161b759_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.6-h32970c0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.17-hb5e3142_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h184a658_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h184a658_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.23.1-h94c364a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.156-h6600424_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
@@ -32,7 +45,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brunsli-0.1-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h7f98852_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.21.0-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-blosc2-2.10.5-hb4ffafa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2023.7.22-hbcca054_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -67,9 +80,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.12.1-h267a509_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gcc_impl_linux-64-13.2.0-h338b0a0_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.1-h0b41bf4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h58526e2_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.57.0-py310h1b8f574_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py310h1b8f574_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-8.2.1-h3d44ed6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-73.2-h59595ed_0.conda
@@ -112,15 +127,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h27087fc_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230125.3-cxx17_h59595ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libarrow-13.0.0-h1ed0495_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libavif16-1.0.1-h87da1f6_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libblas-3.9.0-19_linux64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcblas-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h4637d8d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20191231-he28a2e2_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
@@ -131,20 +151,26 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-14.1.0-hc5f4f2c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.3-h315aac3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-14.1.0-h77fa898_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.57.0-h3905398_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h840a212_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.56.2-h3905398_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.17-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-2.1.5.1-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblapack-3.9.0-19_linux64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libnsl-2.0.1-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-h4ab18f5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopenblas-0.3.24-pthreads_h413a1c8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.23.3-hd1fb520_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsanitizer-13.2.0-h7e041cc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.46.1-hadc24fc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-14.1.0-hc0a3c3a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-13.2.0-h7e041cc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h29866fb_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.44.2-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.3.2-hd590300_0.conda
@@ -180,6 +206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-20.0.0-hfea2f88_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h385abfd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
@@ -208,6 +235,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h36c2ea0_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-13.0.0-py310hf9e7431_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
@@ -225,6 +253,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py310ha75aee5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-26.2.0-py310h71f11fc_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.6.6-he8a937b_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.03.02-h8c504da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/referencing-0.30.2-pyhd8ed1ab_0.conda
@@ -235,6 +264,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.6.9-py310h624018c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rust-1.80.1-h0a17960_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rust-std-x86_64-unknown-linux-gnu-1.80.1-h2c6d0dc_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.54-h06160fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.24.0-py310h0cd1892_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.14.1-py310ha3fb0e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/selenium-4.11.2-pyhd8ed1ab_1.conda
@@ -266,6 +296,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2023c-h71feb2d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.14.1-h64cca9d_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.0.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vega_datasets-0.9.0-pyhd3deb0d_0.tar.bz2
@@ -320,6 +351,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.4-h7fea801_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.2-hfc10710_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.3-h0dc2134_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hd41bdd4_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hab6341b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h868b204_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.32-h2566903_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.6-he6da789_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.17-h5997705_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-hd41bdd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hd41bdd4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.23.1-h4e3dc9b_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.156-h99d1da1_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
@@ -332,7 +376,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/brunsli-0.1-h046ec9c_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h0d85af4_4.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.21.0-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-blosc2-2.14.3-h0ae8482_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2023.7.22-h8857fd0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
@@ -357,8 +401,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freetype-2.12.1-h60636b9_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.1-hb7f2c08_3.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.57.0-py310h0d4bf3c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py310h0d4bf3c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-73.2-hf5e326d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
@@ -397,29 +443,39 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/lerc-4.0.0-hb486fe8_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230125.3-cxx17_h000cb23_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libarrow-13.0.0-hca2412d_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libavif16-1.0.1-h4fa63ff_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libblas-3.9.0-19_osx64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.1.0-h00291cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.1.0-h00291cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.1.0-h00291cd_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcblas-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-19.1.1-hf95d169_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libedit-3.1.20191231-h0678c8f_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-5.0.0-13_2_0_h97931a8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-13.2.0-h2873a65_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.57.0-he6801ca_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h37a168a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.56.2-he6801ca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.1.0-h7728843_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjpeg-turbo-3.0.0-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libjxl-0.10.3-hfb90b89_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/liblapack-3.9.0-19_osx64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopenblas-0.3.24-openmp_h48a4ad5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.23.3-h5feb325_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.20-hfdf4475_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.0-h1b8f9f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.44.2-h0dc2134_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libwebp-base-1.3.2-h0dc2134_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libxcb-1.15-hb7f2c08_0.conda
@@ -454,6 +510,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjdk-20.0.0-h7d26f99_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hef23039_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
@@ -480,6 +537,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pthread-stubs-0.4-hc929b4f_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-13.0.0-py310h6eef95f_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.3.1-py310h1c7075f_1.conda
@@ -577,6 +635,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-hab8b942_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.2-he70778a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.0-hb547adb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-he70778a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hcf14f3f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.12-he297698_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-h3c776e5_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.5-h83b98fe_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-h24e141d_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-he70778a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-he70778a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.23.0-h04fc39a_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h0092a47_21.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backcall-0.2.0-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
@@ -629,11 +700,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdk-pixbuf-2.42.10-h9bcf4fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gettext-0.21.1-h0186832_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.1-h1a8c8d9_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-2.76.4-ha614eb4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glib-tools-2.76.4-ha614eb4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/graphite2-1.3.13-h9f76cd9_1001.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.57.0-py310h95b248a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py310h95b248a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/harfbuzz-7.3.0-h46e5fef_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-72.1-he12128b_0.conda
@@ -674,23 +747,27 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lerc-4.0.0-h9a09cb3_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230125.3-cxx17_h13dd4ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.0.6-hb7217d7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-13.0.0-h6e4acf5_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libavif-0.11.1-h9f83d30_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libblas-3.9.0-17_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.0.9-h1a8c8d9_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.0.9-h1a8c8d9_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.0.9-h1a8c8d9_9.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcblas-3.9.0-17_osxarm64_openblas.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.2.1-hc52a3a8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-19.1.1-ha82da77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.17-h1a8c8d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libedit-3.1.20191231-hc8eb9b7_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h642e427_1.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-5.0.0-13_2_0_hd922786_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-13.2.0-hf226fd6_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.76.4-h24e9cb9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.57.0-h9075ed4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h05652e3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.56.2-h9075ed4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.17-he4db4b2_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/liblapack-3.9.0-17_osxarm64_openblas.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.52.0-hae82a92_0.conda
@@ -701,7 +778,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.0-hfb93653_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.18.1-ha061701_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.5.0-h5dffbdd_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.44.2-hb547adb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libwebp-base-1.3.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libxcb-1.13-h9b22ae9_1004.tar.bz2
@@ -737,6 +816,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-20.0.0-hbe7ddab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-hbc2ba62_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-h858f345_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.2.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.1-pyhd8ed1ab_0.conda
@@ -767,6 +847,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pthread-stubs-0.4-h27ca646_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-13.0.0-py310h382c99a_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.3.1-py310hb3dec1a_1.conda
@@ -850,28 +931,40 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-ng-2.0.7-h1a8c8d9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.2-h4f39d0f_7.conda
       win-64:
-      - conda: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/altair-5.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anywidget-0.9.13-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aom-3.7.1-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py310ha8f682b_5.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-24.2.0-pyh71513ae_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.4-hc10d58f_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.2-hd5965a7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.3-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hd5965a7_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-hea44b67_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-h6dd44e3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.32-ha16e049_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.6-h5e85a83_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.17-ha8f72b6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-hd5965a7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hd5965a7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.23.1-h70f7a23_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.156-h02852bd_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/babel-2.13.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports-1.0-pyhd8ed1ab_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backports.functools_lru_cache-1.6.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/beautifulsoup4-4.12.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/brotli-python-1.1.0-py310h00ffb61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/build-0.7.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h8ffe710_4.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.21.0-hcfcfb64_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.15.1-hb461149_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.14.3-h183a6f4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ca-certificates-2023.7.22-h56e8100_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
@@ -897,10 +990,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freetype-2.12.1-hdaf720e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/future-0.18.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/giflib-5.2.2-h64bf75a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.57.0-py310hb84602e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py310hb84602e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.4-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.6.1-py310h40cd1a8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.1.1-py310hda7f504_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.31.5-pyh8c1a49c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-6.8.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-6.8.0-hd8ed1ab_0.conda
@@ -936,15 +1029,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/lerc-4.0.0-h63175ca_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230125.3-cxx17_h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4e96d62_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libarrow-13.0.0-hba3d5be_3_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libavif-1.0.1-h7a9aacb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libblas-3.9.0-19_win64_mkl.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlicommon-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlidec-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libbrotlienc-1.1.0-hcfcfb64_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libcblas-3.9.0-19_win64_mkl.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.4.2-h8ffe710_5.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.57.0-hea2d5f7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-hbc1b25b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.56.2-hea2d5f7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.9.3-default_haede6df_1009.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.17-h8ffe710_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libjpeg-turbo-3.0.0-hcfcfb64_1.conda
@@ -953,7 +1051,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.23.3-h1975477_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.20-hc70643c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.46.1-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/libwebp-base-1.4.0-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxcb-1.16-h013a479_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.11.6-hc3477c8_0.conda
@@ -989,10 +1090,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.2.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/nodejs-20.5.1-h57928b3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py310hb9d903e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py310hf667824_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjdk-20.0.0-h57928b3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.3.2-h2466b09_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hf2b8f0d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/outcome-1.3.0.post0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/overrides-7.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
@@ -1018,6 +1120,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthread-stubs-0.4-hcd874cb_1001.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/pthreads-win32-2.9.1-hfa6e2cd_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-13.0.0-py310hd0bb7c2_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.16.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh0701188_6.tar.bz2
@@ -1053,12 +1156,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-68.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/sortedcontainers-2.4.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/soupsieve-2.5-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.7.0-h63175ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/symlink-exe-runtime-1.0-hcfcfb64_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/win-64/taplo-0.9.3-h823019e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/tbb-2021.10.0-h91493d7_2.conda
@@ -1107,20 +1210,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_6.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zfp-1.0.1-he0c23c2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.2.2-he0c23c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.0.7-hcfcfb64_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
 packages:
-- kind: conda
-  name: _libavif_api
-  version: 1.1.1
-  build: h57928b3_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/_libavif_api-1.1.1-h57928b3_1.conda
-  sha256: 1a133c072264589452927dac6f7a804a544b0c4b362e4add2497ac76ef8787f1
-  md5: fe3d820ded73ef5bd7415cb821f0f77e
-  size: 9201
-  timestamp: 1724672649849
 - kind: conda
   name: _libgcc_mutex
   version: '0.1'
@@ -1322,20 +1414,20 @@ packages:
   timestamp: 1694226514540
 - kind: conda
   name: aom
-  version: 3.9.1
-  build: he0c23c2_0
+  version: 3.7.1
+  build: h63175ca_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.9.1-he0c23c2_0.conda
-  sha256: 0524d0c0b61dacd0c22ac7a8067f977b1d52380210933b04141f5099c5b6fec7
-  md5: 3d7c14285d3eb3239a76ff79063f27a5
+  url: https://conda.anaconda.org/conda-forge/win-64/aom-3.7.1-h63175ca_0.conda
+  sha256: aa317fd3271b4fabbfe3b800cc0d55a9bbfb9b5aa7f91bfb08c86f2da08d2729
+  md5: 1b52cb3995f780a5c0a52fc1bb81b337
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-2-Clause
   license_family: BSD
-  size: 1958151
-  timestamp: 1718551737234
+  size: 1955945
+  timestamp: 1700530921759
 - kind: conda
   name: appnope
   version: 0.1.3
@@ -1591,6 +1683,960 @@ packages:
   size: 56048
   timestamp: 1722977241383
 - kind: conda
+  name: aws-c-auth
+  version: 0.7.3
+  build: hab8b942_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.3-hab8b942_3.conda
+  sha256: f27b21ba66bfdccd6e892c78f83d53cbc21ce8fdf594c3d677eede9f225b3820
+  md5: 8c9ad5cf200ddc532d73cd63a4458b76
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 92315
+  timestamp: 1692935723694
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.4
+  build: h7fea801_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.4-h7fea801_1.conda
+  sha256: 316b595cd5491b68b890cfd8ec9f5401a78274774667f9be7bbb9c1498c4bcd0
+  md5: 6a391ec90c3efedcd4e29eecdc10198a
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 89157
+  timestamp: 1695806962937
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.4
+  build: hc10d58f_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.4-hc10d58f_1.conda
+  sha256: beea4633962b493cb6b19e54331b3a3cdfff006ee92fcd8bf80fe432ef1eb254
+  md5: 7ed6baf38798ebb4152b821c6b04f061
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 98155
+  timestamp: 1695807069215
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.4
+  build: hc8144f4_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.4-hc8144f4_1.conda
+  sha256: a41d33da5f25bb6666805a8ac72ff7f03742ce6d311c4241de7beb94681c1289
+  md5: 81b00630260ff8c9388ee3913465b208
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 101876
+  timestamp: 1695806693576
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.2
+  build: h09139f6_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.2-h09139f6_2.conda
+  sha256: f6f91c7d04be3888365499628f3369fc94dada451360bd82e5e3c61abeb7fc3e
+  md5: 29c3112841eee851f6f5451f6d705782
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 50982
+  timestamp: 1695755343237
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.2
+  build: hd5965a7_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.2-hd5965a7_2.conda
+  sha256: bf8bc4eae5baacc4a12bef32c25a7f43129b79cf167d2e45c5c5b8672af50815
+  md5: cbfd6b62693f67233f205e72e505109a
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 51212
+  timestamp: 1695756000021
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.2
+  build: he70778a_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.2-he70778a_1.conda
+  sha256: a79d40403b1e07f16c7631b1de255a5852f8181a8109d07ee14c3f03b1d050c1
+  md5: 83a5e6490ab433f6045dfeb096f93c17
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 36212
+  timestamp: 1695089175156
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.2
+  build: hfc10710_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.2-hfc10710_2.conda
+  sha256: 8752777b77fdb1a8b60ec2903916fd4397ad0ddff8618ee8e5156a3cbfe4095a
+  md5: a340450b9351a8979cc1130fece3cc9f
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 40963
+  timestamp: 1695755654862
+- kind: conda
+  name: aws-c-common
+  version: 0.9.0
+  build: hb547adb_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.0-hb547adb_0.conda
+  sha256: ec15d841f362e6a4468e06117d985f7f6007568ba832416ff146d239b2f7f0c0
+  md5: 7d7f91d3daa8d7bbf1da8c97038e336f
+  license: Apache-2.0
+  license_family: Apache
+  size: 182127
+  timestamp: 1691436103004
+- kind: conda
+  name: aws-c-common
+  version: 0.9.3
+  build: h0dc2134_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.3-h0dc2134_0.conda
+  sha256: cd186a847486ecc6f4c90f321552422a148b30bde40c1984cb3c2cdedb5b6842
+  md5: 08315e4f10bb6df0b6457dd2c4aefe04
+  license: Apache-2.0
+  license_family: Apache
+  size: 203404
+  timestamp: 1695654891068
+- kind: conda
+  name: aws-c-common
+  version: 0.9.3
+  build: hcfcfb64_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.3-hcfcfb64_0.conda
+  sha256: 4a83811c573c965c55f3f67c149f232ce81c157391b651699a8c8ad22b743ead
+  md5: ef7faef92f32551745303430e45d61d8
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 217632
+  timestamp: 1695654879342
+- kind: conda
+  name: aws-c-common
+  version: 0.9.3
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.3-hd590300_0.conda
+  sha256: 6f3a9c285199f828ac1917112495b4e5f4ca578d385442f33aae282bd95618ac
+  md5: 434466e97a4174b0c4de114eb7100550
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 220352
+  timestamp: 1695654440131
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: h184a658_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h184a658_3.conda
+  sha256: 07f3431f097f64c1ee916c27ac7745bbf27a9b06768fa0449d9e0eaea1b6f4d2
+  md5: c62775b5028b5a4eda25037f9af7f5b3
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 19162
+  timestamp: 1695755217636
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hd41bdd4_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hd41bdd4_3.conda
+  sha256: 922f2be31994d2ba277f2452c801a35c4695335938788bd280f73ab1cbd189df
+  md5: 8477d925cf7a7972e85139c385ec6f45
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18078
+  timestamp: 1695755408655
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hd5965a7_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hd5965a7_3.conda
+  sha256: 5d63e840b6ba0f737503584e14ed94b94397e68e1768f1d76b263dee771a07dd
+  md5: b0e3df9a002b961bf5fa2400235a8f74
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 22691
+  timestamp: 1695755699057
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: he70778a_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-he70778a_2.conda
+  sha256: 0e5a93b88d77405af89586f4b776f68a3cfd1c9ed44da57ac2a6b042dc96a26c
+  md5: d7a30e85a98d14dcd2d0ca8ae8ca4372
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18406
+  timestamp: 1691607429629
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hab6341b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hab6341b_1.conda
+  sha256: ed52fda59f2c42a50a53055f909189d48169fa875f9fdcf4aa280c326aac3123
+  md5: ea7090c6dce0f098e6f27531204ae9c3
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 46908
+  timestamp: 1695787042268
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hcf14f3f_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hcf14f3f_0.conda
+  sha256: 1923838df400cf19d21a54dc7f19afe5a949339cd998725504c936fe0b24d68a
+  md5: 6c6fc8e9f1fa171136e58a33ffb95d5f
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 48862
+  timestamp: 1692836283506
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hd6ebb48_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-hd6ebb48_1.conda
+  sha256: 32385f297271fcbdfa97adeceea56c1317ffb96d94a681933805f97ef30bda12
+  md5: ef9692e74f437004ef47a4363552bcb6
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 53665
+  timestamp: 1695786768147
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hea44b67_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.3.2-hea44b67_1.conda
+  sha256: 9aa0bb1e4417b17935094e8fadfba1bc9e00f7e20a9e36f04d790ea7ab4cf308
+  md5: 8714f7f7c40e43d9830f41b8f010b9d6
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 54351
+  timestamp: 1695787146551
+- kind: conda
+  name: aws-c-http
+  version: 0.7.12
+  build: he297698_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.12-he297698_1.conda
+  sha256: 5afb1a690124d76a6771b52567fe38a348e5feb113a0c6ea173123dbaaa51f51
+  md5: 8d952fa86e3c02043e85650080ba817b
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 157732
+  timestamp: 1692913796109
+- kind: conda
+  name: aws-c-http
+  version: 0.7.13
+  build: h6dd44e3_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.7.13-h6dd44e3_1.conda
+  sha256: 536f6e1153fd374ed75632bb568a7b9ab106e8634084235b56f128e9be65175e
+  md5: cf2be4ecb54d59f946b6041859051b66
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 179477
+  timestamp: 1695787045722
+- kind: conda
+  name: aws-c-http
+  version: 0.7.13
+  build: h868b204_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.13-h868b204_1.conda
+  sha256: f3db9629daee50f27f86676a2d4dec58c9aa2d6d4a6d0f32433928bac7d58dcd
+  md5: f43a2a8cae0408db86d4461359a0dbe2
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 164664
+  timestamp: 1695786938189
+- kind: conda
+  name: aws-c-http
+  version: 0.7.13
+  build: hc690213_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.13-hc690213_1.conda
+  sha256: 609016dcb4c3480362ba6307759b9dabc59fd02f936d6c09f299c46964c19a7c
+  md5: c912831e92c565598072243266073161
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 193066
+  timestamp: 1695786758113
+- kind: conda
+  name: aws-c-io
+  version: 0.13.32
+  build: h161b759_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.32-h161b759_6.conda
+  sha256: 76b51d2b2911ee0acb79692fefd524ae91b92e92dd5ddf4d89958d29fc1460ee
+  md5: 26c909c7fc3fddc015a9ab4ebfcaed41
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  - s2n >=1.3.54,<1.3.55.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 153867
+  timestamp: 1696719447343
+- kind: conda
+  name: aws-c-io
+  version: 0.13.32
+  build: h2566903_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.32-h2566903_6.conda
+  sha256: 196f33bf7304c08c913b652d58463772a7db6c47d0d2a9c1be9d92b14094ff0a
+  md5: da6927252893084bf95269d745eedada
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 135831
+  timestamp: 1696719527
+- kind: conda
+  name: aws-c-io
+  version: 0.13.32
+  build: h3c776e5_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.32-h3c776e5_3.conda
+  sha256: 5600008b82bdf1d3b025a99e6a39ca9b6cedf901c2c98357cccc7b4fb94237ba
+  md5: f88f5e6e0dbe5e19d55344b8c2cfc900
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139753
+  timestamp: 1694551424429
+- kind: conda
+  name: aws-c-io
+  version: 0.13.32
+  build: ha16e049_6
+  build_number: 6
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.13.32-ha16e049_6.conda
+  sha256: 2ff7e7c16c04e4bdd4e96bf02239afabcc071aa96f199a58c8a57881886148b8
+  md5: 75cb3bc0a2d05063bda6a900eb926b9d
+  depends:
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 158041
+  timestamp: 1696720098642
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.5
+  build: h83b98fe_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.5-h83b98fe_1.conda
+  sha256: 1e02fdc8853eaf607093930d6696f0eedd3f4caf65addf2ebcb12a48b438b984
+  md5: 2b1cf8c40fe264f66c51ddfbf4a6c643
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 123424
+  timestamp: 1692895315126
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.6
+  build: h32970c0_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.6-h32970c0_2.conda
+  sha256: ff961111d41afc107bcb263d1ce727a2900b4546adbb7bae03046e1473157e64
+  md5: 21dd1cb1e73b0ce2ea31e9f9f692e051
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 162703
+  timestamp: 1695917197677
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.6
+  build: h5e85a83_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.9.6-h5e85a83_2.conda
+  sha256: 8f6e103b8a5c85275b541fe52d69b879aa96c9996f5edc81fd6a21d662bc7392
+  md5: 348bde350e6eee35c3dd310cef20775f
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 157202
+  timestamp: 1695917786835
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.6
+  build: he6da789_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.6-he6da789_2.conda
+  sha256: 343781159bb6bc47dd8e69c41eaeaacfc4d146cfa18fd01bf2c75e8b7bd45ba6
+  md5: 4b30f7acb9cf20c7570b000213484f52
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139336
+  timestamp: 1695917405265
+- kind: conda
+  name: aws-c-s3
+  version: 0.3.14
+  build: h24e141d_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.3.14-h24e141d_3.conda
+  sha256: f9bf1668f323197268f9239722cc9273f2ebb4329ab48c469d0798958a952bb3
+  md5: 0fbd1f360ec8b6b08669e900cf31a2bd
+  depends:
+  - aws-c-auth >=0.7.3,<0.7.4.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 78329
+  timestamp: 1692950426132
+- kind: conda
+  name: aws-c-s3
+  version: 0.3.17
+  build: h5997705_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.3.17-h5997705_3.conda
+  sha256: 4146f40b392860c1bb9c76e39d5a6aa95a8429da4d5a7e10b30318147faddfe8
+  md5: e4e8a0ea0385a06a83944f603e56320e
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 74663
+  timestamp: 1695816593583
+- kind: conda
+  name: aws-c-s3
+  version: 0.3.17
+  build: ha8f72b6_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.3.17-ha8f72b6_3.conda
+  sha256: ee731c295a74363afae65e3268d524e3a3d8d198aaaf0b0ab6af4c0cbfd56756
+  md5: e6e98f522c89d8b02766d09468d790f3
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 83349
+  timestamp: 1695817009484
+- kind: conda
+  name: aws-c-s3
+  version: 0.3.17
+  build: hb5e3142_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.3.17-hb5e3142_3.conda
+  sha256: e2735df82153f7bc29d9d118453349b8d1fdd565e43764188af502fbcd32635a
+  md5: f0eeadc3f7fc9a29b7ce416897056826
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 86367
+  timestamp: 1695816475381
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.12
+  build: h184a658_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.12-h184a658_2.conda
+  sha256: f8cea4495d2d6c622aa65257aa24958fde6e5f5d518772036ba1fe5dfd0666ad
+  md5: ba06d81b81ec3eaf4ee83cd47f808134
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 53021
+  timestamp: 1695742870649
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.12
+  build: hd41bdd4_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.12-hd41bdd4_2.conda
+  sha256: 763f1091d0abae8ec74ffe6077788e4a558e88e0a0c9aaba69c66b88f91f9b14
+  md5: ca04a04205202fee021697f614bd59dd
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47319
+  timestamp: 1695743229851
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.12
+  build: hd5965a7_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.12-hd5965a7_2.conda
+  sha256: 029e039ff2bc526d5f31637a5525192787b3457b03cf33e479cd07641a9b5430
+  md5: 5ac1b07dec55938a5f410e04aba2e27a
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 51875
+  timestamp: 1695743449932
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.12
+  build: he70778a_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.12-he70778a_1.conda
+  sha256: 60bf0d3e7bd7bb368bbbc03f917b2a97198642ce8ed491f80c5cacbb6498c566
+  md5: a90a6413bbf361584033773c19cecb65
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48721
+  timestamp: 1691457290683
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: h184a658_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h184a658_2.conda
+  sha256: feeea13a9a15c4dd27a2244fedbe439ee7548192b21e5e6cf6c07142af5a92d1
+  md5: 10fcdbd02ba7fa0827fb8f7d94f8375b
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 50130
+  timestamp: 1695743103287
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hd41bdd4_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hd41bdd4_2.conda
+  sha256: d59f0b77d02fe275f0d758148c5705c72dfca85d97b55c9a227579eb284dd6a2
+  md5: e4d679bf261bafcf215804bcbcd63e6f
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48675
+  timestamp: 1695743318668
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hd5965a7_2
+  build_number: 2
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hd5965a7_2.conda
+  sha256: 0c9e36f6b0729e8b0507b16fd10ab01b6bf59afd99d7d3b6fa93151485ac481f
+  md5: 750eaf78f1354c70743cb15c1e2ad4ac
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 52214
+  timestamp: 1695743755136
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: he70778a_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-he70778a_1.conda
+  sha256: 52606dcecd60ccc587d3c8f100cc30b7a8101f655e8d9b26a90dac9996030f52
+  md5: 5892420ce138d63e1f6e08c9915f0308
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49182
+  timestamp: 1691457138566
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.23.0
+  build: h04fc39a_5
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.23.0-h04fc39a_5.conda
+  sha256: fdce32ae99b57e0fe9d1b52e56d4dea40c641d9bfa3b38239a9f22c69def37f7
+  md5: 9bfad48efc52d9142f7416978b960ffe
+  depends:
+  - aws-c-auth >=0.7.3,<0.7.4.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.12,<0.7.13.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.5,<0.9.6.0a0
+  - aws-c-s3 >=0.3.14,<0.3.15.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 223696
+  timestamp: 1692969704783
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.23.1
+  build: h4e3dc9b_5
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.23.1-h4e3dc9b_5.conda
+  sha256: 63d6022f15f57422243065b09d940cb7c336883bd3d581ce8d8e0a9ae19bc64d
+  md5: 327a1a3776bb737a8de1a02203b67c18
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libcxx >=15.0.7
+  license: Apache-2.0
+  license_family: Apache
+  size: 275005
+  timestamp: 1695993989586
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.23.1
+  build: h70f7a23_5
+  build_number: 5
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.23.1-h70f7a23_5.conda
+  sha256: 7b39b5bbd278838543655068f8779e538b6cd2b7931689762127082b544eea4e
+  md5: c0c9016cd7385ad14dcd575ef349c620
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 236477
+  timestamp: 1695993950546
+- kind: conda
+  name: aws-crt-cpp
+  version: 0.23.1
+  build: h94c364a_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.23.1-h94c364a_5.conda
+  sha256: 2c3af3148c4625a9f4bc8cd46b0d55f6e39f7381ee54095752c62f1c1598c24b
+  md5: 0d9257d4ebe9af80677c178f172d3c39
+  depends:
+  - aws-c-auth >=0.7.4,<0.7.5.0a0
+  - aws-c-cal >=0.6.2,<0.6.3.0a0
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.13,<0.7.14.0a0
+  - aws-c-io >=0.13.32,<0.13.33.0a0
+  - aws-c-mqtt >=0.9.6,<0.9.7.0a0
+  - aws-c-s3 >=0.3.17,<0.3.18.0a0
+  - aws-c-sdkutils >=0.1.12,<0.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 323319
+  timestamp: 1695993507703
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.10.57
+  build: h0092a47_21
+  build_number: 21
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.10.57-h0092a47_21.conda
+  sha256: b11bcb92ea37c422f3fa5939ad953a7eff10c711f2e83082351d38f1a1aad8c8
+  md5: e2e6eecb276e5faa419c1ecfc6a831b1
+  depends:
+  - aws-c-common >=0.9.0,<0.9.1.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-crt-cpp >=0.23.0,<0.23.1.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.2,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3363572
+  timestamp: 1692911449964
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.156
+  build: h02852bd_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.156-h02852bd_3.conda
+  sha256: e183eda509e1079ef8e72927c68ed3108a3006b67d8a07a39edad49dc79636e3
+  md5: 1a232e6d0c8b7ce34b0f819e072fbf7c
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: Apache
+  size: 3228453
+  timestamp: 1696018718586
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.156
+  build: h6600424_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.156-h6600424_3.conda
+  sha256: ed42d559b18025f422d4b4ae81e0574eae200c3e321b9f97e3b269a6d064994a
+  md5: 6caecdec46acbd4743807b4be6efce33
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3432093
+  timestamp: 1696017730687
+- kind: conda
+  name: aws-sdk-cpp
+  version: 1.11.156
+  build: h99d1da1_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.156-h99d1da1_3.conda
+  sha256: b757126d923fb4bf78c4d97025d0b636579a7814d319e493219e36e8f0ab8439
+  md5: c2fed554b5b634befb8849c87dc193c4
+  depends:
+  - aws-c-common >=0.9.3,<0.9.4.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - libcurl >=8.3.0,<9.0a0
+  - libcxx >=15.0.7
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 3190406
+  timestamp: 1696018395381
+- kind: conda
   name: babel
   version: 2.12.1
   build: pyhd8ed1ab_1
@@ -1813,6 +2859,26 @@ packages:
 - kind: conda
   name: blosc
   version: 1.21.5
+  build: hdccc3a2_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.5-hdccc3a2_0.conda
+  sha256: 73cee35e5366ce998ef36ccccb4c11ef9ead297886cc08269379f91539131288
+  md5: 77a5cea2ce92907b7d1e7954457a526a
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 50069
+  timestamp: 1693657396550
+- kind: conda
+  name: blosc
+  version: 1.21.5
   build: heccf04b_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/blosc-1.21.5-heccf04b_0.conda
@@ -1830,26 +2896,6 @@ packages:
   license_family: BSD
   size: 49891
   timestamp: 1693657206065
-- kind: conda
-  name: blosc
-  version: 1.21.6
-  build: h85f69ea_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-h85f69ea_0.conda
-  sha256: 1289853b41df5355f45664f1cb015c868df1f570cf743e9e4a5bda8efe8c42fa
-  md5: 2390269374fded230fcbca8332a4adc0
-  depends:
-  - libzlib >=1.3.1,<2.0a0
-  - lz4-c >=1.9.3,<1.10.0a0
-  - snappy >=1.2.0,<1.3.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 50135
-  timestamp: 1719266616208
 - kind: conda
   name: brotli
   version: 1.0.9
@@ -2196,20 +3242,6 @@ packages:
 - kind: conda
   name: c-ares
   version: 1.21.0
-  build: h10d778d_0
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.21.0-h10d778d_0.conda
-  sha256: 7450d861c07e74b10dfcf3ba680b384cf22f1c2dd34c3eba763ab5920376bf79
-  md5: 88426162f781739069a6bd178841ed5d
-  arch: x86_64
-  platform: osx
-  license: MIT
-  license_family: MIT
-  size: 108924
-  timestamp: 1698936476851
-- kind: conda
-  name: c-ares
-  version: 1.21.0
   build: hcfcfb64_0
   subdir: win-64
   url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.21.0-hcfcfb64_0.conda
@@ -2227,20 +3259,33 @@ packages:
   timestamp: 1698936959417
 - kind: conda
   name: c-ares
-  version: 1.21.0
-  build: hd590300_0
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.21.0-hd590300_0.conda
-  sha256: dfe0e81d5462fced79fd0f99edeec94c9b27268cb04238638180981af2f889f1
-  md5: c06fa0440048270817b9e3142cc661bf
+  version: 1.34.2
+  build: h32b1619_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.2-h32b1619_0.conda
+  sha256: 972d0403c92c9cd1d1c60e34d80991258125ee880cf5a9289ae83a443d8970cd
+  md5: 724edfea6dde646c1faf2ce1423e0faa
   depends:
-  - libgcc-ng >=12
-  arch: x86_64
-  platform: linux
+  - __osx >=10.13
   license: MIT
   license_family: MIT
-  size: 121680
-  timestamp: 1698936210587
+  size: 182342
+  timestamp: 1729006698430
+- kind: conda
+  name: c-ares
+  version: 1.34.2
+  build: heb4867d_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.2-heb4867d_0.conda
+  sha256: c2a515e623ac3e17a56027c06098fbd5ab47afefefbd386b4c21289f2ec55139
+  md5: 2b780c0338fc0ffa678ac82c54af51fd
+  depends:
+  - __glibc >=2.28,<3.0.a0
+  - libgcc >=13
+  license: MIT
+  license_family: MIT
+  size: 205797
+  timestamp: 1729006575652
 - kind: conda
   name: c-blosc2
   version: 2.10.0
@@ -2299,23 +3344,23 @@ packages:
   timestamp: 1712415524207
 - kind: conda
   name: c-blosc2
-  version: 2.15.1
-  build: hb461149_0
+  version: 2.14.3
+  build: h183a6f4_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.15.1-hb461149_0.conda
-  sha256: a380bc3f2bbc423fec963e9ab9284eb67deb8d3d67a0676fc3f5ccce8497685c
-  md5: a84e7df0bc9dc85a9e3db6c2870c9dcf
+  url: https://conda.anaconda.org/conda-forge/win-64/c-blosc2-2.14.3-h183a6f4_0.conda
+  sha256: 32aa27a47c96975f28fce8618d57d5d0b2a00cc4dc60836a214732fa1c0e4993
+  md5: cb3c2e859ac57ae26fe5b0b35546fda9
   depends:
   - lz4-c >=1.9.3,<1.10.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
-  - zlib-ng >=2.2.1,<2.3.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - zlib-ng >=2.0.7,<2.1.0a0
+  - zstd >=1.5.5,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 214945
-  timestamp: 1722389176912
+  size: 210505
+  timestamp: 1712415661052
 - kind: conda
   name: ca-certificates
   version: 2023.7.22
@@ -3478,6 +4523,55 @@ packages:
   size: 4021036
   timestamp: 1665674192347
 - kind: conda
+  name: gflags
+  version: 2.2.2
+  build: h5888daf_1005
+  build_number: 1005
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
+  sha256: 6c33bf0c4d8f418546ba9c250db4e4221040936aef8956353bc764d4877bc39a
+  md5: d411fc29e338efb48c5fd4576d71d881
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 119654
+  timestamp: 1726600001928
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: hac325c4_1005
+  build_number: 1005
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
+  sha256: c0bea66f71a6f4baa8d4f0248e17f65033d558d9e882c0af571b38bcca3e4b46
+  md5: a26de8814083a6971f14f9c8c3cb36c2
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 84946
+  timestamp: 1726600054963
+- kind: conda
+  name: gflags
+  version: 2.2.2
+  build: hf9b8971_1005
+  build_number: 1005
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
+  sha256: fd56ed8a1dab72ab90d8a8929b6f916a6d9220ca297ff077f8f04c5ed3408e20
+  md5: 57a511a5905caa37540eb914dfcbf1fb
+  depends:
+  - __osx >=11.0
+  - libcxx >=17
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 82090
+  timestamp: 1726600145480
+- kind: conda
   name: giflib
   version: 5.2.1
   build: h0b41bf4_3
@@ -3578,6 +4672,52 @@ packages:
   size: 100669
   timestamp: 1688694886885
 - kind: conda
+  name: glog
+  version: 0.6.0
+  build: h6da1cb0_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+  sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
+  md5: 5a570729c7709399cf8511aeeda6f989
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 97658
+  timestamp: 1649144191039
+- kind: conda
+  name: glog
+  version: 0.6.0
+  build: h6f12383_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+  sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+  md5: b31f3565cb84435407594e548a2fb7b2
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libgcc-ng >=10.3.0
+  - libstdcxx-ng >=10.3.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 114321
+  timestamp: 1649143789233
+- kind: conda
+  name: glog
+  version: 0.6.0
+  build: h8ac2a54_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+  sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+  md5: 69eb97ca709a136c53fdca1f2fd33ddf
+  depends:
+  - gflags >=2.2.2,<2.3.0a0
+  - libcxx >=12.0.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 100624
+  timestamp: 1649143914155
+- kind: conda
   name: graphite2
   version: 1.3.13
   build: h58526e2_1001
@@ -3612,71 +4752,75 @@ packages:
   timestamp: 1604365687923
 - kind: conda
   name: grpcio
-  version: 1.57.0
-  build: py310h0d4bf3c_0
+  version: 1.56.2
+  build: py310h0d4bf3c_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.57.0-py310h0d4bf3c_0.conda
-  sha256: 9bc83558d5549f1954eb8f58c935208b07fb1f8efe7521bcb9511ea402f9ff8c
-  md5: 6c00328d9d7ef79d0eb72b299b11c4da
+  url: https://conda.anaconda.org/conda-forge/osx-64/grpcio-1.56.2-py310h0d4bf3c_1.conda
+  sha256: ab9c89203aaa5e32cbfbc955ab8fdb6e36a59827f8658f072e148205f9daf082
+  md5: 07b3f0664ef56646ee40424ee7657e78
   depends:
   - __osx >=10.13
   - libcxx >=15.0.7
-  - libgrpc 1.57.0 he6801ca_0
+  - libgrpc 1.56.2 he6801ca_1
   - libzlib >=1.2.13,<2.0.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: APACHE
-  size: 720760
-  timestamp: 1691555629789
+  size: 710917
+  timestamp: 1692025409041
 - kind: conda
   name: grpcio
-  version: 1.57.0
-  build: py310h1b8f574_0
+  version: 1.56.2
+  build: py310h1b8f574_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.57.0-py310h1b8f574_0.conda
-  sha256: b8395d54798d3a78d8459f64cc6e7ed07cbcac5583de939da98c3d5fa41169ea
-  md5: 09604cfeaf57738389cfee793abea361
+  url: https://conda.anaconda.org/conda-forge/linux-64/grpcio-1.56.2-py310h1b8f574_1.conda
+  sha256: c2eda195f4de3210c1798439a37c075337d331ab2fe0cc9e4a6acb115a15a1ab
+  md5: 08d2538a6907851ea70d8f7cddc2f0d3
   depends:
   - libgcc-ng >=12
-  - libgrpc 1.57.0 h3905398_0
+  - libgrpc 1.56.2 h3905398_1
   - libstdcxx-ng >=12
   - libzlib >=1.2.13,<2.0.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: APACHE
-  size: 776889
-  timestamp: 1691554371116
+  size: 764791
+  timestamp: 1692023633876
 - kind: conda
   name: grpcio
-  version: 1.57.0
-  build: py310h95b248a_0
+  version: 1.56.2
+  build: py310h95b248a_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.57.0-py310h95b248a_0.conda
-  sha256: 6bb0fa69336e4aabda112a0fbe852968ee811cf9ca52048579b1fb02a49eba02
-  md5: 607c040e411cc7c54d67f235140f1484
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/grpcio-1.56.2-py310h95b248a_1.conda
+  sha256: f1b22c8492fcbb41021e909c75786a6c864eb29115098076a8af0a5efe45288e
+  md5: ed8ce58613462ac09ebe53a3606a74d5
   depends:
   - libcxx >=15.0.7
-  - libgrpc 1.57.0 h9075ed4_0
+  - libgrpc 1.56.2 h9075ed4_1
   - libzlib >=1.2.13,<2.0.0a0
   - python >=3.10,<3.11.0a0
   - python >=3.10,<3.11.0a0 *_cpython
   - python_abi 3.10.* *_cp310
   license: Apache-2.0
   license_family: APACHE
-  size: 703519
-  timestamp: 1691555367514
+  size: 695887
+  timestamp: 1692025592968
 - kind: conda
   name: grpcio
-  version: 1.57.0
-  build: py310hb84602e_0
+  version: 1.56.2
+  build: py310hb84602e_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.57.0-py310hb84602e_0.conda
-  sha256: a76c2ea9bbfe34de626a342bb301571513f705182f025bb1e5ee6f379a136754
-  md5: c79a99fcc156b529f5a23385bfb55333
+  url: https://conda.anaconda.org/conda-forge/win-64/grpcio-1.56.2-py310hb84602e_1.conda
+  sha256: bc0bcd5a1aa53f87ae6d2ca35f2a1b5f38145fc337c18e4e0f77bc275aa0a669
+  md5: 9a0b9fafd6453839c986d8d876ce202a
   depends:
-  - libgrpc 1.57.0 hea2d5f7_0
+  - libgrpc 1.56.2 hea2d5f7_1
   - libzlib >=1.2.13,<2.0.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
@@ -3685,8 +4829,8 @@ packages:
   - vc14_runtime >=14.29.30139
   license: Apache-2.0
   license_family: APACHE
-  size: 612997
-  timestamp: 1691555450261
+  size: 607527
+  timestamp: 1692025811162
 - kind: conda
   name: h11
   version: 0.14.0
@@ -3953,24 +5097,24 @@ packages:
   timestamp: 1709943425798
 - kind: conda
   name: imagecodecs
-  version: 2024.6.1
-  build: py310h40cd1a8_2
-  build_number: 2
+  version: 2024.1.1
+  build: py310hda7f504_3
+  build_number: 3
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.6.1-py310h40cd1a8_2.conda
-  sha256: e9219ddb4c00a4bab6278219b17dcfacf8a66f085e40f62fd67b5ea86a99be50
-  md5: b25b6a978244e40c1c73c9881df33a02
+  url: https://conda.anaconda.org/conda-forge/win-64/imagecodecs-2024.1.1-py310hda7f504_3.conda
+  sha256: 9f5fc6486ae2e1c15280f220998dbc4e8dce4957796bb9d3be47facbd86d2e0f
+  md5: 7283584a831c8cd864181437d8ea9709
   depends:
   - blosc >=1.21.5,<2.0a0
   - bzip2 >=1.0.8,<2.0a0
-  - c-blosc2 >=2.15.0,<2.16.0a0
+  - c-blosc2 >=2.13.2,<2.14.4.0a0
   - charls >=2.4.2,<2.5.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - giflib >=5.2.1,<5.3.0a0
   - jxrlib >=1.1,<1.2.0a0
   - lcms2 >=2.16,<3.0a0
   - lerc >=4.0.0,<5.0a0
   - libaec >=1.1.3,<2.0a0
-  - libavif16 >=1.0.4,<2.0a0
+  - libavif >=1.0.1,<1.0.2.0a0
   - libbrotlicommon >=1.1.0,<1.2.0a0
   - libbrotlidec >=1.1.0,<1.2.0a0
   - libbrotlienc >=1.1.0,<1.2.0a0
@@ -3978,25 +5122,25 @@ packages:
   - libjpeg-turbo >=3.0.0,<4.0a0
   - libpng >=1.6.43,<1.7.0a0
   - libtiff >=4.6.0,<4.8.0a0
-  - libwebp-base >=1.4.0,<2.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libwebp-base >=1.3.2,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
   - libzopfli >=1.0.3,<1.1.0a0
   - lz4-c >=1.9.3,<1.10.0a0
-  - numpy >=1.19,<3
+  - numpy >=1.22.4,<2.0a0
   - openjpeg >=2.5.2,<3.0a0
   - python >=3.10,<3.11.0a0
   - python_abi 3.10.* *_cp310
-  - snappy >=1.2.0,<1.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   - xz >=5.2.6,<6.0a0
   - zfp >=1.0.1,<2.0a0
-  - zstd >=1.5.6,<1.6.0a0
+  - zstd >=1.5.5,<1.6.0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 1581531
-  timestamp: 1719237014473
+  size: 1579418
+  timestamp: 1711243735862
 - kind: conda
   name: imageio
   version: 2.31.1
@@ -5646,6 +6790,166 @@ packages:
   size: 32567
   timestamp: 1711021603471
 - kind: conda
+  name: libarrow
+  version: 13.0.0
+  build: h1ed0495_3_cpu
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-13.0.0-h1ed0495_3_cpu.conda
+  sha256: 629859e3e182c68a7500cb3197aeb3379117dfcea6e90da729d38886f6688c7c
+  md5: 4abe40cdbe46985f6d90840e58338883
+  depends:
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libgcc-ng >=12
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.56.2,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libstdcxx-ng >=12
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucx >=1.14.0,<1.15.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =13.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 27851078
+  timestamp: 1694166246163
+- kind: conda
+  name: libarrow
+  version: 13.0.0
+  build: h6e4acf5_0_cpu
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-13.0.0-h6e4acf5_0_cpu.conda
+  sha256: 826aaaa5b2e18b139330aa00d1f5bf61f0389da9e270eddfd77c54c4a4c6aa58
+  md5: ae56a47c174940e94f77877fea626429
+  depends:
+  - aws-crt-cpp >=0.23.0,<0.23.1.0a0
+  - aws-sdk-cpp >=1.10.57,<1.10.58.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libbrotlidec >=1.0.9,<1.1.0a0
+  - libbrotlienc >=1.0.9,<1.1.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.56.2,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libthrift >=0.18.1,<0.18.2.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =13.0.0
+  - parquet-cpp <0.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 17983892
+  timestamp: 1692869320462
+- kind: conda
+  name: libarrow
+  version: 13.0.0
+  build: hba3d5be_3_cpu
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-13.0.0-hba3d5be_3_cpu.conda
+  sha256: 29cfc816e479dd19a10ff84444f7aa1b0946347113700efb10422da06de42cde
+  md5: 250bd749a621453aff938e26873fb836
+  depends:
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.2.1,<9.0a0
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.56.2,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - apache-arrow-proc =*=cpu
+  - parquet-cpp <0.0a0
+  - arrow-cpp =13.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 16625414
+  timestamp: 1694167097111
+- kind: conda
+  name: libarrow
+  version: 13.0.0
+  build: hca2412d_3_cpu
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-13.0.0-hca2412d_3_cpu.conda
+  sha256: 6a3bf63ec9baff0d578aa4cd2e2f3aee7cd7aee42bf1aa75889eec55d70f06b6
+  md5: 68a4f678ba48a1d230dea777d5201c31
+  depends:
+  - aws-crt-cpp >=0.23.1,<0.23.2.0a0
+  - aws-sdk-cpp >=1.11.156,<1.11.157.0a0
+  - bzip2 >=1.0.8,<2.0a0
+  - glog >=0.6.0,<0.7.0a0
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libbrotlidec >=1.1.0,<1.2.0a0
+  - libbrotlienc >=1.1.0,<1.2.0a0
+  - libcxx >=15.0.7
+  - libgoogle-cloud >=2.12.0,<2.13.0a0
+  - libgrpc >=1.56.2,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libthrift >=0.19.0,<0.19.1.0a0
+  - libutf8proc >=2.8.0,<3.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - openssl >=3.1.2,<4.0a0
+  - orc >=1.9.0,<1.9.1.0a0
+  - re2 >=2023.3.2,<2023.3.3.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  constrains:
+  - parquet-cpp <0.0a0
+  - apache-arrow-proc =*=cpu
+  - arrow-cpp =13.0.0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 20017156
+  timestamp: 1694167350734
+- kind: conda
   name: libavif
   version: 0.11.1
   build: h9f83d30_2
@@ -5663,6 +6967,27 @@ packages:
   license_family: BSD
   size: 88849
   timestamp: 1685725242079
+- kind: conda
+  name: libavif
+  version: 1.0.1
+  build: h7a9aacb_3
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libavif-1.0.1-h7a9aacb_3.conda
+  sha256: 7a02658e292c40e1d99aa9b587a02cb5807cce7a784bd17f196a6ce74e24ced7
+  md5: 105425ab3c95efc316bb3277bbc4a75f
+  depends:
+  - aom >=3.7.0,<3.8.0a0
+  - dav1d >=1.2.1,<1.2.2.0a0
+  - rav1e >=0.6.6,<1.0a0
+  - svt-av1 >=1.7.0,<1.7.1.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 104651
+  timestamp: 1699878685050
 - kind: conda
   name: libavif16
   version: 1.0.1
@@ -5704,28 +7029,6 @@ packages:
   license_family: BSD
   size: 95735
   timestamp: 1696226088455
-- kind: conda
-  name: libavif16
-  version: 1.1.1
-  build: h4e96d62_1
-  build_number: 1
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libavif16-1.1.1-h4e96d62_1.conda
-  sha256: 503e281f3998333d423eb66ca2fa4e0a502e1b8544ade639f481c06aa41405de
-  md5: ddb3ed901b5faf1ae63b44b2464c7777
-  depends:
-  - _libavif_api >=1.1.1,<1.1.2.0a0
-  - aom >=3.9.1,<3.10.0a0
-  - dav1d >=1.2.1,<1.2.2.0a0
-  - rav1e >=0.6.6,<1.0a0
-  - svt-av1 >=2.2.1,<2.2.2.0a0
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 97779
-  timestamp: 1724672767195
 - kind: conda
   name: libblas
   version: 3.9.0
@@ -6104,6 +7407,64 @@ packages:
   size: 4984046
   timestamp: 1697485351545
 - kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: h0e60522_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcrc32c-1.1.2-h0e60522_0.tar.bz2
+  sha256: 75e60fbe436ba8a11c170c89af5213e8bec0418f88b7771ab7e3d9710b70c54e
+  md5: cd4cc2d0c610c8cb5419ccc979f2d6ce
+  depends:
+  - vc >=14.1,<15.0a0
+  - vs2015_runtime >=14.16.27012
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25694
+  timestamp: 1633684287072
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: h9c3ff4c_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcrc32c-1.1.2-h9c3ff4c_0.tar.bz2
+  sha256: fd1d153962764433fe6233f34a72cdeed5dcf8a883a85769e8295ce940b5b0c5
+  md5: c965a5aa0d5c1c37ffc62dff36e28400
+  depends:
+  - libgcc-ng >=9.4.0
+  - libstdcxx-ng >=9.4.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20440
+  timestamp: 1633683576494
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: hbdafb3b_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcrc32c-1.1.2-hbdafb3b_0.tar.bz2
+  sha256: 58477b67cc719060b5b069ba57161e20ba69b8695d154a719cb4b60caf577929
+  md5: 32bd82a6a625ea6ce090a81c3d34edeb
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 18765
+  timestamp: 1633683992603
+- kind: conda
+  name: libcrc32c
+  version: 1.1.2
+  build: he49afe7_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcrc32c-1.1.2-he49afe7_0.tar.bz2
+  sha256: 3043869ac1ee84554f177695e92f2f3c2c507b260edad38a0bf3981fce1632ff
+  md5: 23d6d5a69918a438355d7cbc4c3d54c9
+  depends:
+  - libcxx >=11.1.0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 20128
+  timestamp: 1633683906221
+- kind: conda
   name: libcups
   version: 2.3.3
   build: h4637d8d_4
@@ -6142,6 +7503,64 @@ packages:
   license_family: MIT
   size: 346914
   timestamp: 1690401885066
+- kind: conda
+  name: libcurl
+  version: 8.7.1
+  build: h726d00d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
+  sha256: 06cb1bd3bbaf905213777d6ade190ac4c7fb7a20dfe0cf901c977dbbc6cec265
+  md5: fa58e5eaa12006bc3289a71357bef167
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.1,<4.0a0
+  - zstd >=1.5.5,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 378176
+  timestamp: 1711548390530
+- kind: conda
+  name: libcurl
+  version: 8.8.0
+  build: hca28451_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_0.conda
+  sha256: 45aec0ffc6fe3fd4c0083b815aa102b8103380acc2b6714fb272d921acc68ab2
+  md5: f21c27f076a07907e70c49bb57bd0f20
+  depends:
+  - krb5 >=1.21.2,<1.22.0a0
+  - libgcc-ng >=12
+  - libnghttp2 >=1.58.0,<2.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.3.0,<4.0a0
+  - zstd >=1.5.6,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 405535
+  timestamp: 1716378550673
+- kind: conda
+  name: libcurl
+  version: 8.10.1
+  build: h1ee3ff0_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.10.1-h1ee3ff0_0.conda
+  sha256: dfbac497c4fee74f67391f9c4a40cab559468b7d04ff9fad4b404a26b5e1d5b8
+  md5: 7ead800e22ff7b4bccb73e42a8f7a0f4
+  depends:
+  - krb5 >=1.21.3,<1.22.0a0
+  - libssh2 >=1.11.0,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: curl
+  license_family: MIT
+  size: 342388
+  timestamp: 1726660508261
 - kind: conda
   name: libcxx
   version: 19.1.1
@@ -6283,6 +7702,19 @@ packages:
 - kind: conda
   name: libev
   version: '4.33'
+  build: h10d778d_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-h10d778d_2.conda
+  sha256: 0d238488564a7992942aa165ff994eca540f687753b4f0998b29b4e4d030ff43
+  md5: 899db79329439820b7e8f8de41bca902
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 106663
+  timestamp: 1702146352558
+- kind: conda
+  name: libev
+  version: '4.33'
   build: h642e427_1
   build_number: 1
   subdir: osx-arm64
@@ -6295,6 +7727,85 @@ packages:
   license_family: BSD
   size: 100668
   timestamp: 1598868103393
+- kind: conda
+  name: libev
+  version: '4.33'
+  build: hd590300_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
+  sha256: 1cd6048169fa0395af74ed5d8f1716e22c19a81a8a36f934c110ca3ad4dd27b4
+  md5: 172bf1cd1ff8629f2b1179945ed45055
+  depends:
+  - libgcc-ng >=12
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 112766
+  timestamp: 1702146165126
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: h2757513_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libevent-2.1.12-h2757513_1.conda
+  sha256: 8c136d7586259bb5c0d2b913aaadc5b9737787ae4f40e3ad1beaf96c80b919b7
+  md5: 1a109764bff3bdc7bdd84088347d71dc
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 368167
+  timestamp: 1685726248899
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: h3671451_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
+  sha256: af03882afb7a7135288becf340c2f0cf8aa8221138a9a7b108aaeb308a486da1
+  md5: 25efbd786caceef438be46da78a7b5ef
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 410555
+  timestamp: 1685726568668
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: ha90c15b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libevent-2.1.12-ha90c15b_1.conda
+  sha256: e0bd9af2a29f8dd74309c0ae4f17a7c2b8c4b89f875ff1d6540c941eefbd07fb
+  md5: e38e467e577bd193a7d5de7c2c540b04
+  depends:
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 372661
+  timestamp: 1685726378869
+- kind: conda
+  name: libevent
+  version: 2.1.12
+  build: hf998b51_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libevent-2.1.12-hf998b51_1.conda
+  sha256: 2e14399d81fb348e9d231a82ca4d816bf855206923759b69ad006ba482764131
+  md5: a1cfcc585f0c42bf8d5546bb1dfb668d
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 427426
+  timestamp: 1685725977222
 - kind: conda
   name: libexpat
   version: 2.6.3
@@ -6618,13 +8129,113 @@ packages:
   size: 460218
   timestamp: 1724801743478
 - kind: conda
-  name: libgrpc
-  version: 1.57.0
-  build: h3905398_0
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: h05652e3_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h05652e3_1.conda
+  sha256: 1b1ea2a351322f5b5444db2064032bd6ba6954711b3f097c293a3b9f9c5c8904
+  md5: 56d7dcffacd67cd1efeffc86c32e4f22
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.1.2,<9.0a0
+  - libcxx >=15.0.7
+  - libgrpc >=1.56.0,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - openssl >=3.1.1,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_1
+  license: Apache-2.0
+  license_family: Apache
+  size: 36570433
+  timestamp: 1688288627184
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: h37a168a_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-h37a168a_1.conda
+  sha256: da74766c1670824677a2dbe97da86b8ed751decc50621be86c021fdac0fc5b70
+  md5: 52442c1cd6eabf4b18a470f69ccaa6f5
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.1.2,<9.0a0
+  - libcxx >=15.0.7
+  - libgrpc >=1.56.0,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - openssl >=3.1.1,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_1
+  license: Apache-2.0
+  license_family: Apache
+  size: 32557767
+  timestamp: 1688288193643
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: h840a212_1
+  build_number: 1
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.57.0-h3905398_0.conda
-  sha256: aaf6b80d30825d94dd6cc6fa922ff7d1962e93e618ce785752d3679e97f2dd1c
-  md5: 41e2a5f193a40322c3872f28fc1a024e
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-h840a212_1.conda
+  sha256: 18d9050dced23e4b3a1e5f77956d11ef8d98bb34e007647de5a1aa0e2c099bc9
+  md5: 03c225a73835f5aa68c13e62eb360406
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.1.2,<9.0a0
+  - libgcc-ng >=12
+  - libgrpc >=1.56.0,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libstdcxx-ng >=12
+  - openssl >=3.1.1,<4.0a0
+  constrains:
+  - google-cloud-cpp 2.12.0 *_1
+  license: Apache-2.0
+  license_family: Apache
+  size: 46106632
+  timestamp: 1688284832753
+- kind: conda
+  name: libgoogle-cloud
+  version: 2.12.0
+  build: hbc1b25b_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-hbc1b25b_1.conda
+  sha256: a8bdedad9a6568f229d4111861fb3c5294febe333c24180c3a59bf02fa66ab14
+  md5: 204576c98cf2226c0423c6eeb387889e
+  depends:
+  - libabseil * cxx17*
+  - libabseil >=20230125.3,<20230126.0a0
+  - libcrc32c >=1.1.2,<1.2.0a0
+  - libcurl >=8.1.2,<9.0a0
+  - libgrpc >=1.56.0,<1.57.0a0
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - google-cloud-cpp 2.12.0 *_1
+  license: Apache-2.0
+  license_family: Apache
+  size: 13228
+  timestamp: 1688283247784
+- kind: conda
+  name: libgrpc
+  version: 1.56.2
+  build: h3905398_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.56.2-h3905398_1.conda
+  sha256: 587c14bd5969d49f3a0a94dd933efbeabe77864319306d91714905b5caa5aa35
+  md5: 0b01e6ff8002994bd4ddbffcdbec7856
   depends:
   - c-ares >=1.19.1,<2.0a0
   - libabseil * cxx17*
@@ -6636,19 +8247,20 @@ packages:
   - openssl >=3.1.2,<4.0a0
   - re2 >=2023.3.2,<2023.3.3.0a0
   constrains:
-  - grpc-cpp =1.57.0
+  - grpc-cpp =1.56.2
   license: Apache-2.0
   license_family: APACHE
-  size: 5983084
-  timestamp: 1691554161260
+  size: 6331805
+  timestamp: 1692023574803
 - kind: conda
   name: libgrpc
-  version: 1.57.0
-  build: h9075ed4_0
+  version: 1.56.2
+  build: h9075ed4_1
+  build_number: 1
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.57.0-h9075ed4_0.conda
-  sha256: f41bf9ddf126cf5dadedf8c1c85394a027aa209cdf7fac78483aba1f17b4a5a9
-  md5: 440c7e050563ec74550d90c19e26e304
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.56.2-h9075ed4_1.conda
+  sha256: 1bbc06147fe298b95a7b7dcb22db0c9f95fe7383195fa9eb05e23ca73548f225
+  md5: 7d9c580f8d0379e8b5cb7e78a357bf60
   depends:
   - c-ares >=1.19.1,<2.0a0
   - libabseil * cxx17*
@@ -6659,19 +8271,20 @@ packages:
   - openssl >=3.1.2,<4.0a0
   - re2 >=2023.3.2,<2023.3.3.0a0
   constrains:
-  - grpc-cpp =1.57.0
+  - grpc-cpp =1.56.2
   license: Apache-2.0
   license_family: APACHE
-  size: 4475402
-  timestamp: 1691555209943
+  size: 4357621
+  timestamp: 1692025115126
 - kind: conda
   name: libgrpc
-  version: 1.57.0
-  build: he6801ca_0
+  version: 1.56.2
+  build: he6801ca_1
+  build_number: 1
   subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.57.0-he6801ca_0.conda
-  sha256: 314698fe9513b3de482281df444182898b17a3321887d0a57bfed500d53e58ef
-  md5: bf367a220789d4ce93e03d44386e8bd9
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.56.2-he6801ca_1.conda
+  sha256: 26d86fe9037c5f85f68ef46710d11f94c4d1b3795ff94231892f199cd5c625cd
+  md5: 23e94509afba7c596f4e854054f4b267
   depends:
   - __osx >=10.13
   - c-ares >=1.19.1,<2.0a0
@@ -6683,19 +8296,20 @@ packages:
   - openssl >=3.1.2,<4.0a0
   - re2 >=2023.3.2,<2023.3.3.0a0
   constrains:
-  - grpc-cpp =1.57.0
+  - grpc-cpp =1.56.2
   license: Apache-2.0
   license_family: APACHE
-  size: 4353122
-  timestamp: 1691555518062
+  size: 4311474
+  timestamp: 1692025032875
 - kind: conda
   name: libgrpc
-  version: 1.57.0
-  build: hea2d5f7_0
+  version: 1.56.2
+  build: hea2d5f7_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.57.0-hea2d5f7_0.conda
-  sha256: 75acd2ea4d021b88ccee67f39e7c1d8e247d218730a8775297b791f1f2b3f5b2
-  md5: 3ba8d18d45287fc3c68b0d5cff8c85ba
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.56.2-hea2d5f7_1.conda
+  sha256: 2371c46e341052cb21b2148418f35127baf129939bb169bb5a233ecb265ca323
+  md5: 706baf79d5928afd39e7b747dc43b5ae
   depends:
   - c-ares >=1.19.1,<2.0a0
   - libabseil * cxx17*
@@ -6708,11 +8322,11 @@ packages:
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   constrains:
-  - grpc-cpp =1.57.0
+  - grpc-cpp =1.56.2
   license: Apache-2.0
   license_family: APACHE
-  size: 12938908
-  timestamp: 1691555247186
+  size: 12851376
+  timestamp: 1692025226820
 - kind: conda
   name: libhwloc
   version: 2.9.3
@@ -6969,6 +8583,48 @@ packages:
   size: 564295
   timestamp: 1677678452375
 - kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: h47da74e_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.58.0-h47da74e_1.conda
+  sha256: 1910c5306c6aa5bcbd623c3c930c440e9c77a5a019008e1487810e3c1d3716cb
+  md5: 700ac6ea6d53d5510591c4344d5c989a
+  depends:
+  - c-ares >=1.23.0,<2.0a0
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 631936
+  timestamp: 1702130036271
+- kind: conda
+  name: libnghttp2
+  version: 1.58.0
+  build: h64cf6d3_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.58.0-h64cf6d3_1.conda
+  sha256: 412fd768e787e586602f8e9ea52bf089f3460fc630f6987f0cbd89b70e9a4380
+  md5: faecc55c2a8155d9ff1c0ff9a0fef64f
+  depends:
+  - __osx >=10.9
+  - c-ares >=1.23.0,<2.0a0
+  - libcxx >=16.0.6
+  - libev >=4.33,<4.34.0a0
+  - libev >=4.33,<5.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.2.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 599736
+  timestamp: 1702130398536
+- kind: conda
   name: libnsl
   version: 2.0.1
   build: hd590300_0
@@ -6984,6 +8640,20 @@ packages:
   license_family: GPL
   size: 33408
   timestamp: 1697359010159
+- kind: conda
+  name: libnuma
+  version: 2.0.18
+  build: h4ab18f5_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.18-h4ab18f5_2.conda
+  sha256: cef7d073a3f40876e6184bb5d269a99fa72de58b1106409510f81a1cd5f3d83c
+  md5: a263760479dbc7bc1f3df12707bd90dc
+  depends:
+  - libgcc-ng >=12
+  license: LGPL-2.1-only
+  size: 43346
+  timestamp: 1714593927305
 - kind: conda
   name: libopenblas
   version: 0.3.23
@@ -7334,6 +9004,22 @@ packages:
 - kind: conda
   name: libssh2
   version: 1.11.0
+  build: h0841786_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.0-h0841786_0.conda
+  sha256: 50e47fd9c4f7bf841a11647ae7486f65220cfc988ec422a4475fe8d5a823824d
+  md5: 1f5a58e686b13bcfde88b93f547d23fe
+  depends:
+  - libgcc-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 271133
+  timestamp: 1685837707056
+- kind: conda
+  name: libssh2
+  version: 1.11.0
   build: h7a5bd25_0
   subdir: osx-arm64
   url: https://conda.anaconda.org/conda-forge/osx-arm64/libssh2-1.11.0-h7a5bd25_0.conda
@@ -7348,6 +9034,39 @@ packages:
   license_family: BSD
   size: 255610
   timestamp: 1685837894256
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: h7dfc565_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libssh2-1.11.0-h7dfc565_0.conda
+  sha256: 813fd04eed2a2d5d9c36e53c554f9c1f08e9324e2922bd60c9c52dbbed2dbcec
+  md5: dc262d03aae04fe26825062879141a41
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 266806
+  timestamp: 1685838242099
+- kind: conda
+  name: libssh2
+  version: 1.11.0
+  build: hd019ec5_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libssh2-1.11.0-hd019ec5_0.conda
+  sha256: f3886763b88f4b24265db6036535ef77b7b77ce91b1cbe588c0fbdd861eec515
+  md5: ca3a72efba692c59a90d4b9fc0dfe774
+  depends:
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 259556
+  timestamp: 1685837820566
 - kind: conda
   name: libstdcxx
   version: 14.1.0
@@ -7378,6 +9097,81 @@ packages:
   license_family: GPL
   size: 3842773
   timestamp: 1695219454837
+- kind: conda
+  name: libthrift
+  version: 0.18.1
+  build: ha061701_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libthrift-0.18.1-ha061701_2.conda
+  sha256: 4b3cbe168c7fb070a79960fd20bdc60b309d79805619ed93cdf93f71bdc88bf6
+  md5: c1a4bb91d705cc903de58a95aa35ab5b
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.1,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 329212
+  timestamp: 1685891755482
+- kind: conda
+  name: libthrift
+  version: 0.19.0
+  build: h064b379_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libthrift-0.19.0-h064b379_1.conda
+  sha256: 4346c25ef6e2ff3d0fc93074238508531188ecd0dbea6414f6cb93a7775072c4
+  md5: b152655bfad7c2374ff03be0596052b6
+  depends:
+  - libcxx >=15.0.7
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 325415
+  timestamp: 1695958330036
+- kind: conda
+  name: libthrift
+  version: 0.19.0
+  build: ha2b3283_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libthrift-0.19.0-ha2b3283_1.conda
+  sha256: 89bbc59898c827429a52315c9c0dd888ea73ab1157a8c86098aeae7d13454ac4
+  md5: d3432b9d4950e91d2fdf3bed91248ee0
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: Apache-2.0
+  license_family: APACHE
+  size: 612342
+  timestamp: 1695958519927
+- kind: conda
+  name: libthrift
+  version: 0.19.0
+  build: hb90f79a_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libthrift-0.19.0-hb90f79a_1.conda
+  sha256: 719add2cf20d144ef9962c57cd0f77178259bdb3aae1cded2e2b2b7c646092f5
+  md5: 8cdb7d41faa0260875ba92414c487e2d
+  depends:
+  - libevent >=2.1.12,<2.1.13.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 409409
+  timestamp: 1695958011498
 - kind: conda
   name: libtiff
   version: 4.5.0
@@ -7468,6 +9262,60 @@ packages:
   license: HPND
   size: 787198
   timestamp: 1711218639912
+- kind: conda
+  name: libutf8proc
+  version: 2.8.0
+  build: h166bdaf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libutf8proc-2.8.0-h166bdaf_0.tar.bz2
+  sha256: 49082ee8d01339b225f7f8c60f32a2a2c05fe3b16f31b554b4fb2c1dea237d1c
+  md5: ede4266dc02e875fe1ea77b25dd43747
+  depends:
+  - libgcc-ng >=12
+  license: MIT
+  license_family: MIT
+  size: 101070
+  timestamp: 1667316029302
+- kind: conda
+  name: libutf8proc
+  version: 2.8.0
+  build: h1a8c8d9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libutf8proc-2.8.0-h1a8c8d9_0.tar.bz2
+  sha256: a3faddac08efd930fa3a1cc254b5053b4ed9428c49a888d437bf084d403c931a
+  md5: f8c9c41a122ab3abdf8943b13f4957ee
+  license: MIT
+  license_family: MIT
+  size: 103492
+  timestamp: 1667316405233
+- kind: conda
+  name: libutf8proc
+  version: 2.8.0
+  build: h82a8f57_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/libutf8proc-2.8.0-h82a8f57_0.tar.bz2
+  sha256: 6efa83e3f2fb9acaf096a18d21d0f679d110934798348c5defc780d4b759a76c
+  md5: 076894846fe9f068f91c57d158c90cba
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vs2015_runtime >=14.29.30139
+  license: MIT
+  license_family: MIT
+  size: 104389
+  timestamp: 1667316359211
+- kind: conda
+  name: libutf8proc
+  version: 2.8.0
+  build: hb7f2c08_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libutf8proc-2.8.0-hb7f2c08_0.tar.bz2
+  sha256: 55a7f96b2802e94def207fdfe92bc52c24d705d139bb6cdb3d936cbe85e1c505
+  md5: db98dc3e58cbc11583180609c429c17d
+  license: MIT
+  license_family: MIT
+  size: 98942
+  timestamp: 1667316472080
 - kind: conda
   name: libuuid
   version: 2.38.1
@@ -9052,12 +10900,12 @@ packages:
   timestamp: 1707226187124
 - kind: conda
   name: numpy
-  version: 2.1.2
-  build: py310hb9d903e_0
+  version: 1.26.4
+  build: py310hf667824_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/numpy-2.1.2-py310hb9d903e_0.conda
-  sha256: 383409a36fa1bc5ef4ea29c980d6bac016816d7bc3b78a5c2394dc648e48eed6
-  md5: dd75b8747730f68301487421f0d19bbf
+  url: https://conda.anaconda.org/conda-forge/win-64/numpy-1.26.4-py310hf667824_0.conda
+  sha256: 20ca447a8f840c01961f2bdf0847fc7b7785a62968e867d7aa4ca8a66d70f9ad
+  md5: 93e881c391880df90e74e43a4b67c16d
   depends:
   - libblas >=3.9.0,<4.0a0
   - libcblas >=3.9.0,<4.0a0
@@ -9071,8 +10919,8 @@ packages:
   - numpy-base <0a0
   license: BSD-3-Clause
   license_family: BSD
-  size: 6562663
-  timestamp: 1728665315648
+  size: 5977469
+  timestamp: 1707226445438
 - kind: conda
   name: openjdk
   version: 20.0.0
@@ -9296,6 +11144,89 @@ packages:
   license_family: Apache
   size: 2544654
   timestamp: 1725410973572
+- kind: conda
+  name: orc
+  version: 1.9.0
+  build: h385abfd_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.0-h385abfd_1.conda
+  sha256: bfd6af35afe7b8dfcc24721f05d5e3f9e8577105429c768f423a61f0fcc65105
+  md5: 2cd5aac7ef1b4c6ac51bf521251a89b3
+  depends:
+  - libgcc-ng >=12
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libstdcxx-ng >=12
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 1020883
+  timestamp: 1688234533243
+- kind: conda
+  name: orc
+  version: 1.9.0
+  build: h858f345_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.0-h858f345_1.conda
+  sha256: d0d43507d5f651529f814ed800d37eca1abebc87d654afb9ff75b6921c85d224
+  md5: fca38d4f87f6d92751ee07189cf0f9c3
+  depends:
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 440491
+  timestamp: 1688235037695
+- kind: conda
+  name: orc
+  version: 1.9.0
+  build: hef23039_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.0-hef23039_1.conda
+  sha256: 8fc1f3cd45716559a6a875d15ed0ff06372c0e64934f63cf54450ddba2dc20f9
+  md5: 6a24a185108c2e075a0e80b300003c26
+  depends:
+  - libcxx >=15.0.7
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 441342
+  timestamp: 1688234737518
+- kind: conda
+  name: orc
+  version: 1.9.0
+  build: hf2b8f0d_1
+  build_number: 1
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.0-hf2b8f0d_1.conda
+  sha256: 05d5c8075c7b96868f056b6f38ffaf63bb9a119928f926f6913caade5b60db5e
+  md5: 2d5dfd05e0d6673662f21342caed3d0f
+  depends:
+  - libprotobuf >=4.23.3,<4.23.4.0a0
+  - libzlib >=1.2.13,<2.0.0a0
+  - lz4-c >=1.9.3,<1.10.0a0
+  - snappy >=1.1.10,<1.2.0a0
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  - zstd >=1.5.2,<1.6.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 874908
+  timestamp: 1688234815207
 - kind: conda
   name: outcome
   version: 1.2.0
@@ -10463,6 +12394,93 @@ packages:
   size: 14551
   timestamp: 1642876055775
 - kind: conda
+  name: pyarrow
+  version: 13.0.0
+  build: py310h382c99a_0_cpu
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-13.0.0-py310h382c99a_0_cpu.conda
+  sha256: 22a2575bf616298a34a61d1d5b513e7a77e2d69a6e23d230c886495a8e5ddbac
+  md5: ba3da2d3bacf00993d827ee682d73406
+  depends:
+  - libarrow 13.0.0 h6e4acf5_0_cpu
+  - libcxx >=15.0.7
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.11.0a0 *_cpython
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3668280
+  timestamp: 1692869942766
+- kind: conda
+  name: pyarrow
+  version: 13.0.0
+  build: py310h6eef95f_3_cpu
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-13.0.0-py310h6eef95f_3_cpu.conda
+  sha256: 14a3fcabdef8e372993ad0af5074b5a39464f01e4583e46feb1f05a952778d0c
+  md5: e617083ad4d644cdd0c7fb8222448a54
+  depends:
+  - libarrow 13.0.0 hca2412d_3_cpu
+  - libcxx >=15.0.7
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 3625282
+  timestamp: 1694168931927
+- kind: conda
+  name: pyarrow
+  version: 13.0.0
+  build: py310hd0bb7c2_3_cpu
+  build_number: 3
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-13.0.0-py310hd0bb7c2_3_cpu.conda
+  sha256: 72942b7653cebfeed9889ac23b42ff5e3c374c1c14885670c62cabcc5e35edec
+  md5: b3d1f6c2d4b44299bd7762b79651dd17
+  depends:
+  - libarrow 13.0.0 hba3d5be_3_cpu
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 2991846
+  timestamp: 1694170082892
+- kind: conda
+  name: pyarrow
+  version: 13.0.0
+  build: py310hf9e7431_3_cpu
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-13.0.0-py310hf9e7431_3_cpu.conda
+  sha256: bec4783484feab07d9b9138ed943d452f720c2f4d5bb75b91598a2c15fd06c22
+  md5: 8d00baa18cc3a8bc986b6081c15f681c
+  depends:
+  - libarrow 13.0.0 h1ed0495_3_cpu
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  - numpy >=1.22.4,<2.0a0
+  - python >=3.10,<3.11.0a0
+  - python_abi 3.10.* *_cp310
+  constrains:
+  - apache-arrow-proc =*=cpu
+  license: Apache-2.0
+  license_family: APACHE
+  size: 4016600
+  timestamp: 1694167295169
+- kind: conda
   name: pycparser
   version: '2.21'
   build: pyhd8ed1ab_0
@@ -11394,6 +13412,23 @@ packages:
   size: 15423721
   timestamp: 1694329261357
 - kind: conda
+  name: rdma-core
+  version: '28.9'
+  build: h59595ed_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-28.9-h59595ed_1.conda
+  sha256: 832f9393ab3144ce6468c6f150db9d398fad4451e96a8879afb3059f0c9902f6
+  md5: aeffb7c06b5f65e55e6c637408dc4100
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Linux-OpenIB
+  license_family: BSD
+  size: 3735644
+  timestamp: 1684785130341
+- kind: conda
   name: re2
   version: 2023.03.02
   build: h096449b_0
@@ -11871,6 +13906,21 @@ packages:
   license: MIT
   size: 33938994
   timestamp: 1723153507938
+- kind: conda
+  name: s2n
+  version: 1.3.54
+  build: h06160fa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.3.54-h06160fa_0.conda
+  sha256: 21941b4cc007fe556ce0ec66b590f2038fecf89ce850549a8bd072ba09d1a1a7
+  md5: 149520612b92991a7de6f17550a19739
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.1.3,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 387091
+  timestamp: 1696545067741
 - kind: conda
   name: scikit-image
   version: 0.24.0
@@ -12378,20 +14428,21 @@ packages:
   timestamp: 1678534590321
 - kind: conda
   name: snappy
-  version: 1.2.1
-  build: h23299a8_0
+  version: 1.1.10
+  build: hfb803bf_1
+  build_number: 1
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.1-h23299a8_0.conda
-  sha256: 5b9450f619aabcfbf3d284a272964250b2e1971ab0f7a7ef9143dda0ecc537b8
-  md5: 7635a408509e20dcfc7653ca305ad799
+  url: https://conda.anaconda.org/conda-forge/win-64/snappy-1.1.10-hfb803bf_1.conda
+  sha256: a96f79a6ed5714ff3d2daebccdb9296a9c08394ed934ff78cec1a31dd15e29ec
+  md5: c6837784f15b2dd7a1927c4e8b8dcecd
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
   - vc14_runtime >=14.29.30139
   license: BSD-3-Clause
   license_family: BSD
-  size: 59350
-  timestamp: 1720004197144
+  size: 57651
+  timestamp: 1712591561466
 - kind: conda
   name: sniffio
   version: 1.3.0
@@ -12511,6 +14562,22 @@ packages:
 - kind: conda
   name: svt-av1
   version: 1.7.0
+  build: h63175ca_0
+  subdir: win-64
+  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-1.7.0-h63175ca_0.conda
+  sha256: 3d52d959e9b4e4654c36d03765fb4e8dbebfc1d17f271a46033bf301737a25cc
+  md5: fe5d2314e6fc3be8f8e3e2e73c14ab02
+  depends:
+  - ucrt >=10.0.20348.0
+  - vc >=14.2,<15
+  - vc14_runtime >=14.29.30139
+  license: BSD-2-Clause
+  license_family: BSD
+  size: 2353906
+  timestamp: 1692967156046
+- kind: conda
+  name: svt-av1
+  version: 1.7.0
   build: he965462_0
   subdir: osx-64
   url: https://conda.anaconda.org/conda-forge/osx-64/svt-av1-1.7.0-he965462_0.conda
@@ -12524,22 +14591,6 @@ packages:
   license_family: BSD
   size: 2429529
   timestamp: 1692967052961
-- kind: conda
-  name: svt-av1
-  version: 2.2.1
-  build: he0c23c2_0
-  subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/svt-av1-2.2.1-he0c23c2_0.conda
-  sha256: 79985e6ea3e93f8e6a71f06dbe7ca1f5f61c1948b7a45d1d5ac7e71f46461cad
-  md5: c34bbf7ec0696702f361d1c791ed3246
-  depends:
-  - ucrt >=10.0.20348.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  license: BSD-2-Clause
-  license_family: BSD
-  size: 1704957
-  timestamp: 1724459941490
 - kind: conda
   name: symlink-exe-runtime
   version: '1.0'
@@ -13252,6 +15303,26 @@ packages:
   license_family: PROPRIETARY
   size: 1283972
   timestamp: 1666630199266
+- kind: conda
+  name: ucx
+  version: 1.14.1
+  build: h64cca9d_5
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.14.1-h64cca9d_5.conda
+  sha256: a62f3fb56849dc37270f9078e1c8ba32328bc3ba4d32cf1f7dace48b431d5abe
+  md5: 39aa3b356d10d7e5add0c540945a0944
+  depends:
+  - libgcc-ng >=12
+  - libnuma >=2.0.16,<3.0a0
+  - libstdcxx-ng >=12
+  - rdma-core >=28.9,<29.0a0
+  constrains:
+  - cuda-version >=11.2,<12
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 15210025
+  timestamp: 1695214404131
 - kind: conda
   name: uri-template
   version: 1.3.0
@@ -14825,20 +16896,20 @@ packages:
   timestamp: 1679095009343
 - kind: conda
   name: zlib-ng
-  version: 2.2.2
-  build: he0c23c2_0
+  version: 2.0.7
+  build: hcfcfb64_0
   subdir: win-64
-  url: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.2.2-he0c23c2_0.conda
-  sha256: 90c6e86dc30a1f768fd5b131464644bedd4ebd52e80e75595066cd37facf6b01
-  md5: ba337fbdf9bdfe84ed0030329069d405
+  url: https://conda.anaconda.org/conda-forge/win-64/zlib-ng-2.0.7-hcfcfb64_0.conda
+  sha256: 61a4e4c209f04d3f426213a187686262ebc2dccac9a97a0743c2ebbf6e3e3dd8
+  md5: c72bb979d406650d3a78743ff888c451
   depends:
   - ucrt >=10.0.20348.0
   - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
+  - vs2015_runtime >=14.29.30139
   license: Zlib
   license_family: Other
-  size: 108763
-  timestamp: 1726591296481
+  size: 90788
+  timestamp: 1679095380986
 - kind: conda
   name: zstd
   version: 1.5.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -132,6 +132,8 @@ ruff = ">=0.6.9,<0.7"
 mypy = ">=1.11.2,<2"
 pixi-pycharm = ">=0.0.8,<0.0.9"
 scipy = "1.14.1.*"
+pandas = ">=2.2.3,<3"
+pyarrow = ">=13.0.0,<14"
 
 # Dependencies are those required at runtime by the Python packages
 [dependencies]

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -33,6 +33,12 @@ workspace = true
 [dependencies.prost-types]
 workspace = true
 
+[dependencies.chrono-tz]
+workspace = true
+
+[dependencies.async-trait]
+workspace = true
+
 [dependencies.sqlparser]
 workspace = true
 optional = true
@@ -48,6 +54,10 @@ version = "1.6.9"
 
 [dependencies.datafusion-common]
 workspace = true
+
+[dependencies.vegafusion-dataframe]
+path = "../vegafusion-dataframe"
+version = "1.6.9"
 
 [dependencies.pyo3]
 workspace = true

--- a/vegafusion-core/src/chart_state.rs
+++ b/vegafusion-core/src/chart_state.rs
@@ -1,0 +1,236 @@
+use crate::{
+    data::dataset::VegaFusionDataset,
+    planning::{
+        apply_pre_transform::apply_pre_transform_datasets,
+        plan::SpecPlan,
+        stitch::CommPlan,
+        watch::{ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace},
+    },
+    proto::gen::{
+        pretransform::PreTransformSpecWarning,
+        tasks::{NodeValueIndex, TaskGraph, TzConfig, Variable, VariableNamespace},
+    },
+    runtime::VegaFusionRuntimeTrait,
+    spec::chart::ChartSpec,
+    task_graph::{graph::ScopedVariable, task_value::TaskValue},
+};
+use datafusion_common::ScalarValue;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+};
+use vegafusion_common::{
+    data::{scalar::ScalarValueHelpers, table::VegaFusionTable},
+    error::{Result, ResultWithContext, VegaFusionError},
+};
+
+#[derive(Clone)]
+pub struct ChartState {
+    input_spec: ChartSpec,
+    transformed_spec: ChartSpec,
+    plan: SpecPlan,
+    inline_datasets: HashMap<String, VegaFusionDataset>,
+    task_graph: Arc<Mutex<TaskGraph>>,
+    task_graph_mapping: Arc<HashMap<ScopedVariable, NodeValueIndex>>,
+    server_to_client_value_indices: Arc<HashSet<NodeValueIndex>>,
+    warnings: Vec<PreTransformSpecWarning>,
+}
+
+impl ChartState {
+    pub async fn try_new(
+        runtime: &dyn VegaFusionRuntimeTrait,
+        spec: ChartSpec,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
+        tz_config: TzConfig,
+        row_limit: Option<u32>,
+    ) -> Result<Self> {
+        let dataset_fingerprints = inline_datasets
+            .iter()
+            .map(|(k, ds)| (k.clone(), ds.fingerprint()))
+            .collect::<HashMap<_, _>>();
+
+        let plan = SpecPlan::try_new(&spec, &Default::default())?;
+
+        let task_scope = plan
+            .server_spec
+            .to_task_scope()
+            .with_context(|| "Failed to create task scope for server spec")?;
+        let tasks = plan
+            .server_spec
+            .to_tasks(&tz_config, &dataset_fingerprints)
+            .unwrap();
+        let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
+        let task_graph_mapping = task_graph.build_mapping();
+        let server_to_client_value_indices: Arc<HashSet<_>> = Arc::new(
+            plan.comm_plan
+                .server_to_client
+                .iter()
+                .map(|scoped_var| task_graph_mapping.get(scoped_var).unwrap().clone())
+                .collect(),
+        );
+
+        // Gather values of server-to-client values using query_request
+        let indices: Vec<NodeValueIndex> = plan
+            .comm_plan
+            .server_to_client
+            .iter()
+            .map(|var| task_graph_mapping.get(var).unwrap().clone())
+            .collect();
+
+        let response_task_values = runtime
+            .query_request(Arc::new(task_graph.clone()), &indices, &inline_datasets)
+            .await?;
+
+        let mut init = Vec::new();
+        for response_value in response_task_values {
+            let variable = response_value
+                .variable
+                .with_context(|| "Missing variable for response value".to_string())?;
+
+            let scope = response_value.scope;
+            let proto_value = response_value
+                .value
+                .with_context(|| "Missing value for response value".to_string())?;
+
+            let value = TaskValue::try_from(&proto_value).with_context(|| {
+                "Deserialization failed for value of response value".to_string()
+            })?;
+
+            init.push(ExportUpdateArrow {
+                namespace: ExportUpdateNamespace::try_from(variable.ns()).unwrap(),
+                name: variable.name.clone(),
+                scope,
+                value,
+            });
+        }
+
+        let (transformed_spec, warnings) =
+            apply_pre_transform_datasets(&spec, &plan, init, row_limit)?;
+
+        Ok(Self {
+            input_spec: spec,
+            transformed_spec,
+            plan,
+            inline_datasets,
+            task_graph: Arc::new(Mutex::new(task_graph)),
+            task_graph_mapping: Arc::new(task_graph_mapping),
+            server_to_client_value_indices,
+            warnings,
+        })
+    }
+
+    pub async fn update(
+        &self,
+        runtime: &dyn VegaFusionRuntimeTrait,
+        updates: Vec<ExportUpdateJSON>,
+    ) -> Result<Vec<ExportUpdateJSON>> {
+        let mut task_graph = self.task_graph.lock().map_err(|err| {
+            VegaFusionError::internal(format!("Failed to acquire task graph lock: {:?}", err))
+        })?;
+        let server_to_client = self.server_to_client_value_indices.clone();
+        let mut indices: Vec<NodeValueIndex> = Vec::new();
+        for export_update in &updates {
+            let var = match export_update.namespace {
+                ExportUpdateNamespace::Signal => Variable::new_signal(&export_update.name),
+                ExportUpdateNamespace::Data => Variable::new_data(&export_update.name),
+            };
+            let scoped_var: ScopedVariable = (var, export_update.scope.clone());
+            let node_value_index = self
+                .task_graph_mapping
+                .get(&scoped_var)
+                .with_context(|| format!("No task graph node found for {scoped_var:?}"))?
+                .clone();
+
+            let value = match export_update.namespace {
+                ExportUpdateNamespace::Signal => {
+                    TaskValue::Scalar(ScalarValue::from_json(&export_update.value)?)
+                }
+                ExportUpdateNamespace::Data => {
+                    TaskValue::Table(VegaFusionTable::from_json(&export_update.value)?)
+                }
+            };
+
+            indices.extend(task_graph.update_value(node_value_index.node_index as usize, value)?);
+        }
+
+        // Filter to update nodes in the comm plan
+        let indices: Vec<_> = indices
+            .iter()
+            .filter(|&node| server_to_client.contains(node))
+            .cloned()
+            .collect();
+
+        let cloned_task_graph = task_graph.clone();
+
+        // Drop the MutexGuard before await call to avoid warning
+        drop(task_graph);
+
+        let response_task_values = runtime
+            .query_request(
+                Arc::new(cloned_task_graph),
+                indices.as_slice(),
+                &self.inline_datasets,
+            )
+            .await?;
+
+        let mut response_updates = response_task_values
+            .into_iter()
+            .map(|response_value| {
+                let variable = response_value
+                    .variable
+                    .with_context(|| "Missing variable for response value".to_string())?;
+
+                let scope = response_value.scope;
+                let proto_value = response_value
+                    .value
+                    .with_context(|| "missing value for response value: {:?}".to_string())?;
+
+                let value = TaskValue::try_from(&proto_value).with_context(|| {
+                    "Deserialization failed for value of response value: {:?}".to_string()
+                })?;
+
+                Ok(ExportUpdateJSON {
+                    namespace: match variable.ns() {
+                        VariableNamespace::Signal => ExportUpdateNamespace::Signal,
+                        VariableNamespace::Data => ExportUpdateNamespace::Data,
+                        VariableNamespace::Scale => {
+                            return Err(VegaFusionError::internal("Unexpected scale variable"))
+                        }
+                    },
+                    name: variable.name.clone(),
+                    scope: scope.clone(),
+                    value: value.to_json()?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        // Sort for deterministic ordering
+        response_updates.sort_by_key(|update| update.name.clone());
+
+        Ok(response_updates)
+    }
+
+    pub fn get_input_spec(&self) -> &ChartSpec {
+        &self.input_spec
+    }
+
+    pub fn get_server_spec(&self) -> &ChartSpec {
+        &self.plan.server_spec
+    }
+
+    pub fn get_client_spec(&self) -> &ChartSpec {
+        &self.plan.client_spec
+    }
+
+    pub fn get_transformed_spec(&self) -> &ChartSpec {
+        &self.transformed_spec
+    }
+
+    pub fn get_comm_plan(&self) -> &CommPlan {
+        &self.plan.comm_plan
+    }
+
+    pub fn get_warnings(&self) -> &Vec<PreTransformSpecWarning> {
+        &self.warnings
+    }
+}

--- a/vegafusion-core/src/data/dataset.rs
+++ b/vegafusion-core/src/data/dataset.rs
@@ -1,8 +1,8 @@
+use crate::error::Result;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 use vegafusion_common::data::table::VegaFusionTable;
-use vegafusion_core::error::Result;
 use vegafusion_dataframe::dataframe::DataFrame;
 
 #[derive(Clone)]

--- a/vegafusion-core/src/data/mod.rs
+++ b/vegafusion-core/src/data/mod.rs
@@ -1,1 +1,2 @@
+pub mod dataset;
 pub mod tasks;

--- a/vegafusion-core/src/lib.rs
+++ b/vegafusion-core/src/lib.rs
@@ -2,11 +2,13 @@
 extern crate lazy_static;
 extern crate core;
 
+pub mod chart_state;
 pub mod data;
 pub mod expression;
 pub mod patch;
 pub mod planning;
 pub mod proto;
+pub mod runtime;
 pub mod spec;
 pub mod task_graph;
 pub mod transform;

--- a/vegafusion-core/src/planning/apply_pre_transform.rs
+++ b/vegafusion-core/src/planning/apply_pre_transform.rs
@@ -1,0 +1,129 @@
+use super::{
+    destringify_selection_datetimes::destringify_selection_datetimes,
+    plan::SpecPlan,
+    watch::{ExportUpdateArrow, ExportUpdateNamespace},
+};
+use crate::{
+    proto::gen::{
+        pretransform::{
+            pre_transform_spec_warning::WarningType, PlannerWarning,
+            PreTransformBrokenInteractivityWarning, PreTransformRowLimitWarning,
+            PreTransformSpecWarning, PreTransformUnsupportedWarning,
+        },
+        tasks::Variable,
+    },
+    spec::{chart::ChartSpec, values::MissingNullOrValue},
+};
+use serde_json::Value;
+use vegafusion_common::error::{Result, VegaFusionError};
+
+pub fn apply_pre_transform_datasets(
+    input_spec: &ChartSpec,
+    plan: &SpecPlan,
+    init: Vec<ExportUpdateArrow>,
+    row_limit: Option<u32>,
+) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
+    // Update client spec with server values
+    let mut spec = plan.client_spec.clone();
+    let mut limited_datasets: Vec<Variable> = Vec::new();
+    for export_update in init {
+        let scope = export_update.scope.clone();
+        let name = export_update.name.as_str();
+        let export_update = export_update.to_json()?;
+        match export_update.namespace {
+            ExportUpdateNamespace::Signal => {
+                let signal = spec.get_nested_signal_mut(&scope, name)?;
+                signal.value = MissingNullOrValue::Value(export_update.value);
+            }
+            ExportUpdateNamespace::Data => {
+                let data = spec.get_nested_data_mut(&scope, name)?;
+
+                // If the input dataset includes inline values and no transforms,
+                // copy the input JSON directly to avoid the case where round-tripping
+                // through Arrow homogenizes mixed type arrays.
+                // E.g. round tripping may turn [1, "two"] into ["1", "two"]
+                let input_values = input_spec
+                    .get_nested_data(&scope, name)
+                    .ok()
+                    .and_then(|data| {
+                        if data.transform.is_empty() {
+                            data.values.clone()
+                        } else {
+                            None
+                        }
+                    });
+                let value = if let Some(input_values) = input_values {
+                    input_values
+                } else if let Value::Array(values) = &export_update.value {
+                    if let Some(row_limit) = row_limit {
+                        let row_limit = row_limit as usize;
+                        if values.len() > row_limit {
+                            limited_datasets.push(export_update.to_scoped_var().0);
+                            Value::Array(Vec::from(&values[..row_limit]))
+                        } else {
+                            Value::Array(values.clone())
+                        }
+                    } else {
+                        Value::Array(values.clone())
+                    }
+                } else {
+                    return Err(VegaFusionError::internal(
+                        "Expected Data value to be an Array",
+                    ));
+                };
+
+                // Set inline value
+                // Other properties are cleared by planning process so we don't alter them here
+                data.values = Some(value);
+            }
+        }
+    }
+
+    // Destringify datetime strings in selection store datasets
+    destringify_selection_datetimes(&mut spec)?;
+
+    // Build warnings
+    let mut warnings: Vec<PreTransformSpecWarning> = Vec::new();
+
+    // Add unsupported warning (
+    if plan.comm_plan.server_to_client.is_empty() {
+        warnings.push(PreTransformSpecWarning {
+            warning_type: Some(WarningType::Unsupported(PreTransformUnsupportedWarning {})),
+        });
+    }
+
+    // Add Row Limit warning
+    if !limited_datasets.is_empty() {
+        warnings.push(PreTransformSpecWarning {
+            warning_type: Some(WarningType::RowLimit(PreTransformRowLimitWarning {
+                datasets: limited_datasets,
+            })),
+        });
+    }
+
+    // Add Broken Interactivity warning
+    if !plan.comm_plan.client_to_server.is_empty() {
+        let vars: Vec<_> = plan
+            .comm_plan
+            .client_to_server
+            .iter()
+            .map(|var| var.0.clone())
+            .collect();
+        warnings.push(PreTransformSpecWarning {
+            warning_type: Some(WarningType::BrokenInteractivity(
+                PreTransformBrokenInteractivityWarning { vars },
+            )),
+        });
+    }
+
+    // Add planner warnings
+    for planner_warning in &plan.warnings {
+        warnings.push(PreTransformSpecWarning {
+            warning_type: Some(WarningType::Planner(PlannerWarning {
+                message: planner_warning.message(),
+            })),
+        });
+    }
+
+    Ok((spec, warnings))
+}

--- a/vegafusion-core/src/planning/destringify_selection_datetimes.rs
+++ b/vegafusion-core/src/planning/destringify_selection_datetimes.rs
@@ -1,11 +1,11 @@
+use crate::error::Result;
+use crate::planning::parse_datetime::parse_datetime;
+use crate::spec::chart::{ChartSpec, MutChartVisitor};
+use crate::spec::data::DataSpec;
+use crate::spec::transform::formula::FormulaTransformSpec;
+use crate::spec::transform::TransformSpec;
 use serde_json::Value;
 use std::collections::HashSet;
-use vegafusion_core::error::Result;
-use vegafusion_core::spec::chart::{ChartSpec, MutChartVisitor};
-use vegafusion_core::spec::data::DataSpec;
-use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
-use vegafusion_core::spec::transform::TransformSpec;
-use vegafusion_datafusion_udfs::udfs::datetime::str_to_utc_timestamp::parse_datetime;
 
 /// Post pre-transform transformation that detects the use of datetime strings in
 /// Vega-Lite style selection "_store" datasets, and adds a transform to convert

--- a/vegafusion-core/src/planning/mod.rs
+++ b/vegafusion-core/src/planning/mod.rs
@@ -1,8 +1,11 @@
+pub mod apply_pre_transform;
 pub mod dependency_graph;
+pub mod destringify_selection_datetimes;
 pub mod extract;
 pub mod fuse;
 pub mod lift_facet_aggregations;
 pub mod optimize_server;
+pub mod parse_datetime;
 pub mod plan;
 pub mod projection_pushdown;
 pub mod split_domain_data;

--- a/vegafusion-core/src/planning/parse_datetime.rs
+++ b/vegafusion-core/src/planning/parse_datetime.rs
@@ -1,0 +1,324 @@
+use chrono::{
+    format::{parse, Parsed, StrftimeItems},
+    {DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc},
+};
+use regex::Regex;
+use std::sync::Arc;
+use vegafusion_common::arrow::array::{ArrayRef, StringArray, TimestampMillisecondArray};
+
+lazy_static! {
+    pub static ref ALL_STRF_DATETIME_ITEMS: Vec<StrftimeItems<'static>> = vec![
+        // ISO 8601 / RFC 3339
+        // e.g. 2001-07-08T00:34:60.026490+09:30
+        StrftimeItems::new("%Y-%m-%dT%H:%M:%S%.f%:z"),
+
+        // Like ISO 8601 with space instead of T
+        // e.g. 2001-07-08 00:34:60.026490+09:30
+        StrftimeItems::new("%Y-%m-%d %H:%M:%S%.f%:z"),
+
+        // Like ISO 8601 with space, but forward slashes in date
+        // e.g. 2001/07/08 00:34:60.026490+09:30
+        StrftimeItems::new("%Y/%m/%d %H:%M:%S%.f%:z"),
+
+        // month, day, year with slashes
+        // e.g. 2001/07/08 00:34:60.026490+09:30
+        StrftimeItems::new("%m/%d/%Y %H:%M:%S%.f%:z"),
+
+        // ctime format
+        // e.g. Sun Jul 8 00:34:60 2001
+        StrftimeItems::new("%a %b %e %T %Y"),
+
+        // e.g. 01 Jan 2012 00:00:00
+        StrftimeItems::new("%d %b %Y %T"),
+
+        // e.g. Sun, 01 Jan 2012 00:00:00
+        StrftimeItems::new("%a, %d %b %Y %T"),
+
+        // e.g. December 17, 1995 03:00:00
+        StrftimeItems::new("%B %d, %Y %T"),
+    ];
+
+    pub static ref ALL_STRF_DATE_ITEMS: Vec<StrftimeItems<'static>> = vec![
+        // // e.g. 1995/02/04
+        // StrftimeItems::new("%Y/%m/%d"),
+
+        // e.g. July 15, 2010
+        StrftimeItems::new("%B %d, %Y"),
+
+        // e.g. 01 Jan 2012
+        StrftimeItems::new("%d %b %Y"),
+    ];
+}
+
+pub fn parse_datetime(
+    date_str: &str,
+    default_input_tz: &Option<chrono_tz::Tz>,
+) -> Option<DateTime<Utc>> {
+    for strf_item in &*ALL_STRF_DATETIME_ITEMS {
+        let mut parsed = Parsed::new();
+        parse(&mut parsed, date_str, strf_item.clone()).ok();
+
+        if let Ok(datetime) = parsed.to_datetime() {
+            return Some(datetime.with_timezone(&chrono::Utc));
+        } else if let (Ok(date), Ok(time)) = (parsed.to_naive_date(), parsed.to_naive_time()) {
+            let datetime = NaiveDateTime::new(date, time);
+            if date_str.ends_with('Z') {
+                // UTC
+                if let Some(datetime) = chrono::Utc.from_local_datetime(&datetime).earliest() {
+                    return Some(datetime);
+                }
+            } else {
+                // Local
+                let local_tz = (*default_input_tz)?;
+                let dt = if let Some(dt) = local_tz.from_local_datetime(&datetime).earliest() {
+                    dt
+                } else {
+                    // Handle positive timezone transition by adding 1 hour
+                    let datetime = datetime.with_hour(datetime.hour() + 1)?;
+                    local_tz.from_local_datetime(&datetime).earliest()?
+                };
+                let dt_utc = dt.with_timezone(&chrono::Utc);
+                return Some(dt_utc);
+            }
+        }
+    }
+
+    // Try plain dates
+    if let Ok(date) = NaiveDate::parse_from_str(date_str, r#"%Y-%m-%d"#) {
+        // UTC midnight to follow JavaScript convention
+        let datetime = date.and_hms_opt(0, 0, 0).expect("Invalid date");
+        return Some(chrono::Utc.from_utc_datetime(&datetime));
+    } else {
+        for strf_item in &*ALL_STRF_DATE_ITEMS {
+            let mut parsed = Parsed::new();
+            parse(&mut parsed, date_str, strf_item.clone()).ok();
+            if let Ok(date) = parsed.to_naive_date() {
+                // Local midnight to follow JavaScript convention
+                let datetime = date.and_hms_opt(0, 0, 0).expect("Invalid date");
+                let default_input_tz = (*default_input_tz)?;
+                let datetime = default_input_tz.from_local_datetime(&datetime).earliest()?;
+                return Some(datetime.with_timezone(&chrono::Utc));
+            }
+        }
+    }
+
+    parse_datetime_fallback(date_str, default_input_tz)
+}
+
+/// Parse a more generous specification of the iso 8601 date standard
+/// Allow omission of time components
+pub fn parse_datetime_fallback(
+    date_str: &str,
+    default_input_tz: &Option<chrono_tz::Tz>,
+) -> Option<DateTime<Utc>> {
+    let mut date_tokens = [String::from(""), String::from(""), String::from("")];
+    let mut time_tokens = [
+        String::from(""),
+        String::from(""),
+        String::from(""),
+        String::from(""),
+    ];
+    let mut timezone_tokens = [String::from(""), String::from("")];
+    let mut timezone_sign = ' ';
+    let mut date_ind = 0;
+    let mut time_ind = 0;
+    let mut timezone_ind = 0;
+    let mut stage = 0;
+    let mut has_time = false;
+    let mut date_split = '-';
+
+    // tokenize date string
+    for c in date_str.trim().chars() {
+        match stage {
+            0 => {
+                // Parsing date
+                if date_ind < 2 && (c == '-' || c == '/' || c == ' ') {
+                    date_split = c;
+                    date_ind += 1;
+                } else if date_ind == 2 && (c == 'T' || c == ' ') {
+                    // Move on to time portion
+                    stage += 1;
+                } else if c.is_ascii_alphanumeric() {
+                    date_tokens[date_ind].push(c)
+                } else {
+                    return None;
+                }
+            }
+            1 => {
+                // Parsing time
+                if c.is_whitespace() {
+                    continue;
+                } else if c.is_ascii_digit() {
+                    has_time = true;
+                    time_tokens[time_ind].push(c)
+                } else if (time_ind < 2 && c == ':') || (time_ind == 2 && c == '.') {
+                    // Move on to next portion
+                    time_ind += 1;
+                } else if c == '+' || c == '-' {
+                    // Move on to time zone
+                    stage += 1;
+
+                    // Save sign of offset hour
+                    timezone_sign = c;
+                } else if c == 'Z' {
+                    // Done, UTC 0
+                    timezone_tokens[0].push('0');
+                    timezone_tokens[1].push('0');
+                    break;
+                } else {
+                    return None;
+                }
+            }
+            2 => {
+                // Parsing timezone
+                if c.is_ascii_digit() {
+                    timezone_tokens[timezone_ind].push(c)
+                } else if timezone_ind == 0 && c == ':' {
+                    timezone_ind += 1;
+                } else {
+                    // String should have ended
+                    return None;
+                }
+            }
+            _ => return None,
+        }
+    }
+
+    // determine which date token holds year, month, and date
+    let year_re = Regex::new(r"\d{4}").unwrap();
+
+    let (year, month, day, iso8601_date) = if year_re.is_match(&date_tokens[0]) {
+        // Assume YYYY-MM-DD (where '-' can also be '/' or ' ')
+        // Year parsing needs to succeed, or we fail. All other components are optional
+        let year: i32 = date_tokens[0].parse().ok()?;
+        let month: u32 = parse_month_str(&date_tokens[1]).unwrap_or(1);
+        let day: u32 = date_tokens[2].parse().unwrap_or(1);
+        (year, month, day, date_split == '-')
+    } else if year_re.is_match(&date_tokens[2]) {
+        // Assume MM/DD/YYYY (where '/' can also be '-' or ' ')
+        let year: i32 = date_tokens[2].parse().ok()?;
+        let month: u32 = parse_month_str(&date_tokens[0]).unwrap_or(1);
+        let day: u32 = date_tokens[1].parse().ok()?;
+        (year, month, day, false)
+    } else {
+        // 4-digit year may be the first of third date component
+        return None;
+    };
+
+    let hour: u32 = time_tokens[0].parse().unwrap_or(0);
+    let minute: u32 = time_tokens[1].parse().unwrap_or(0);
+    let second: u32 = time_tokens[2].parse().unwrap_or(0);
+    let milliseconds: u32 = if time_tokens[3].is_empty() {
+        0
+    } else if time_tokens[3].len() == 3 {
+        time_tokens[3].parse().ok()?
+    } else {
+        return None;
+    };
+
+    let offset = if timezone_tokens[0].is_empty() {
+        if iso8601_date && !has_time {
+            FixedOffset::east_opt(0).expect("FixedOffset::east out of bounds")
+        } else {
+            // Treat date as in local timezone
+            let local_tz = (*default_input_tz)?;
+
+            // No timezone specified, build NaiveDateTime
+            let naive_date =
+                NaiveDate::from_ymd_opt(year, month, day).expect("invalid or out-of-range date");
+            let naive_time = NaiveTime::from_hms_milli_opt(hour, minute, second, milliseconds)
+                .expect("invalid or out-of-range date");
+            let naive_datetime = NaiveDateTime::new(naive_date, naive_time);
+
+            local_tz
+                .offset_from_local_datetime(&naive_datetime)
+                .single()?
+                .fix()
+        }
+    } else {
+        let timezone_hours: i32 = timezone_tokens[0].parse().unwrap_or(0);
+        let timezone_minutes: i32 = timezone_tokens[1].parse().unwrap_or(0);
+        let time_offset_seconds = timezone_hours * 3600 + timezone_minutes * 60;
+
+        if timezone_sign == '-' {
+            FixedOffset::west_opt(time_offset_seconds).expect("FixedOffset::west out of bounds")
+        } else {
+            FixedOffset::east_opt(time_offset_seconds).expect("FixedOffset::east out of bounds")
+        }
+    };
+
+    let parsed = offset
+        .with_ymd_and_hms(year, month, day, hour, minute, second)
+        .earliest()?
+        .with_nanosecond(milliseconds * 1_000_000)?
+        .with_timezone(&chrono::Utc);
+
+    Some(parsed)
+}
+
+fn parse_month_str(month_str: &str) -> Option<u32> {
+    // try parsing as integer
+    let month_str = month_str.to_lowercase();
+    if let Ok(month) = month_str.parse::<u32>() {
+        Some(month)
+    } else if month_str.len() > 2 {
+        // Try parsing as month name
+        if "january"[..month_str.len()] == month_str {
+            Some(1)
+        } else if "february"[..month_str.len()] == month_str {
+            Some(2)
+        } else if "march"[..month_str.len()] == month_str {
+            Some(3)
+        } else if "april"[..month_str.len()] == month_str {
+            Some(4)
+        } else if "may"[..month_str.len()] == month_str {
+            Some(5)
+        } else if "june"[..month_str.len()] == month_str {
+            Some(6)
+        } else if "july"[..month_str.len()] == month_str {
+            Some(7)
+        } else if "august"[..month_str.len()] == month_str {
+            Some(8)
+        } else if "september"[..month_str.len()] == month_str {
+            Some(9)
+        } else if "october"[..month_str.len()] == month_str {
+            Some(10)
+        } else if "november"[..month_str.len()] == month_str {
+            Some(11)
+        } else if "december"[..month_str.len()] == month_str {
+            Some(12)
+        } else {
+            None
+        }
+    } else {
+        None
+    }
+}
+
+pub fn parse_datetime_to_utc_millis(
+    date_str: &str,
+    default_input_tz: &Option<chrono_tz::Tz>,
+) -> Option<i64> {
+    // Parse to datetime
+    let parsed_utc = parse_datetime(date_str, default_input_tz)?;
+
+    // Extract milliseconds
+    Some(parsed_utc.timestamp_millis())
+}
+
+pub fn datetime_strs_to_timestamp_millis(
+    date_strs: &StringArray,
+    default_input_tz: &Option<chrono_tz::Tz>,
+) -> ArrayRef {
+    let millis_array = TimestampMillisecondArray::from(
+        date_strs
+            .iter()
+            .map(|date_str| -> Option<i64> {
+                date_str
+                    .and_then(|date_str| parse_datetime_to_utc_millis(date_str, default_input_tz))
+            })
+            .collect::<Vec<Option<i64>>>(),
+    );
+
+    Arc::new(millis_array) as ArrayRef
+}

--- a/vegafusion-core/src/runtime.rs
+++ b/vegafusion-core/src/runtime.rs
@@ -1,0 +1,19 @@
+use std::{collections::HashMap, sync::Arc};
+
+use async_trait::async_trait;
+use vegafusion_common::error::Result;
+
+use crate::{
+    data::dataset::VegaFusionDataset,
+    proto::gen::tasks::{NodeValueIndex, ResponseTaskValue, TaskGraph},
+};
+
+#[async_trait]
+pub trait VegaFusionRuntimeTrait {
+    async fn query_request(
+        &self,
+        task_graph: Arc<TaskGraph>,
+        indices: &[NodeValueIndex],
+        inline_datasets: &HashMap<String, VegaFusionDataset>,
+    ) -> Result<Vec<ResponseTaskValue>>;
+}

--- a/vegafusion-dataframe/Cargo.toml
+++ b/vegafusion-dataframe/Cargo.toml
@@ -5,8 +5,9 @@ version = "1.6.9"
 edition = "2021"
 description = "VegaFusion's DataFrame and Connection traits"
 
-[dependencies]
-async-trait = "0.1.73"
+
+[dependencies.async-trait]
+workspace = true
 
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"

--- a/vegafusion-datafusion-udfs/Cargo.toml
+++ b/vegafusion-datafusion-udfs/Cargo.toml
@@ -22,6 +22,10 @@ workspace = true
 path = "../vegafusion-common"
 version = "1.6.9"
 
+[dependencies.vegafusion-core]
+path = "../vegafusion-core"
+version = "1.6.9"
+
 [dependencies.datafusion-physical-expr]
 workspace = true
 

--- a/vegafusion-datafusion-udfs/src/udfs/datetime/str_to_utc_timestamp.rs
+++ b/vegafusion-datafusion-udfs/src/udfs/datetime/str_to_utc_timestamp.rs
@@ -1,8 +1,3 @@
-use chrono::{
-    format::{parse, Parsed, StrftimeItems},
-    {DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Offset, TimeZone, Timelike, Utc},
-};
-use regex::Regex;
 use std::any::Any;
 use std::{str::FromStr, sync::Arc};
 use vegafusion_common::arrow::array::{ArrayRef, StringArray, TimestampMillisecondArray};
@@ -11,295 +6,7 @@ use vegafusion_common::datafusion_common::{DataFusionError, ScalarValue};
 use vegafusion_common::datafusion_expr::{
     ColumnarValue, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
 };
-
-lazy_static! {
-    pub static ref ALL_STRF_DATETIME_ITEMS: Vec<StrftimeItems<'static>> = vec![
-        // ISO 8601 / RFC 3339
-        // e.g. 2001-07-08T00:34:60.026490+09:30
-        StrftimeItems::new("%Y-%m-%dT%H:%M:%S%.f%:z"),
-
-        // Like ISO 8601 with space instead of T
-        // e.g. 2001-07-08 00:34:60.026490+09:30
-        StrftimeItems::new("%Y-%m-%d %H:%M:%S%.f%:z"),
-
-        // Like ISO 8601 with space, but forward slashes in date
-        // e.g. 2001/07/08 00:34:60.026490+09:30
-        StrftimeItems::new("%Y/%m/%d %H:%M:%S%.f%:z"),
-
-        // month, day, year with slashes
-        // e.g. 2001/07/08 00:34:60.026490+09:30
-        StrftimeItems::new("%m/%d/%Y %H:%M:%S%.f%:z"),
-
-        // ctime format
-        // e.g. Sun Jul 8 00:34:60 2001
-        StrftimeItems::new("%a %b %e %T %Y"),
-
-        // e.g. 01 Jan 2012 00:00:00
-        StrftimeItems::new("%d %b %Y %T"),
-
-        // e.g. Sun, 01 Jan 2012 00:00:00
-        StrftimeItems::new("%a, %d %b %Y %T"),
-
-        // e.g. December 17, 1995 03:00:00
-        StrftimeItems::new("%B %d, %Y %T"),
-    ];
-
-    pub static ref ALL_STRF_DATE_ITEMS: Vec<StrftimeItems<'static>> = vec![
-        // // e.g. 1995/02/04
-        // StrftimeItems::new("%Y/%m/%d"),
-
-        // e.g. July 15, 2010
-        StrftimeItems::new("%B %d, %Y"),
-
-        // e.g. 01 Jan 2012
-        StrftimeItems::new("%d %b %Y"),
-    ];
-}
-
-pub fn parse_datetime(
-    date_str: &str,
-    default_input_tz: &Option<chrono_tz::Tz>,
-) -> Option<DateTime<Utc>> {
-    for strf_item in &*ALL_STRF_DATETIME_ITEMS {
-        let mut parsed = Parsed::new();
-        parse(&mut parsed, date_str, strf_item.clone()).ok();
-
-        if let Ok(datetime) = parsed.to_datetime() {
-            return Some(datetime.with_timezone(&chrono::Utc));
-        } else if let (Ok(date), Ok(time)) = (parsed.to_naive_date(), parsed.to_naive_time()) {
-            let datetime = NaiveDateTime::new(date, time);
-            if date_str.ends_with('Z') {
-                // UTC
-                if let Some(datetime) = chrono::Utc.from_local_datetime(&datetime).earliest() {
-                    return Some(datetime);
-                }
-            } else {
-                // Local
-                let local_tz = (*default_input_tz)?;
-                let dt = if let Some(dt) = local_tz.from_local_datetime(&datetime).earliest() {
-                    dt
-                } else {
-                    // Handle positive timezone transition by adding 1 hour
-                    let datetime = datetime.with_hour(datetime.hour() + 1)?;
-                    local_tz.from_local_datetime(&datetime).earliest()?
-                };
-                let dt_utc = dt.with_timezone(&chrono::Utc);
-                return Some(dt_utc);
-            }
-        }
-    }
-
-    // Try plain dates
-    if let Ok(date) = NaiveDate::parse_from_str(date_str, r#"%Y-%m-%d"#) {
-        // UTC midnight to follow JavaScript convention
-        let datetime = date.and_hms_opt(0, 0, 0).expect("Invalid date");
-        return Some(chrono::Utc.from_utc_datetime(&datetime));
-    } else {
-        for strf_item in &*ALL_STRF_DATE_ITEMS {
-            let mut parsed = Parsed::new();
-            parse(&mut parsed, date_str, strf_item.clone()).ok();
-            if let Ok(date) = parsed.to_naive_date() {
-                // Local midnight to follow JavaScript convention
-                let datetime = date.and_hms_opt(0, 0, 0).expect("Invalid date");
-                let default_input_tz = (*default_input_tz)?;
-                let datetime = default_input_tz.from_local_datetime(&datetime).earliest()?;
-                return Some(datetime.with_timezone(&chrono::Utc));
-            }
-        }
-    }
-
-    parse_datetime_fallback(date_str, default_input_tz)
-}
-
-/// Parse a more generous specification of the iso 8601 date standard
-/// Allow omission of time components
-pub fn parse_datetime_fallback(
-    date_str: &str,
-    default_input_tz: &Option<chrono_tz::Tz>,
-) -> Option<DateTime<Utc>> {
-    let mut date_tokens = [String::from(""), String::from(""), String::from("")];
-    let mut time_tokens = [
-        String::from(""),
-        String::from(""),
-        String::from(""),
-        String::from(""),
-    ];
-    let mut timezone_tokens = [String::from(""), String::from("")];
-    let mut timezone_sign = ' ';
-    let mut date_ind = 0;
-    let mut time_ind = 0;
-    let mut timezone_ind = 0;
-    let mut stage = 0;
-    let mut has_time = false;
-    let mut date_split = '-';
-
-    // tokenize date string
-    for c in date_str.trim().chars() {
-        match stage {
-            0 => {
-                // Parsing date
-                if date_ind < 2 && (c == '-' || c == '/' || c == ' ') {
-                    date_split = c;
-                    date_ind += 1;
-                } else if date_ind == 2 && (c == 'T' || c == ' ') {
-                    // Move on to time portion
-                    stage += 1;
-                } else if c.is_ascii_alphanumeric() {
-                    date_tokens[date_ind].push(c)
-                } else {
-                    return None;
-                }
-            }
-            1 => {
-                // Parsing time
-                if c.is_whitespace() {
-                    continue;
-                } else if c.is_ascii_digit() {
-                    has_time = true;
-                    time_tokens[time_ind].push(c)
-                } else if (time_ind < 2 && c == ':') || (time_ind == 2 && c == '.') {
-                    // Move on to next portion
-                    time_ind += 1;
-                } else if c == '+' || c == '-' {
-                    // Move on to time zone
-                    stage += 1;
-
-                    // Save sign of offset hour
-                    timezone_sign = c;
-                } else if c == 'Z' {
-                    // Done, UTC 0
-                    timezone_tokens[0].push('0');
-                    timezone_tokens[1].push('0');
-                    break;
-                } else {
-                    return None;
-                }
-            }
-            2 => {
-                // Parsing timezone
-                if c.is_ascii_digit() {
-                    timezone_tokens[timezone_ind].push(c)
-                } else if timezone_ind == 0 && c == ':' {
-                    timezone_ind += 1;
-                } else {
-                    // String should have ended
-                    return None;
-                }
-            }
-            _ => return None,
-        }
-    }
-
-    // determine which date token holds year, month, and date
-    let year_re = Regex::new(r"\d{4}").unwrap();
-
-    let (year, month, day, iso8601_date) = if year_re.is_match(&date_tokens[0]) {
-        // Assume YYYY-MM-DD (where '-' can also be '/' or ' ')
-        // Year parsing needs to succeed, or we fail. All other components are optional
-        let year: i32 = date_tokens[0].parse().ok()?;
-        let month: u32 = parse_month_str(&date_tokens[1]).unwrap_or(1);
-        let day: u32 = date_tokens[2].parse().unwrap_or(1);
-        (year, month, day, date_split == '-')
-    } else if year_re.is_match(&date_tokens[2]) {
-        // Assume MM/DD/YYYY (where '/' can also be '-' or ' ')
-        let year: i32 = date_tokens[2].parse().ok()?;
-        let month: u32 = parse_month_str(&date_tokens[0]).unwrap_or(1);
-        let day: u32 = date_tokens[1].parse().ok()?;
-        (year, month, day, false)
-    } else {
-        // 4-digit year may be the first of third date component
-        return None;
-    };
-
-    let hour: u32 = time_tokens[0].parse().unwrap_or(0);
-    let minute: u32 = time_tokens[1].parse().unwrap_or(0);
-    let second: u32 = time_tokens[2].parse().unwrap_or(0);
-    let milliseconds: u32 = if time_tokens[3].is_empty() {
-        0
-    } else if time_tokens[3].len() == 3 {
-        time_tokens[3].parse().ok()?
-    } else {
-        return None;
-    };
-
-    let offset = if timezone_tokens[0].is_empty() {
-        if iso8601_date && !has_time {
-            FixedOffset::east_opt(0).expect("FixedOffset::east out of bounds")
-        } else {
-            // Treat date as in local timezone
-            let local_tz = (*default_input_tz)?;
-
-            // No timezone specified, build NaiveDateTime
-            let naive_date =
-                NaiveDate::from_ymd_opt(year, month, day).expect("invalid or out-of-range date");
-            let naive_time = NaiveTime::from_hms_milli_opt(hour, minute, second, milliseconds)
-                .expect("invalid or out-of-range date");
-            let naive_datetime = NaiveDateTime::new(naive_date, naive_time);
-
-            local_tz
-                .offset_from_local_datetime(&naive_datetime)
-                .single()?
-                .fix()
-        }
-    } else {
-        let timezone_hours: i32 = timezone_tokens[0].parse().unwrap_or(0);
-        let timezone_minutes: i32 = timezone_tokens[1].parse().unwrap_or(0);
-        let time_offset_seconds = timezone_hours * 3600 + timezone_minutes * 60;
-
-        if timezone_sign == '-' {
-            FixedOffset::west_opt(time_offset_seconds).expect("FixedOffset::west out of bounds")
-        } else {
-            FixedOffset::east_opt(time_offset_seconds).expect("FixedOffset::east out of bounds")
-        }
-    };
-
-    let parsed = offset
-        .with_ymd_and_hms(year, month, day, hour, minute, second)
-        .earliest()?
-        .with_nanosecond(milliseconds * 1_000_000)?
-        .with_timezone(&chrono::Utc);
-
-    Some(parsed)
-}
-
-fn parse_month_str(month_str: &str) -> Option<u32> {
-    // try parsing as integer
-    let month_str = month_str.to_lowercase();
-    if let Ok(month) = month_str.parse::<u32>() {
-        Some(month)
-    } else if month_str.len() > 2 {
-        // Try parsing as month name
-        if "january"[..month_str.len()] == month_str {
-            Some(1)
-        } else if "february"[..month_str.len()] == month_str {
-            Some(2)
-        } else if "march"[..month_str.len()] == month_str {
-            Some(3)
-        } else if "april"[..month_str.len()] == month_str {
-            Some(4)
-        } else if "may"[..month_str.len()] == month_str {
-            Some(5)
-        } else if "june"[..month_str.len()] == month_str {
-            Some(6)
-        } else if "july"[..month_str.len()] == month_str {
-            Some(7)
-        } else if "august"[..month_str.len()] == month_str {
-            Some(8)
-        } else if "september"[..month_str.len()] == month_str {
-            Some(9)
-        } else if "october"[..month_str.len()] == month_str {
-            Some(10)
-        } else if "november"[..month_str.len()] == month_str {
-            Some(11)
-        } else if "december"[..month_str.len()] == month_str {
-            Some(12)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
-}
+use vegafusion_core::planning::parse_datetime::parse_datetime;
 
 pub fn parse_datetime_to_utc_millis(
     date_str: &str,
@@ -407,38 +114,43 @@ lazy_static! {
     pub static ref STR_TO_UTC_TIMESTAMP_UDF: ScalarUDF =
         ScalarUDF::from(StrToUtcTimestampUDF::new());
 }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
 
-#[test]
-fn test_parse_datetime() {
-    let local_tz = Some(chrono_tz::Tz::America__New_York);
-    let utc = Some(chrono_tz::Tz::UTC);
-    let res = parse_datetime("2020-05-16T09:30:00+05:00", &utc).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+    #[test]
+    fn test_parse_datetime() {
+        let local_tz = Some(chrono_tz::Tz::America__New_York);
+        let utc = Some(chrono_tz::Tz::UTC);
+        let res = parse_datetime("2020-05-16T09:30:00+05:00", &utc).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
 
-    let res = parse_datetime("2020-05-16T09:30:00", &utc).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+        let res = parse_datetime("2020-05-16T09:30:00", &utc).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
 
-    let res = parse_datetime("2020-05-16T09:30:00", &local_tz).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+        let res = parse_datetime("2020-05-16T09:30:00", &local_tz).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
 
-    let res = parse_datetime("2001/02/05 06:20", &local_tz).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+        let res = parse_datetime("2001/02/05 06:20", &local_tz).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
 
-    let res = parse_datetime("2001/02/05 06:20", &utc).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+        let res = parse_datetime("2001/02/05 06:20", &utc).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
 
-    let res = parse_datetime("2000-01-01T08:00:00.000Z", &utc).unwrap();
-    let utc_res = res.with_timezone(&Utc);
-    println!("res: {res}");
-    println!("utc_res: {utc_res}");
+        let res = parse_datetime("2000-01-01T08:00:00.000Z", &utc).unwrap();
+        let utc_res = res.with_timezone(&Utc);
+        println!("res: {res}");
+        println!("utc_res: {utc_res}");
+    }
 }

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -15,9 +15,11 @@ protobuf-src = ["vegafusion-core/protobuf-src"]
 [dependencies]
 log = "0.4.17"
 env_logger = "0.10.0"
-async-trait = "0.1.73"
 uuid = "1.3.0"
 sysinfo = "0.32.0"
+
+[dependencies.async-trait]
+workspace = true
 
 [dependencies.lazy_static]
 workspace = true

--- a/vegafusion-python/src/lib.rs
+++ b/vegafusion-python/src/lib.rs
@@ -9,16 +9,18 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::{Arc, Once};
 use tokio::runtime::Runtime;
+use vegafusion_core::chart_state::ChartState as RsChartState;
 use vegafusion_core::error::{ToExternalError, VegaFusionError};
 use vegafusion_core::proto::gen::pretransform::pre_transform_extract_warning::WarningType as ExtractWarningType;
 use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType as ValueWarningType;
-use vegafusion_runtime::task_graph::runtime::{ChartState as RsChartState, VegaFusionRuntime};
+use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 
 use crate::connection::{PySqlConnection, PySqlDataset};
 use env_logger::{Builder, Target};
 use pythonize::{depythonize, pythonize};
 use serde_json::json;
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 use vegafusion_core::patch::patch_pre_transformed_spec;
 use vegafusion_core::planning::plan::{PlannerConfig, PreTransformSpecWarningSpec, SpecPlan};
 use vegafusion_core::planning::projection_pushdown::get_column_usage as rs_get_column_usage;
@@ -27,7 +29,6 @@ use vegafusion_core::proto::gen::tasks::{TzConfig, Variable};
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::task_graph::graph::ScopedVariable;
 use vegafusion_core::task_graph::task_value::TaskValue;
-use vegafusion_runtime::data::dataset::VegaFusionDataset;
 use vegafusion_runtime::tokio_runtime::TOKIO_THREAD_STACK_SIZE;
 use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 use vegafusion_sql::connection::Connection;
@@ -64,7 +65,7 @@ impl PyChartState {
         row_limit: Option<u32>,
     ) -> PyResult<Self> {
         let state = tokio_runtime.block_on(RsChartState::try_new(
-            &runtime,
+            runtime.as_ref(),
             spec,
             inline_datasets,
             tz_config,
@@ -89,7 +90,7 @@ impl PyChartState {
 
         let result_updates = py.allow_threads(|| {
             self.tokio_runtime
-                .block_on(self.state.update(&self.runtime, updates))
+                .block_on(self.state.update(self.runtime.as_ref(), updates))
         })?;
 
         let a = result_updates

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -157,9 +157,9 @@ class ChartState:
 class VegaFusionRuntime:
     def __init__(
         self,
-        cache_capacity: int,
-        memory_limit: int,
-        worker_threads: int,
+        cache_capacity: int = 64,
+        memory_limit: int | None = None,
+        worker_threads: int | None = None,
         connection: SqlConnection | None = None,
     ) -> None:
         """
@@ -190,6 +190,11 @@ class VegaFusionRuntime:
         if self._embedded_runtime is None:
             # Try to initialize an embedded runtime
             from vegafusion._vegafusion import PyVegaFusionRuntime
+
+            if self.memory_limit is None:
+                self.memory_limit = get_virtual_memory() // 2
+            if self.worker_threads is None:
+                self.worker_threads = get_cpu_count()
 
             self._embedded_runtime = PyVegaFusionRuntime(
                 self.cache_capacity,
@@ -335,7 +340,7 @@ class VegaFusionRuntime:
             columns = inline_dataset_usage.get(name)
             if isinstance(value, SqlDataset):
                 imported_inline_datasets[name] = value
-            elif pd is not None and isinstance(value, pd.DataFrame):
+            elif pd is not None and pa is not None and isinstance(value, pd.DataFrame):
                 # rename to help mypy
                 inner_value: pd.DataFrame = value
                 del value
@@ -366,7 +371,6 @@ class VegaFusionRuntime:
                             inner_value = inner_value.assign(
                                 **{col: inner_value[col].astype("string[pyarrow]")}
                             )
-
                 if self._connection is not None:
                     try:
                         # Try registering DataFrame if supported
@@ -376,7 +380,12 @@ class VegaFusionRuntime:
                         continue
                     except ValueError:
                         pass
-                imported_inline_datasets[name] = Table(inner_value)
+                if hasattr(inner_value, "__arrow_c_stream__"):
+                    # TODO: this requires pyarrow 14.0.0 or later
+                    imported_inline_datasets[name] = Table(inner_value)
+                else:
+                    # Older pandas, convert through pyarrow
+                    imported_inline_datasets[name] = Table(pa.from_pandas(inner_value))
             elif isinstance(value, dict):
                 # Let narwhals import the dict using a default backend
                 df_nw = nw.from_dict(value, native_namespace=_get_default_namespace())
@@ -887,7 +896,7 @@ class VegaFusionRuntime:
             return cast(dict[str, Any], pre_transformed_spec2)
 
     @property
-    def worker_threads(self) -> int:
+    def worker_threads(self) -> int | None:
         """
         Get the number of worker threads for the runtime.
 
@@ -1071,4 +1080,4 @@ def get_inline_column_usage(
     }
 
 
-runtime = VegaFusionRuntime(64, get_virtual_memory() // 2, get_cpu_count())
+runtime = VegaFusionRuntime(64, None, None)

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -21,7 +21,6 @@ itertools = "0.11.0"
 float-cmp = "0.9.0"
 lru = "0.11.1"
 futures = "0.3.21"
-async-trait = "0.1.73"
 async-recursion = "1.0.5"
 async-lock = "2.8.0"
 tempfile = "3.3.0"
@@ -43,6 +42,9 @@ base64 = "0.21.0"
 pixelmatch = "0.1.0"
 rgb = "0.8.32"
 lodepng = "3.6.1"
+
+[dependencies.async-trait]
+workspace = true
 
 [dependencies.lazy_static]
 workspace = true

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -20,7 +20,6 @@ num-traits = "0.2.15"
 itertools = "0.11.0"
 float-cmp = "0.9.0"
 lru = "0.11.1"
-futures = "0.3.21"
 async-recursion = "1.0.5"
 async-lock = "2.8.0"
 tempfile = "3.3.0"
@@ -34,7 +33,6 @@ reqwest-retry = "0.3.0"
 reqwest-middleware = "0.2.0"
 
 [dev-dependencies]
-futures = "0.3.21"
 futures-util = "0.3.21"
 rstest = "0.18.2"
 test-case = "3.1.0"
@@ -44,6 +42,9 @@ rgb = "0.8.32"
 lodepng = "3.6.1"
 
 [dependencies.async-trait]
+workspace = true
+
+[dependencies.futures]
 workspace = true
 
 [dependencies.lazy_static]

--- a/vegafusion-runtime/src/data/mod.rs
+++ b/vegafusion-runtime/src/data/mod.rs
@@ -1,2 +1,1 @@
-pub mod dataset;
 pub mod tasks;

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -8,11 +8,11 @@ use async_trait::async_trait;
 use datafusion_expr::{expr, lit, Expr};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 
 use std::sync::Arc;
 use tokio::io::AsyncReadExt;
 
-use crate::data::dataset::VegaFusionDataset;
 use crate::task_graph::timezone::RuntimeTzConfig;
 use crate::transform::pipeline::TransformPipelineUtils;
 

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/data/vl_selection_test.rs
@@ -18,13 +18,12 @@ use vegafusion_common::datatypes::{
     cast_to, is_float_datatype, is_integer_datatype, is_numeric_datatype, is_string_datatype,
 };
 use vegafusion_common::error::{Result, ResultWithContext, VegaFusionError};
+use vegafusion_core::planning::parse_datetime::parse_datetime;
 use vegafusion_core::proto::gen::expression::literal::Value;
 use vegafusion_core::proto::gen::{
     expression::expression::Expr as ProtoExpr, expression::Expression, expression::Literal,
 };
-use vegafusion_datafusion_udfs::udfs::datetime::str_to_utc_timestamp::{
-    parse_datetime, STR_TO_UTC_TIMESTAMP_UDF,
-};
+use vegafusion_datafusion_udfs::udfs::datetime::str_to_utc_timestamp::STR_TO_UTC_TIMESTAMP_UDF;
 use vegafusion_datafusion_udfs::udfs::datetime::utc_timestamp_to_epoch::UTC_TIMESTAMP_TO_EPOCH_MS;
 
 /// Op

--- a/vegafusion-runtime/src/lib.rs
+++ b/vegafusion-runtime/src/lib.rs
@@ -4,7 +4,6 @@ extern crate core;
 
 pub mod data;
 pub mod expression;
-pub mod pre_transform;
 pub mod signal;
 pub mod task_graph;
 pub mod tokio_runtime;

--- a/vegafusion-runtime/src/pre_transform/mod.rs
+++ b/vegafusion-runtime/src/pre_transform/mod.rs
@@ -1,1 +1,0 @@
-pub mod destringify_selection_datetimes;

--- a/vegafusion-runtime/src/signal/mod.rs
+++ b/vegafusion-runtime/src/signal/mod.rs
@@ -5,8 +5,8 @@ use crate::task_graph::task::TaskCall;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::Arc;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 
-use crate::data::dataset::VegaFusionDataset;
 use crate::task_graph::timezone::RuntimeTzConfig;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::tasks::SignalTask;

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -1,30 +1,22 @@
-use async_recursion::async_recursion;
-use std::collections::{HashMap, HashSet};
-use vegafusion_core::error::{Result, ResultWithContext, ToExternalError, VegaFusionError};
-use vegafusion_core::task_graph::task_value::TaskValue;
-
-use crate::data::dataset::VegaFusionDataset;
-use crate::pre_transform::destringify_selection_datetimes::destringify_selection_datetimes;
 use crate::task_graph::cache::VegaFusionCache;
 use crate::task_graph::task::TaskCall;
 use crate::task_graph::timezone::RuntimeTzConfig;
-use datafusion_common::ScalarValue;
+use async_recursion::async_recursion;
 use futures_util::{future, FutureExt};
 use prost::Message as ProstMessage;
-use serde_json::Value;
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::panic::AssertUnwindSafe;
-use std::sync::{Arc, Mutex};
-use vegafusion_common::data::scalar::ScalarValueHelpers;
+use std::sync::Arc;
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::error::{Result, ResultWithContext, ToExternalError, VegaFusionError};
+use vegafusion_core::planning::apply_pre_transform::apply_pre_transform_datasets;
+use vegafusion_core::planning::destringify_selection_datetimes::destringify_selection_datetimes;
 use vegafusion_core::planning::plan::{PlannerConfig, SpecPlan};
-use vegafusion_core::planning::stitch::CommPlan;
-use vegafusion_core::planning::watch::{
-    ExportUpdateArrow, ExportUpdateJSON, ExportUpdateNamespace,
-};
+use vegafusion_core::planning::watch::{ExportUpdateArrow, ExportUpdateNamespace};
 use vegafusion_core::proto::gen::errors::error::Errorkind;
 use vegafusion_core::proto::gen::errors::{Error, TaskGraphValueError};
-use vegafusion_core::proto::gen::pretransform::pre_transform_spec_warning::WarningType;
 use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType as ValuesWarningType;
 use vegafusion_core::proto::gen::pretransform::{
     pre_transform_extract_warning, PlannerWarning,
@@ -33,8 +25,7 @@ use vegafusion_core::proto::gen::pretransform::{
     PreTransformValuesRequest, PreTransformValuesResponse, PreTransformValuesWarning,
 };
 use vegafusion_core::proto::gen::pretransform::{
-    PreTransformBrokenInteractivityWarning, PreTransformRowLimitWarning, PreTransformSpecRequest,
-    PreTransformSpecResponse, PreTransformUnsupportedWarning,
+    PreTransformRowLimitWarning, PreTransformSpecRequest, PreTransformSpecResponse,
 };
 use vegafusion_core::proto::gen::services::{
     pre_transform_extract_result, pre_transform_spec_result, pre_transform_values_result,
@@ -43,11 +34,13 @@ use vegafusion_core::proto::gen::services::{
 };
 use vegafusion_core::proto::gen::tasks::{
     task::TaskKind, InlineDataset, NodeValueIndex, ResponseTaskValue, TaskGraph,
-    TaskGraphValueResponse, TaskValue as ProtoTaskValue, TzConfig, Variable, VariableNamespace,
+    TaskGraphValueResponse, TaskValue as ProtoTaskValue, TzConfig, VariableNamespace,
 };
+use vegafusion_core::runtime::VegaFusionRuntimeTrait;
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::spec::values::MissingNullOrValue;
 use vegafusion_core::task_graph::graph::ScopedVariable;
+use vegafusion_core::task_graph::task_value::TaskValue;
 use vegafusion_dataframe::connection::Connection;
 
 type CacheValue = (TaskValue, Vec<TaskValue>);
@@ -716,6 +709,60 @@ impl VegaFusionRuntime {
     }
 }
 
+#[async_trait::async_trait]
+impl VegaFusionRuntimeTrait for VegaFusionRuntime {
+    async fn query_request(
+        &self,
+        task_graph: Arc<TaskGraph>,
+        indices: &[NodeValueIndex],
+        inline_datasets: &HashMap<String, VegaFusionDataset>,
+    ) -> Result<Vec<ResponseTaskValue>> {
+        // Clone task_graph and task_graph_runtime for use in closure
+        let task_graph_runtime = self.clone();
+        let response_value_futures: Vec<_> = indices
+            .iter()
+            .map(|node_value_index| {
+                let node = task_graph
+                    .nodes
+                    .get(node_value_index.node_index as usize)
+                    .with_context(|| {
+                        format!(
+                            "Node index {} out of bounds for graph with size {}",
+                            node_value_index.node_index,
+                            task_graph.nodes.len()
+                        )
+                    })?;
+                let task = node.task();
+                let var = match node_value_index.output_index {
+                    None => task.variable().clone(),
+                    Some(output_index) => task.output_vars()[output_index as usize].clone(),
+                };
+
+                let scope = node.task().scope.clone();
+
+                // Clone task_graph and task_graph_runtime for use in closure
+                let task_graph_runtime = task_graph_runtime.clone();
+                let task_graph = task_graph.clone();
+
+                Ok(async move {
+                    let value = task_graph_runtime
+                        .clone()
+                        .get_node_value(task_graph, node_value_index, inline_datasets.clone())
+                        .await?;
+
+                    Ok::<_, VegaFusionError>(ResponseTaskValue {
+                        variable: Some(var),
+                        scope,
+                        value: Some(ProtoTaskValue::try_from(&value).unwrap()),
+                    })
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        future::try_join_all(response_value_futures).await
+    }
+}
+
 #[async_recursion]
 async fn get_or_compute_node_value(
     task_graph: Arc<TaskGraph>,
@@ -788,315 +835,5 @@ async fn get_or_compute_node_value(
         // get or construct from cache
 
         cache.get_or_try_insert_with(cache_key, fut).await
-    }
-}
-
-fn apply_pre_transform_datasets(
-    input_spec: &ChartSpec,
-    plan: &SpecPlan,
-    init: Vec<ExportUpdateArrow>,
-    row_limit: Option<u32>,
-) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
-    // Update client spec with server values
-    let mut spec = plan.client_spec.clone();
-    let mut limited_datasets: Vec<Variable> = Vec::new();
-    for export_update in init {
-        let scope = export_update.scope.clone();
-        let name = export_update.name.as_str();
-        let export_update = export_update.to_json()?;
-        match export_update.namespace {
-            ExportUpdateNamespace::Signal => {
-                let signal = spec.get_nested_signal_mut(&scope, name)?;
-                signal.value = MissingNullOrValue::Value(export_update.value);
-            }
-            ExportUpdateNamespace::Data => {
-                let data = spec.get_nested_data_mut(&scope, name)?;
-
-                // If the input dataset includes inline values and no transforms,
-                // copy the input JSON directly to avoid the case where round-tripping
-                // through Arrow homogenizes mixed type arrays.
-                // E.g. round tripping may turn [1, "two"] into ["1", "two"]
-                let input_values = input_spec
-                    .get_nested_data(&scope, name)
-                    .ok()
-                    .and_then(|data| {
-                        if data.transform.is_empty() {
-                            data.values.clone()
-                        } else {
-                            None
-                        }
-                    });
-                let value = if let Some(input_values) = input_values {
-                    input_values
-                } else if let Value::Array(values) = &export_update.value {
-                    if let Some(row_limit) = row_limit {
-                        let row_limit = row_limit as usize;
-                        if values.len() > row_limit {
-                            limited_datasets.push(export_update.to_scoped_var().0);
-                            Value::Array(Vec::from(&values[..row_limit]))
-                        } else {
-                            Value::Array(values.clone())
-                        }
-                    } else {
-                        Value::Array(values.clone())
-                    }
-                } else {
-                    return Err(VegaFusionError::internal(
-                        "Expected Data value to be an Array",
-                    ));
-                };
-
-                // Set inline value
-                // Other properties are cleared by planning process so we don't alter them here
-                data.values = Some(value);
-            }
-        }
-    }
-
-    // Destringify datetime strings in selection store datasets
-    destringify_selection_datetimes(&mut spec)?;
-
-    // Build warnings
-    let mut warnings: Vec<PreTransformSpecWarning> = Vec::new();
-
-    // Add unsupported warning (
-    if plan.comm_plan.server_to_client.is_empty() {
-        warnings.push(PreTransformSpecWarning {
-            warning_type: Some(WarningType::Unsupported(PreTransformUnsupportedWarning {})),
-        });
-    }
-
-    // Add Row Limit warning
-    if !limited_datasets.is_empty() {
-        warnings.push(PreTransformSpecWarning {
-            warning_type: Some(WarningType::RowLimit(PreTransformRowLimitWarning {
-                datasets: limited_datasets,
-            })),
-        });
-    }
-
-    // Add Broken Interactivity warning
-    if !plan.comm_plan.client_to_server.is_empty() {
-        let vars: Vec<_> = plan
-            .comm_plan
-            .client_to_server
-            .iter()
-            .map(|var| var.0.clone())
-            .collect();
-        warnings.push(PreTransformSpecWarning {
-            warning_type: Some(WarningType::BrokenInteractivity(
-                PreTransformBrokenInteractivityWarning { vars },
-            )),
-        });
-    }
-
-    // Add planner warnings
-    for planner_warning in &plan.warnings {
-        warnings.push(PreTransformSpecWarning {
-            warning_type: Some(WarningType::Planner(PlannerWarning {
-                message: planner_warning.message(),
-            })),
-        });
-    }
-
-    Ok((spec, warnings))
-}
-
-#[derive(Clone)]
-pub struct ChartState {
-    input_spec: ChartSpec,
-    transformed_spec: ChartSpec,
-    plan: SpecPlan,
-    inline_datasets: HashMap<String, VegaFusionDataset>,
-    task_graph: Arc<Mutex<TaskGraph>>,
-    task_graph_mapping: Arc<HashMap<ScopedVariable, NodeValueIndex>>,
-    server_to_client_value_indices: Arc<HashSet<NodeValueIndex>>,
-    warnings: Vec<PreTransformSpecWarning>,
-}
-
-impl ChartState {
-    pub async fn try_new(
-        runtime: &VegaFusionRuntime,
-        spec: ChartSpec,
-        inline_datasets: HashMap<String, VegaFusionDataset>,
-        tz_config: TzConfig,
-        row_limit: Option<u32>,
-    ) -> Result<Self> {
-        let dataset_fingerprints = inline_datasets
-            .iter()
-            .map(|(k, ds)| (k.clone(), ds.fingerprint()))
-            .collect::<HashMap<_, _>>();
-
-        let plan = SpecPlan::try_new(&spec, &Default::default())?;
-
-        let task_scope = plan
-            .server_spec
-            .to_task_scope()
-            .with_context(|| "Failed to create task scope for server spec")?;
-        let tasks = plan
-            .server_spec
-            .to_tasks(&tz_config, &dataset_fingerprints)
-            .unwrap();
-        let task_graph = TaskGraph::new(tasks, &task_scope).unwrap();
-        let task_graph_mapping = task_graph.build_mapping();
-        let server_to_client_value_indices: Arc<HashSet<_>> = Arc::new(
-            plan.comm_plan
-                .server_to_client
-                .iter()
-                .map(|scoped_var| task_graph_mapping.get(scoped_var).unwrap().clone())
-                .collect(),
-        );
-
-        // Gather values of server-to-client values
-        let mut init = Vec::new();
-        for var in &plan.comm_plan.server_to_client {
-            let node_index = task_graph_mapping
-                .get(var)
-                .with_context(|| format!("Failed to lookup variable '{var:?}'"))?;
-            let value = runtime
-                .get_node_value(
-                    Arc::new(task_graph.clone()),
-                    node_index,
-                    inline_datasets.clone(),
-                )
-                .await
-                .with_context(|| "Failed to get node value")?;
-
-            init.push(ExportUpdateArrow {
-                namespace: ExportUpdateNamespace::try_from(var.0.namespace()).unwrap(),
-                name: var.0.name.clone(),
-                scope: var.1.clone(),
-                value,
-            });
-        }
-
-        let (transformed_spec, warnings) =
-            apply_pre_transform_datasets(&spec, &plan, init, row_limit)?;
-
-        Ok(Self {
-            input_spec: spec,
-            transformed_spec,
-            plan,
-            inline_datasets,
-            task_graph: Arc::new(Mutex::new(task_graph)),
-            task_graph_mapping: Arc::new(task_graph_mapping),
-            server_to_client_value_indices,
-            warnings,
-        })
-    }
-
-    pub async fn update(
-        &self,
-        runtime: &VegaFusionRuntime,
-        updates: Vec<ExportUpdateJSON>,
-    ) -> Result<Vec<ExportUpdateJSON>> {
-        let mut task_graph = self.task_graph.lock().map_err(|err| {
-            VegaFusionError::internal(format!("Failed to acquire task graph lock: {:?}", err))
-        })?;
-        let server_to_client = self.server_to_client_value_indices.clone();
-        let mut indices: Vec<NodeValueIndex> = Vec::new();
-        for export_update in &updates {
-            let var = match export_update.namespace {
-                ExportUpdateNamespace::Signal => Variable::new_signal(&export_update.name),
-                ExportUpdateNamespace::Data => Variable::new_data(&export_update.name),
-            };
-            let scoped_var: ScopedVariable = (var, export_update.scope.clone());
-            let node_value_index = self
-                .task_graph_mapping
-                .get(&scoped_var)
-                .with_context(|| format!("No task graph node found for {scoped_var:?}"))?
-                .clone();
-
-            let value = match export_update.namespace {
-                ExportUpdateNamespace::Signal => {
-                    TaskValue::Scalar(ScalarValue::from_json(&export_update.value)?)
-                }
-                ExportUpdateNamespace::Data => {
-                    TaskValue::Table(VegaFusionTable::from_json(&export_update.value)?)
-                }
-            };
-
-            indices.extend(task_graph.update_value(node_value_index.node_index as usize, value)?);
-        }
-
-        // Filter to update nodes in the comm plan
-        let indices: Vec<_> = indices
-            .iter()
-            .filter(|&node| server_to_client.contains(node))
-            .cloned()
-            .collect();
-
-        let cloned_task_graph = task_graph.clone();
-
-        // Drop the MutexGuard before await call to avoid warning
-        drop(task_graph);
-
-        let response_task_values = runtime
-            .query_request(
-                Arc::new(cloned_task_graph),
-                indices.as_slice(),
-                &self.inline_datasets,
-            )
-            .await?;
-
-        let mut response_updates = response_task_values
-            .into_iter()
-            .map(|response_value| {
-                let variable = response_value
-                    .variable
-                    .with_context(|| "Missing variable for response value".to_string())?;
-
-                let scope = response_value.scope;
-                let proto_value = response_value
-                    .value
-                    .with_context(|| "missing value for response value: {:?}".to_string())?;
-
-                let value = TaskValue::try_from(&proto_value).with_context(|| {
-                    "Deserialization failed for value of response value: {:?}".to_string()
-                })?;
-
-                Ok(ExportUpdateJSON {
-                    namespace: match variable.ns() {
-                        VariableNamespace::Signal => ExportUpdateNamespace::Signal,
-                        VariableNamespace::Data => ExportUpdateNamespace::Data,
-                        VariableNamespace::Scale => {
-                            return Err(VegaFusionError::internal("Unexpected scale variable"))
-                        }
-                    },
-                    name: variable.name.clone(),
-                    scope: scope.clone(),
-                    value: value.to_json()?,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-
-        // Sort for deterministic ordering
-        response_updates.sort_by_key(|update| update.name.clone());
-
-        Ok(response_updates)
-    }
-
-    pub fn get_input_spec(&self) -> &ChartSpec {
-        &self.input_spec
-    }
-
-    pub fn get_server_spec(&self) -> &ChartSpec {
-        &self.plan.server_spec
-    }
-
-    pub fn get_client_spec(&self) -> &ChartSpec {
-        &self.plan.client_spec
-    }
-
-    pub fn get_transformed_spec(&self) -> &ChartSpec {
-        &self.transformed_spec
-    }
-
-    pub fn get_comm_plan(&self) -> &CommPlan {
-        &self.plan.comm_plan
-    }
-
-    pub fn get_warnings(&self) -> &Vec<PreTransformSpecWarning> {
-        &self.warnings
     }
 }

--- a/vegafusion-runtime/src/task_graph/task.rs
+++ b/vegafusion-runtime/src/task_graph/task.rs
@@ -1,9 +1,9 @@
-use crate::data::dataset::VegaFusionDataset;
 use crate::task_graph::timezone::RuntimeTzConfig;
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::sync::Arc;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::tasks::task::TaskKind;
 use vegafusion_core::proto::gen::tasks::Task;

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -9,10 +9,11 @@ mod tests {
     use serde_json::json;
     use std::fs;
     use std::sync::Arc;
+    use vegafusion_core::chart_state::ChartState;
     use vegafusion_core::planning::watch::{ExportUpdateJSON, ExportUpdateNamespace};
     use vegafusion_core::proto::gen::tasks::TzConfig;
     use vegafusion_core::spec::chart::ChartSpec;
-    use vegafusion_runtime::task_graph::runtime::{ChartState, VegaFusionRuntime};
+    use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
     use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 
     #[tokio::test]

--- a/vegafusion-runtime/tests/test_pre_transform_values.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_values.rs
@@ -23,11 +23,11 @@ mod tests {
     use std::sync::Arc;
     use vegafusion_common::data::table::VegaFusionTable;
     use vegafusion_common::error::VegaFusionError;
+    use vegafusion_core::data::dataset::VegaFusionDataset;
     use vegafusion_core::proto::gen::pretransform::pre_transform_values_warning::WarningType;
     use vegafusion_core::proto::gen::tasks::Variable;
     use vegafusion_core::spec::chart::ChartSpec;
     use vegafusion_core::spec::values::StringOrSignalSpec;
-    use vegafusion_runtime::data::dataset::VegaFusionDataset;
     use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
     use vegafusion_sql::connection::datafusion_conn::DataFusionConnection;
 

--- a/vegafusion-sql/Cargo.toml
+++ b/vegafusion-sql/Cargo.toml
@@ -20,7 +20,6 @@ datafusion-conn = [
 ]
 
 [dependencies]
-async-trait = "0.1.73"
 deterministic-hash = "1.0.1"
 log = "0.4.17"
 uuid = "1.4.1"
@@ -31,6 +30,9 @@ rstest_reuse = "0.6.0"
 toml = "0.7.2"
 
 [dev-dependencies.lazy_static]
+workspace = true
+
+[dependencies.async-trait]
 workspace = true
 
 [dependencies.chrono]

--- a/vegafusion-wasm/Cargo.toml
+++ b/vegafusion-wasm/Cargo.toml
@@ -18,6 +18,7 @@ wasm-bindgen-futures = "0.4.28"
 js-sys = "0.3.55"
 indexmap = "1.9.2"
 
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 
@@ -25,6 +26,9 @@ wasm-bindgen-test = "0.3.13"
 workspace = true
 
 [dependencies.prost-types]
+workspace = true
+
+[dependencies.futures]
 workspace = true
 
 [dependencies.vegafusion-common]
@@ -58,6 +62,9 @@ optional = true
 [dependencies.web-sys]
 version = "0.3.55"
 features = ["Document", "Element", "HtmlElement", "Node", "Window"]
+
+[dependencies.async-trait]
+workspace = true
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = ["-Os"]

--- a/vegafusion-wasm/js/vega_utils.js
+++ b/vegafusion-wasm/js/vega_utils.js
@@ -123,7 +123,7 @@ function trap(view, fn) {
 
 // Other utility functions
 export function make_grpc_send_message_fn(client, hostname) {
-    let send_message_grpc = (send_msg_bytes, receiver) => {
+    let send_message_grpc = async (send_msg_bytes, receiver) => {
         let grpc_route = '/services.VegaFusionRuntime/TaskGraphQuery'
 
         // Make custom MethodDescriptor that does not perform serialization
@@ -136,15 +136,12 @@ export function make_grpc_send_message_fn(client, hostname) {
             (v) => v,
         );
 
-        let promise = client.unaryCall(
+        return await client.unaryCall(
             hostname + grpc_route,
             send_msg_bytes,
             {},
             methodDescriptor,
-        );
-        promise.then((response) => {
-            receiver.receive(response)
-        })
+        )
     }
     return send_message_grpc
 }


### PR DESCRIPTION
Ok, I took another stab a refactoring so that vegafusion-wasm can use the ChartState structure.  This de-duplicates the state management logic. Implementing the `VegaFusionRuntimeTrait` using a JavaScript function was a bit tricky due to JS functions not being Send/Sync, but in the end it works well.

I also added an example that exercises vegafusion-wasm and vegafusion-embed, connected to vegafusion-server.  The first two aren't used by VegaFusionWidget anymore, so we didn't have a way of trying them