### PR TITLE
perf: use Narwhals expressions (and stable API)

### DIFF
--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -566,12 +566,12 @@ class VegaFusionRuntime:
                     "transformed data"
                 )
 
-        # Localize datetime columns to UTC, then extract the native DataFrame
-        # to return
+        # Convert to `local_tz` (or, set to UTC and then convert if starting
+        # from time-zone-naive data), then extract the native DataFrame to return.
         processed_datasets = []
         for df in nw_dataframes:
             df = df.with_columns(
-                nw.col(col).dt.replace_time_zone("UTC").dt.convert_time_zone(local_tz)
+                nw.col(col).dt.convert_time_zone(local_tz)
                 for col, dtype in df.schema.items()
                 if dtype == nw.Datetime
             )

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -4,7 +4,7 @@ import sys
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union, cast
 
-import narwhals as nw
+import narwhals.stable.v1 as nw
 from arro3.core import Table
 
 from vegafusion._vegafusion import get_cpu_count, get_virtual_memory
@@ -570,14 +570,11 @@ class VegaFusionRuntime:
         # to return
         processed_datasets = []
         for df in nw_dataframes:
-            for name in df.columns:
-                dtype = df[name].dtype
-                if dtype == nw.Datetime:
-                    df = df.with_columns(
-                        df[name]
-                        .dt.replace_time_zone("UTC")
-                        .dt.convert_time_zone(local_tz)
-                    )
+            df = df.with_columns(
+                nw.col(col).dt.replace_time_zone("UTC").dt.convert_time_zone(local_tz)
+                for col, dtype in df.schema.items()
+                if dtype == nw.Datetime
+            )
             processed_datasets.append(df.to_native())
 
         return processed_datasets, warnings


### PR DESCRIPTION
Hey, this does a couple of things:
- refactors the loop to use expressions, as that'll make the most out of backends like Polars (which, even with eager dataframes, can perform some optimisations when you use expressions as opposed to Series)
- uses the `narwhals.stable.v1` api (see https://github.com/vega/altair/pull/3670 for an example of where it ended up being really useful)