### PR TITLE
v2-chore: Cleanup toward v2 release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,0 @@
-# Pin third-part actions
-For improved security, third-party GitHub actions are pinned using [pin-github-action](https://github.com/mheap/pin-github-action). To add pins:
-
-```
-GH_ADMIN_TOKEN={token} pin-github-action .github/workflows/build.yml
-```

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -57,7 +57,7 @@ jobs:
           pixi run test-rs --release
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4
-        if: always()
+        if: failure()
         with:
           name: vegafusion-rt-test-images-${{ matrix.os }}
           path: |
@@ -298,7 +298,7 @@ jobs:
         run: pytest
       - name: Upload test artifacts
         uses: actions/upload-artifact@v4.4.3
-        if: always()
+        if: failure()
         with:
           name: vegafusion-python-test-failures
           path: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -317,7 +317,7 @@ jobs:
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@v4.1.8
         with:
-          name: python-wheels-osx-64
+          name: python-wheels-osx-arm64
           path: target/wheels/
       - name: install wheels
         working-directory: target/wheels/

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build wheels (Linux)
-        uses: messense/maturin-action@v1.45
+        uses: messense/maturin-action@v1.45.0
         with:
           command: build
           manylinux: 2014
@@ -150,7 +150,7 @@ jobs:
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build arm64 wheels
-        uses: messense/maturin-action@v1.45
+        uses: messense/maturin-action@v1.45.0
         with:
           command: build
           manylinux: 2_28

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
           cache: true
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-check-rust
           path: |
@@ -38,12 +38,12 @@ jobs:
           - macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-test-rust2
           path: |
@@ -67,12 +67,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-wasm
           path: |
@@ -85,7 +85,7 @@ jobs:
           mkdir -p vegafusion-wasm/package
           cp vegafusion-wasm/pkg/vegafusion-wasm-*.tgz vegafusion-wasm/package/
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-wasm-package
           path: vegafusion-wasm/package/
@@ -94,12 +94,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-wasm
           path: |
@@ -122,27 +122,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      # - name: Install latest stable Rust toolchain
-      #   uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-      #   with:
-      #     toolchain: stable
-      #     override: true
-      # - name: Cache rust dependencies
-      #   uses: Swatinem/rust-cache@v2
-      #   with:
-      #     cache-on-failure: True
+        uses: actions/checkout@v4.2.2
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build wheels (Linux)
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@v1.45
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: python-wheels-linux-64
           path: |
@@ -155,30 +146,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      # - name: Install latest stable Rust toolchain
-      #   uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-      #   with:
-      #     toolchain: stable
-      #     override: true
-      # - name: Cache rust dependencies
-      #   uses: Swatinem/rust-cache@v2
-      #   with:
-      #     cache-on-failure: True
-      # - name: Download arm64 toolchain
-      #   run: |
-      #     rustup target add aarch64-unknown-linux-gnu
+        uses: actions/checkout@v4.2.2
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build arm64 wheels
-        uses: messense/maturin-action@v1
+        uses: messense/maturin-action@v1.45
         with:
           command: build
           manylinux: 2_28
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: python-wheels-linux-arm64
           path: |
@@ -191,16 +170,12 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
-      # - name: Setup Python
-      #   uses: actions/setup-python@v5
-      #   with:
-      #     python-version: "3.11"
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-python-win-64
           path: |
@@ -211,7 +186,7 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: python-wheels-win-64
           path: |
@@ -224,12 +199,12 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-python-osx-64
           path: |
@@ -240,7 +215,7 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: python-wheels-osx-64
           path: |
@@ -253,12 +228,12 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-python-osx-arm64
           path: |
@@ -269,7 +244,7 @@ jobs:
         run: |
           pixi run build-py --target aarch64-apple-darwin
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: python-wheels-osx-arm64
           path: |
@@ -283,9 +258,9 @@ jobs:
     needs: [build-vegafusion-python-linux-64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.11"
       - name: Install Chrome
@@ -298,7 +273,7 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: python-wheels-linux-64
           path: target/wheels/
@@ -322,7 +297,7 @@ jobs:
           VEGAFUSION_TEST_HEADLESS: 1
         run: pytest
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         if: always()
         with:
           name: vegafusion-python-test-failures
@@ -334,13 +309,13 @@ jobs:
     needs: [build-vegafusion-python-osx-arm64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.10"
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: python-wheels-osx-64
           path: target/wheels/
@@ -365,13 +340,13 @@ jobs:
     needs: [build-vegafusion-python-win-64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.9"
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           name: python-wheels-win-64
           path: target/wheels/
@@ -397,12 +372,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-server-linux-64
           path: |
@@ -413,12 +388,12 @@ jobs:
         run: |
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.2
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-server-linux-64
           path: |
@@ -434,11 +409,11 @@ jobs:
   #    runs-on: ubuntu-20.04
   #    steps:
   #      - name: Check out repository code
-  #        uses: actions/checkout@v4
+  #        uses: actions/checkout@v4.2.2
   #      - name: Install pixi
   #        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
   #      - name: Cache
-  #        uses: actions/cache@v3
+  #        uses: actions/cache@v4.1.2
   #        with:
   #          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-server
   #          path: |
@@ -452,12 +427,12 @@ jobs:
   #          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
   #          pixi run build-rs-server --features=protobuf-src --target aarch64-unknown-linux-gnu
   #      - name: zip executable
-  #        uses: vimtor/action-zip@v1
+  #        uses: vimtor/action-zip@v1.2
   #        with:
   #          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
   #          dest: vegafusion-server-linux-arm64.zip
   #      - name: Upload artifacts
-  #        uses: actions/upload-artifact@v4
+  #        uses: actions/upload-artifact@v4.4.3
   #        with:
   #          name: vegafusion-server-linux-arm64
   #          path: |
@@ -467,13 +442,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - name: Install latest stable Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.7.5
         with:
           cache-on-failure: True
       - name: Download arm64 toolchain
@@ -489,12 +464,12 @@ jobs:
         run: |
           cargo build -p vegafusion-server --features=protobuf-src --profile release-opt --target=aarch64-unknown-linux-gnu
       - name: zip executable
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.2
         with:
           files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
           dest: vegafusion-server-linux-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-server-linux-arm64
           path: |
@@ -506,12 +481,12 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-server-win-64b
           path: |
@@ -523,12 +498,12 @@ jobs:
           pixi install -vvv
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.2
         with:
           files: target/release/vegafusion-server.exe
           dest: vegafusion-server-win-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-server-win-64
           path: |
@@ -540,12 +515,12 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: ${{ runner.os }}-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-server-osx-64
           path: |
@@ -556,12 +531,12 @@ jobs:
         run: |
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.2
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-osx-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-server-osx-64
           path: |
@@ -573,12 +548,12 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.34.0
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.1.2
         with:
           key: osx-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-build-vegafusion-server-osx-arm64
           path: |
@@ -589,12 +564,12 @@ jobs:
         run: |
           pixi run build-rs-server --target aarch64-apple-darwin
       - name: zip executable
-        uses: vimtor/action-zip@v1
+        uses: vimtor/action-zip@v1.2
         with:
           files: target/aarch64-apple-darwin/release/vegafusion-server
           dest: vegafusion-server-osx-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-server-osx-arm64
           path: |
@@ -615,7 +590,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Server Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v4.4.3
         with:
           name: vegafusion-server-all
           pattern: vegafusion-server-*
@@ -637,7 +612,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Merge Wheel Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v4.4.3
         with:
           name: vegafusion-python-wheels-all
           pattern: python-wheels-*

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: vegafusion-rt-test-images
+          name: vegafusion-rt-test-images-${{ matrix.os }}
           path: |
             vegafusion-runtime/tests/output
 
@@ -622,13 +622,15 @@ jobs:
 
   # Bundle all python wheels into a single artifact for easier downloading
   bundle-vegafusion-python-wheels:
-    needs:
-      [
-        build-vegafusion-python-linux-64,
+    needs: [
+        # jobs that build but don't have test dependencies
         build-vegafusion-python-linux-arm64,
-        build-vegafusion-python-win-64,
         build-vegafusion-python-osx-64,
-        build-vegafusion-python-osx-arm64,
+
+        # jobs that test the wheels
+        test-vegafusion-python-linux-64,
+        test-vegafusion-python-osx-arm64,
+        test-vegafusion-python-win-64,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -390,7 +390,7 @@ jobs:
       - name: zip executable
         uses: vimtor/action-zip@v1.2
         with:
-          files: target/release/vegafusion-server
+          files: target/release-opt/vegafusion-server
           dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
@@ -466,7 +466,7 @@ jobs:
       - name: zip executable
         uses: vimtor/action-zip@v1.2
         with:
-          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+          files: target/aarch64-unknown-linux-gnu/release-opt/vegafusion-server
           dest: vegafusion-server-linux-arm64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
@@ -500,7 +500,7 @@ jobs:
       - name: zip executable
         uses: vimtor/action-zip@v1.2
         with:
-          files: target/release/vegafusion-server.exe
+          files: target/release-opt/vegafusion-server.exe
           dest: vegafusion-server-win-64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
@@ -533,7 +533,7 @@ jobs:
       - name: zip executable
         uses: vimtor/action-zip@v1.2
         with:
-          files: target/release/vegafusion-server
+          files: target/release-opt/vegafusion-server
           dest: vegafusion-server-osx-64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
@@ -566,7 +566,7 @@ jobs:
       - name: zip executable
         uses: vimtor/action-zip@v1.2
         with:
-          files: target/aarch64-apple-darwin/release/vegafusion-server
+          files: target/aarch64-apple-darwin/release-opts/vegafusion-server
           dest: vegafusion-server-osx-arm64.zip
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -82,11 +82,13 @@ jobs:
       - name: Build package
         run: |
           pixi run pack-wasm
+          mkdir -p vegafusion-wasm/package
+          cp vegafusion-wasm/pkg/vegafusion-wasm-*.tgz vegafusion-wasm/package/
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-wasm-packages
-          path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
+          name: vegafusion-wasm-package
+          path: vegafusion-wasm/package/
 
   check-vegafusion-python:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,7 +1,7 @@
 name: build_test
 on:
   pull_request:
-    types: [ opened, synchronize ]
+    types: [opened, synchronize]
 jobs:
   check-rust:
     runs-on: ubuntu-20.04
@@ -138,7 +138,7 @@ jobs:
           command: build
           manylinux: 2014
           rust-toolchain: stable
-          args: --release -m vegafusion-python/Cargo.toml --features=protobuf-src --strip
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip
       - name: Upload artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
         with:
@@ -172,7 +172,7 @@ jobs:
           command: build
           manylinux: 2_28
           rust-toolchain: stable
-          args: --release -m vegafusion-python/Cargo.toml --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
       - name: Upload artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
         with:
@@ -189,7 +189,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: v0.30.0
@@ -275,7 +275,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.11'
+          python-version: "3.11"
       - name: Install Chrome
         uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
         with:
@@ -300,7 +300,7 @@ jobs:
           python -m pip install pyarrow pandas polars-lts-cpu "duckdb>=1.0" "vl-convert-python>=1.0.1rc1" scikit-image "pandas>=2.2" jupytext voila anywidget ipywidgets chromedriver-binary-auto
 
           # Test dependencies
-          python -m pip install pytest altair vega-datasets scikit-image jupytext voila ipykernel anywidget ipywidgets selenium flaky tenacity chromedriver-binary-auto 
+          python -m pip install pytest altair vega-datasets scikit-image jupytext voila ipykernel anywidget ipywidgets selenium flaky tenacity chromedriver-binary-auto
       - name: Test lazy imports
         working-directory: vegafusion-python/
         run: python checks/check_lazy_imports.py
@@ -326,7 +326,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
         with:
@@ -357,7 +357,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
         with:
-          python-version: '3.9'
+          python-version: "3.9"
       - name: Install Chrome
         uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
         with:
@@ -378,13 +378,12 @@ jobs:
 
           # Optional dependencies
           python -m pip install pyarrow pandas "numpy<2" polars[timezone] "duckdb>=1.0" vl-convert-python 
-          
+
           # Test dependencies
           python -m pip install pytest altair vega-datasets scikit-image
       - name: Test vegafusion
         working-directory: vegafusion-python/
         run: pytest --ignore=tests/test_jupyter_widget.py
-
 
   build-vegafusion-server-linux-64:
     runs-on: ubuntu-20.04
@@ -417,43 +416,42 @@ jobs:
           path: |
             vegafusion-server-*
 
-# # Below is an Attempt to cross compile to linux aarch64 within conda environment.
-# # It fails in compiling protobuf-src. So instead we fall back to the direct use of
-# # cargo (without involving conda).
-#
-#  build-vegafusion-server-linux-arm64:
-#    runs-on: ubuntu-20.04
-#    steps:
-#      - name: Check out repository code
-#        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-#      - name: Install pixi
-#        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
-#      - name: Cache
-#        uses: actions/cache@v3
-#        with:
-#          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-server
-#          path: |
-#            ~/.cargo
-#            target
-#            .pixi
-#      - name: Build vegafusion-server
-#        run: |
-#          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
-#          pixi add gcc_linux-aarch64 -p linux-64
-#          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
-#          pixi run build-rs-server --features=protobuf-src --target aarch64-unknown-linux-gnu
-#      - name: zip executable
-#        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
-#        with:
-#          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
-#          dest: vegafusion-server-linux-arm64.zip
-#      - name: Upload artifacts
-#        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
-#        with:
-#          name: vegafusion-server
-#          path: |
-#            vegafusion-server-*
-
+  # # Below is an Attempt to cross compile to linux aarch64 within conda environment.
+  # # It fails in compiling protobuf-src. So instead we fall back to the direct use of
+  # # cargo (without involving conda).
+  #
+  #  build-vegafusion-server-linux-arm64:
+  #    runs-on: ubuntu-20.04
+  #    steps:
+  #      - name: Check out repository code
+  #        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+  #      - name: Install pixi
+  #        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
+  #      - name: Cache
+  #        uses: actions/cache@v3
+  #        with:
+  #          key: linux-arm64-${{ hashFiles('pixi.lock', 'Cargo.lock', 'vegafusion-python/pyproject.toml') }}-server
+  #          path: |
+  #            ~/.cargo
+  #            target
+  #            .pixi
+  #      - name: Build vegafusion-server
+  #        run: |
+  #          pixi run python automation/download_rust_target.py aarch64-unknown-linux-gnu
+  #          pixi add gcc_linux-aarch64 -p linux-64
+  #          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
+  #          pixi run build-rs-server --features=protobuf-src --target aarch64-unknown-linux-gnu
+  #      - name: zip executable
+  #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+  #        with:
+  #          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
+  #          dest: vegafusion-server-linux-arm64.zip
+  #      - name: Upload artifacts
+  #        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+  #        with:
+  #          name: vegafusion-server
+  #          path: |
+  #            vegafusion-server-*
 
   build-vegafusion-server-linux-arm64:
     runs-on: ubuntu-latest
@@ -482,7 +480,7 @@ jobs:
           RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
         with:
           command: build
-          args: -p vegafusion-server --release --features=protobuf-src --target=aarch64-unknown-linux-gnu
+          args: -p vegafusion-server --features=protobuf-src --profile release-opt --target=aarch64-unknown-linux-gnu
       - name: zip executable
         uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
         with:

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -82,13 +82,14 @@ jobs:
       - name: Build package
         run: |
           pixi run pack-wasm
-          mkdir -p vegafusion-wasm/package
-          cp vegafusion-wasm/pkg/vegafusion-wasm-*.tgz vegafusion-wasm/package/
+          mkdir -p package
+          cp vegafusion-wasm/pkg/vegafusion-wasm-*.tgz package/
+          echo "timestamp: $(date)" > package/info.txt
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
         with:
           name: vegafusion-wasm-package
-          path: vegafusion-wasm/package/
+          path: package
 
   check-vegafusion-python:
     runs-on: ubuntu-20.04

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -7,10 +7,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
           cache: true
       - name: Cache
         uses: actions/cache@v3
@@ -38,10 +38,10 @@ jobs:
           - macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -56,7 +56,7 @@ jobs:
         run: |
           pixi run test-rs --release
       - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: vegafusion-rt-test-images
@@ -67,10 +67,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -83,7 +83,7 @@ jobs:
         run: |
           pixi run pack-wasm
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-wasm-packages
           path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
@@ -92,10 +92,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -120,27 +120,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
+        uses: actions/checkout@v4
+      # - name: Install latest stable Rust toolchain
+      #   uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      #   with:
+      #     toolchain: stable
+      #     override: true
+      # - name: Cache rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     cache-on-failure: True
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build wheels (Linux)
-        uses: messense/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa # pin@v1.41.1
+        uses: messense/maturin-action@v1
         with:
           command: build
           manylinux: 2014
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: python-wheels
           path: |
@@ -151,30 +151,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
-        with:
-          cache-on-failure: True
-      - name: Download arm64 toolchain
-        run: |
-          rustup target add aarch64-unknown-linux-gnu
+        uses: actions/checkout@v4
+      # - name: Install latest stable Rust toolchain
+      #   uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+      #   with:
+      #     toolchain: stable
+      #     override: true
+      # - name: Cache rust dependencies
+      #   uses: Swatinem/rust-cache@v2
+      #   with:
+      #     cache-on-failure: True
+      # - name: Download arm64 toolchain
+      #   run: |
+      #     rustup target add aarch64-unknown-linux-gnu
       - name: Clear target/wheels
         run: rm -rf target/wheels
       - name: Build arm64 wheels
-        uses: messense/maturin-action@60d11847b29f81ca5375519a8eb33cc336ba4bfa # pin@v1.41.1
+        uses: messense/maturin-action@v1
         with:
           command: build
           manylinux: 2_28
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: python-wheels
           path: |
@@ -185,14 +185,14 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
-      - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
-        with:
-          python-version: "3.11"
+        uses: actions/checkout@v4
+      # - name: Setup Python
+      #   uses: actions/setup-python@v5
+      #   with:
+      #     python-version: "3.11"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -205,7 +205,7 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: python-wheels
           path: |
@@ -216,10 +216,10 @@ jobs:
     runs-on: macos-12
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -232,7 +232,7 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: python-wheels
           path: |
@@ -243,10 +243,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -259,7 +259,7 @@ jobs:
         run: |
           pixi run build-py --target aarch64-apple-darwin
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: python-wheels
           path: |
@@ -271,13 +271,13 @@ jobs:
     needs: [build-vegafusion-python-linux-64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
+        uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable
       - name: Install fonts on Linux
@@ -286,7 +286,7 @@ jobs:
           echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
           sudo apt-get install ttf-mscorefonts-installer
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: target/wheels/
@@ -310,7 +310,7 @@ jobs:
           VEGAFUSION_TEST_HEADLESS: 1
         run: pytest
       - name: Upload test artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: vegafusion-python-test-failures
@@ -322,13 +322,13 @@ jobs:
     needs: [build-vegafusion-python-osx-arm64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: target/wheels/
@@ -353,17 +353,13 @@ jobs:
     needs: [build-vegafusion-python-win-64]
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # pin@4.7
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
-      - name: Install Chrome
-        uses: browser-actions/setup-chrome@f0ff752add8c926994566c80b3ceadfd03f24d12 # pin@latest
-        with:
-          chrome-version: stable
       - name: Download vegafusion-python wheel
-        uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # pin@v2
+        uses: actions/download-artifact@v4
         with:
           name: python-wheels
           path: target/wheels/
@@ -389,10 +385,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -405,12 +401,12 @@ jobs:
         run: |
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        uses: vimtor/action-zip@v1
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-server
           path: |
@@ -424,7 +420,7 @@ jobs:
   #    runs-on: ubuntu-20.04
   #    steps:
   #      - name: Check out repository code
-  #        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+  #        uses: actions/checkout@v4
   #      - name: Install pixi
   #        run: curl -fsSL https://pixi.sh/install.sh | bash && echo "${HOME}/.pixi/bin" >> $GITHUB_PATH
   #      - name: Cache
@@ -442,12 +438,12 @@ jobs:
   #          export RUSTFLAGS="-C linker=aarch64-linux-gnu-gcc"
   #          pixi run build-rs-server --features=protobuf-src --target aarch64-unknown-linux-gnu
   #      - name: zip executable
-  #        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+  #        uses: vimtor/action-zip@v1
   #        with:
   #          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
   #          dest: vegafusion-server-linux-arm64.zip
   #      - name: Upload artifacts
-  #        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+  #        uses: actions/upload-artifact@v3
   #        with:
   #          name: vegafusion-server
   #          path: |
@@ -457,14 +453,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - name: Install latest stable Rust toolchain
-        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # pin@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - name: Cache rust dependencies
-        uses: Swatinem/rust-cache@81d053bdb0871dcd3f10763c8cc60d0adc41762b # pin@v1
+        uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: True
       - name: Download arm64 toolchain
@@ -475,19 +470,17 @@ jobs:
           sudo apt-get update
           sudo apt-get install gcc-aarch64-linux-gnu
       - name: Build vegafusion-server
-        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # pin@v1
         env:
           RUSTFLAGS: "-C linker=aarch64-linux-gnu-gcc"
-        with:
-          command: build
-          args: -p vegafusion-server --features=protobuf-src --profile release-opt --target=aarch64-unknown-linux-gnu
+        run: |
+          cargo build -p vegafusion-server --features=protobuf-src --profile release-opt --target=aarch64-unknown-linux-gnu
       - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        uses: vimtor/action-zip@v1
         with:
           files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
           dest: vegafusion-server-linux-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-server
           path: |
@@ -497,10 +490,10 @@ jobs:
     runs-on: windows-2022
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -514,12 +507,12 @@ jobs:
           pixi install -vvv
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        uses: vimtor/action-zip@v1
         with:
           files: target/release/vegafusion-server.exe
           dest: vegafusion-server-win-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-server
           path: |
@@ -529,10 +522,10 @@ jobs:
     runs-on: macos-13
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -545,12 +538,12 @@ jobs:
         run: |
           pixi run build-rs-server
       - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        uses: vimtor/action-zip@v1
         with:
           files: target/release/vegafusion-server
           dest: vegafusion-server-osx-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-server
           path: |
@@ -560,10 +553,10 @@ jobs:
     runs-on: macos-14
     steps:
       - name: Check out repository code
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # pin@v3.5.2
+        uses: actions/checkout@v4
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
-          pixi-version: v0.30.0
+          pixi-version: v0.34.0
       - name: Cache
         uses: actions/cache@v3
         with:
@@ -576,12 +569,12 @@ jobs:
         run: |
           pixi run build-rs-server --target aarch64-apple-darwin
       - name: zip executable
-        uses: vimtor/action-zip@26a249fb00d43ca98dad77a4b3838025fc226aa1 # pin@v1.1
+        uses: vimtor/action-zip@v1
         with:
           files: target/aarch64-apple-darwin/release/vegafusion-server
           dest: vegafusion-server-osx-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # pin@v3.1.2
+        uses: actions/upload-artifact@v3
         with:
           name: vegafusion-server
           path: |

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           pixi run test-rs --release
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: vegafusion-rt-test-images
@@ -83,7 +83,7 @@ jobs:
         run: |
           pixi run pack-wasm
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: vegafusion-wasm-packages
           path: vegafusion-wasm/pkg/vegafusion-wasm-*.tgz
@@ -140,12 +140,14 @@ jobs:
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-linux-64
           path: |
             target/wheels/*.tar.gz
             target/wheels/*.whl
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-python-linux-arm64:
     runs-on: ubuntu-latest
@@ -174,12 +176,14 @@ jobs:
           rust-toolchain: stable
           args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-linux-arm64
           path: |
             target/wheels/*.tar.gz
             target/wheels/*.whl
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-python-win-64:
     runs-on: windows-2022
@@ -205,12 +209,14 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-win-64
           path: |
             target/wheels/*.tar.gz
             target/wheels/*.whl
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-python-osx-64:
     runs-on: macos-12
@@ -232,12 +238,14 @@ jobs:
         run: |
           pixi run build-py
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-osx-64
           path: |
             target/wheels/*.tar.gz
             target/wheels/*.whl
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-python-osx-arm64:
     runs-on: macos-14
@@ -259,12 +267,14 @@ jobs:
         run: |
           pixi run build-py --target aarch64-apple-darwin
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-osx-arm64
           path: |
             target/wheels/*.tar.gz
             target/wheels/*.whl
+          retention-days: 1
+          if-no-files-found: error
 
   test-vegafusion-python-linux-64:
     runs-on: ubuntu-20.04
@@ -288,7 +298,7 @@ jobs:
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-linux-64
           path: target/wheels/
       - name: install wheels
         working-directory: target/wheels/
@@ -310,7 +320,7 @@ jobs:
           VEGAFUSION_TEST_HEADLESS: 1
         run: pytest
       - name: Upload test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: vegafusion-python-test-failures
@@ -330,7 +340,7 @@ jobs:
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-osx-64
           path: target/wheels/
       - name: install wheels
         working-directory: target/wheels/
@@ -361,7 +371,7 @@ jobs:
       - name: Download vegafusion-python wheel
         uses: actions/download-artifact@v4
         with:
-          name: python-wheels
+          name: python-wheels-win-64
           path: target/wheels/
       - name: install wheels
         working-directory: target/wheels/
@@ -406,11 +416,13 @@ jobs:
           files: target/release/vegafusion-server
           dest: vegafusion-server-linux-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-server
+          name: vegafusion-server-linux-64
           path: |
             vegafusion-server-*
+          retention-days: 1
+          if-no-files-found: error
 
   # # Below is an Attempt to cross compile to linux aarch64 within conda environment.
   # # It fails in compiling protobuf-src. So instead we fall back to the direct use of
@@ -443,9 +455,9 @@ jobs:
   #          files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
   #          dest: vegafusion-server-linux-arm64.zip
   #      - name: Upload artifacts
-  #        uses: actions/upload-artifact@v3
+  #        uses: actions/upload-artifact@v4
   #        with:
-  #          name: vegafusion-server
+  #          name: vegafusion-server-linux-arm64
   #          path: |
   #            vegafusion-server-*
 
@@ -480,11 +492,13 @@ jobs:
           files: target/aarch64-unknown-linux-gnu/release/vegafusion-server
           dest: vegafusion-server-linux-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-server
+          name: vegafusion-server-linux-arm64
           path: |
             vegafusion-server-*
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-server-win-64:
     runs-on: windows-2022
@@ -512,11 +526,13 @@ jobs:
           files: target/release/vegafusion-server.exe
           dest: vegafusion-server-win-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-server
+          name: vegafusion-server-win-64
           path: |
             vegafusion-server-*
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-server-osx-64:
     runs-on: macos-13
@@ -543,11 +559,13 @@ jobs:
           files: target/release/vegafusion-server
           dest: vegafusion-server-osx-64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-server
+          name: vegafusion-server-osx-64
           path: |
             vegafusion-server-*
+          retention-days: 1
+          if-no-files-found: error
 
   build-vegafusion-server-osx-arm64:
     runs-on: macos-14
@@ -574,8 +592,50 @@ jobs:
           files: target/aarch64-apple-darwin/release/vegafusion-server
           dest: vegafusion-server-osx-arm64.zip
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: vegafusion-server
+          name: vegafusion-server-osx-arm64
           path: |
             vegafusion-server-*
+          retention-days: 1
+          if-no-files-found: error
+
+  # Bundle all server builds into a single artifact for easier downloading
+  bundle-vegafusion-server-builds:
+    needs:
+      [
+        build-vegafusion-server-linux-64,
+        build-vegafusion-server-linux-arm64,
+        build-vegafusion-server-win-64,
+        build-vegafusion-server-osx-64,
+        build-vegafusion-server-osx-arm64,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Server Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: vegafusion-server-all
+          pattern: vegafusion-server-*
+          delete-merged: true
+          separate-directories: false
+
+  # Bundle all python wheels into a single artifact for easier downloading
+  bundle-vegafusion-python-wheels:
+    needs:
+      [
+        build-vegafusion-python-linux-64,
+        build-vegafusion-python-linux-arm64,
+        build-vegafusion-python-win-64,
+        build-vegafusion-python-osx-64,
+        build-vegafusion-python-osx-arm64,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Merge Wheel Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: vegafusion-python-wheels-all
+          pattern: python-wheels-*
+          delete-merged: true
+          separate-directories: false

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -196,7 +196,7 @@ jobs:
           if-no-files-found: error
 
   build-vegafusion-python-osx-64:
-    runs-on: macos-12
+    runs-on: macos-13
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4.2.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4535,7 +4535,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-common"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "arrow",
  "base64 0.21.7",
@@ -4560,7 +4560,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-core"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-runtime"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "async-lock",
  "async-mutex",
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-server"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "assert_cmd",
  "clap 4.5.20",
@@ -4674,7 +4674,7 @@ dependencies = [
 
 [[package]]
 name = "vegafusion-wasm"
-version = "1.6.9"
+version = "2.0.0-a0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -3,185 +3,26 @@
 <img src="https://user-images.githubusercontent.com/15064365/213880036-3d28c1b6-5b76-47c4-a010-2a623522c9f2.svg#gh-light-mode-only" width=50%>
 
 ---
+# Overview
+VegaFusion provides Rust, Python, and JavaScript libraries for analyzing and scaling [Vega](https://vega.github.io/vega/) visualizations. The goal is to provide low-level building blocks that higher level Vega systems (such as [Vega-Altair](https://altair-viz.github.io/) in Python) can integrate with.
 
-VegaFusion provides serverside acceleration for the [Vega](https://vega.github.io/) visualization grammar. While not limited to Python, an initial application of VegaFusion is the acceleration of the [Vega-Altair](https://altair-viz.github.io/) Python interface to [Vega-Lite](https://vega.github.io/vega-lite/).
+> [!NOTE]  
+> If you've arrived here looking for information on how to scale Vega-Altair visualizations to support larger datasets, 
+> see the Vega-Altair documentation on the [`"vegafusion"` data transformer](https://altair-viz.github.io/user_guide/large_datasets.html#vegafusion-data-transformer).
 
-The core VegaFusion algorithms are implemented in Rust. Python integration is provided using [PyO3](https://pyo3.rs/v0.15.1/) and JavaScript integration is provided using [wasm-bindgen](https://github.com/rustwasm/wasm-bindgen).
+## Python Installation
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hex-inc/vegafusion-demos/HEAD?labpath=notebooks)
-
-## Documentation
-See the documentation at https://vegafusion.io
-
-## History
-VegaFusion was developed by Jon Mease and acquired by [Hex Technologies](https://hex.tech/) in 2022. Hex donated VegaFusion to the Vega Project in 2024 and continues to support its development and maintenance.
-
-VegaFusion's integration with Vega-Altair was initially developed outside of Altair in the `vegafusion` Python package. As of Vega-Altair version 5.3, all of these integrations have been incorporated into the upstream Vega-Altair package.
-
-## Quickstart 1: Overcome `MaxRowsError` with VegaFusion
-The Vega-Altair [`"vegafusion"` data transformer](https://altair-viz.github.io/user_guide/large_datasets.html#vegafusion-data-transformer) can be used to overcome the Altair [`MaxRowsError`](https://altair-viz.github.io/user_guide/faq.html#maxrowserror-how-can-i-plot-large-datasets) by performing data-intensive aggregations on the server and pruning unused columns from the source dataset. First install the `altair` Python package with the `all` extras enabled
+The VegaFusion Python package can be installed into a Python environment using pip
 
 ```bash
-pip install "altair[all]>=5.3"
+pip install vegafusion
 ```
 
-Then open a Jupyter notebook (either the classic notebook or a notebook inside JupyterLab), and create an Altair histogram of a 1 million row flights dataset
+or conda
 
-```python
-import pandas as pd
-import altair as alt
-
-flights = pd.read_parquet(
-    "https://vegafusion-datasets.s3.amazonaws.com/vega/flights_1m.parquet"
-)
-
-delay_hist = alt.Chart(flights).mark_bar().encode(
-    alt.X("delay", bin=alt.Bin(maxbins=30)),
-    alt.Y("count()")
-)
-delay_hist
-```
-```
----------------------------------------------------------------------------
-MaxRowsError: The number of rows in your dataset is greater than the maximum allowed (5000).
-
-Try enabling the VegaFusion data transformer which raises this limit by pre-evaluating data
-transformations in Python.
-    >> import altair as alt
-    >> alt.data_transformers.enable("vegafusion")
-
-Or, see https://altair-viz.github.io/user_guide/large_datasets.html for additional information
-on how to plot large datasets.
+```bash
+conda install -c conda-forge vegafusion
 ```
 
-This results in an Altair `MaxRowsError`, as by default Altair is configured to allow no more than 5,000 rows of data to be sent to the browser.  This is a safety measure to avoid crashing the user's browser.  The `"vegafusion"` data transformer can be used to overcome this limitation by performing data intensive transforms (e.g. filtering, binning, aggregation, etc.) in the Python kernel before the resulting data is sent to the web browser.
-
-The `"vegafusion"` data transformer is enabled like this:
-
-```python
-alt.data_transformers.enable("vegafusion")
-```
-
-Now the chart displays quickly without errors
-```
-delay_hist
-```
-![Flight Delay Histogram](https://user-images.githubusercontent.com/15064365/209973961-948b9d10-4202-4547-bbc8-d1981dcc8c4e.png)
-
-## Quickstart 2: Extract transformed data
-By default, data transforms in an Altair chart (e.g. filtering, binning, aggregation, etc.) are performed by the Vega JavaScript library running in the browser. This has the advantage of making the charts produced by Altair fully standalone, not requiring access to a running Python kernel to render properly. But it has the disadvantage of making it difficult to access the transformed data (e.g. the histogram bin edges and count values) from Python.  Since VegaFusion evaluates these transforms in the Python kernel, it's possible to access them from Python using the `chart.transformed_data()` function.
-
-For example, the following code demonstrates how to access the histogram bin edges and counts for the example above:
-
-```python
-import pandas as pd
-import altair as alt
-
-flights = pd.read_parquet(
-    "https://vegafusion-datasets.s3.amazonaws.com/vega/flights_1m.parquet"
-)
-
-delay_hist = alt.Chart(flights).mark_bar().encode(
-    alt.X("delay", bin=alt.Bin(maxbins=30)),
-    alt.Y("count()")
-)
-delay_hist.transformed_data()
-```
-|    |   bin_maxbins_30_delay |   bin_maxbins_30_delay_end |   __count |
-|---:|-----------------------:|---------------------------:|----------:|
-|  0 |                    -20 |                          0 |    419400 |
-|  1 |                     80 |                        100 |     11000 |
-|  2 |                      0 |                         20 |    392700 |
-|  3 |                     40 |                         60 |     38400 |
-|  4 |                     60 |                         80 |     21800 |
-|  5 |                     20 |                         40 |     92700 |
-|  6 |                    100 |                        120 |      5300 |
-|  7 |                    -40 |                        -20 |      9900 |
-|  8 |                    120 |                        140 |      3300 |
-|  9 |                    140 |                        160 |      2000 |
-| 10 |                    160 |                        180 |      1800 |
-| 11 |                    320 |                        340 |       100 |
-| 12 |                    180 |                        200 |       900 |
-| 13 |                    240 |                        260 |       100 |
-| 14 |                    -60 |                        -40 |       100 |
-| 15 |                    260 |                        280 |       100 |
-| 16 |                    200 |                        220 |       300 |
-| 17 |                    360 |                        380 |       100 |
-
-## Quickstart 3: Accelerate interactive charts
-
-As shown above, the `"vegafusion"` data transformer can be combined with Vega-Altair's standard [renderers](https://altair-viz.github.io/user_guide/display_frontends.html), and this configuration will work well to scale non-interactive charts. However, because the standard renderers do not support passing information from the browser back to the Python kernel, VegaFusion is unable to evaluate transforms that are referenced by selections. To support this use case, the `"vegafusion"` data transformer may be combined with Altair's [`JupyterChart`](https://altair-viz.github.io/user_guide/jupyter_chart.html). Because `JupyterChart` (when used in an environment that support Jupyter Widgets) provides a two-way connection between the browser and the Python kernel, selection operations (e.g. filtering to the extents of a brush selection) can be evaluated interactively in the Python kernel, which eliminates the need to transfer the full dataset to the browser in order to maintain interactivity.
-
-This mode is activate by enabling the `"vegafusion"` data transformer and either enabling the `"jupyter"` renderer, or using `JupyterChart` directly.
-
-```python
-import pandas as pd
-import altair as alt
-
-alt.data_transformers.enable("vegafusion")
-alt.renderers.enable("jupyter")
-
-flights = pd.read_parquet(
-    "https://vegafusion-datasets.s3.amazonaws.com/vega/flights_1m.parquet"
-)
-
-brush = alt.selection_interval(encodings=['x'])
-
-# Define the base chart, with the common parts of the
-# background and highlights
-base = alt.Chart().mark_bar().encode(
-    x=alt.X(alt.repeat('column'), type='quantitative', bin=alt.Bin(maxbins=20)),
-    y='count()'
-).properties(
-    width=160,
-    height=130
-)
-
-# gray background with selection
-background = base.encode(
-    color=alt.value('#ddd')
-).add_params(brush)
-
-# blue highlights on the selected data
-highlight = base.transform_filter(brush)
-
-# layer the two charts & repeat
-chart = alt.layer(
-    background,
-    highlight,
-    data=flights
-).transform_calculate(
-    "time",
-    "hours(datum.date)"
-).repeat(column=["distance", "delay", "time"])
-
-chart
-```
-
-https://user-images.githubusercontent.com/15064365/209974420-480121b4-b206-4bb2-b473-0c663e38ea5e.mov
-
-Histogram binning, aggregation, and selection filtering are now evaluated in the Python kernel process with efficient parallelization, and only the aggregated data (one row per histogram bar) is sent to the browser.
-
-You can see that the JupyterChart widget maintains a live connection to the Python kernel by noticing that the Python [kernel is running](https://experienceleague.adobe.com/docs/experience-platform/data-science-workspace/jupyterlab/overview.html?lang=en#kernel-sessions) as the selection region is created or moved.
-
-## Motivation for VegaFusion
-Vega makes it possible to create declarative JSON specifications for rich interactive visualizations that are fully self-contained. They can run entirely in a web browser without requiring access to an external database or a Python kernel.
-
-For datasets of a few thousand rows or fewer, this architecture results in extremely smooth and responsive interactivity. However, this architecture does not scale very well to datasets of hundreds of thousands of rows or more.  This is the problem that VegaFusion aims to solve.
-
-## DataFusion integration
-[Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion) is an SQL compatible query engine that integrates with the Rust implementation of Apache Arrow.  VegaFusion uses DataFusion to implement many of the Vega transforms, and it compiles the Vega expression language directly into the DataFusion expression language.  In addition to being quite fast, a particularly powerful characteristic of DataFusion is that it provides many interfaces that can be extended with custom Rust logic.  For example, VegaFusion defines many custom UDFs that are designed to implement the precise semantics of the Vega expression language and Vega expression functions.
-
-# License
-VegaFusion is licensed under the [BSD-3](https://opensource.org/licenses/BSD-3-Clause) license. This is the same license used by Vega, Vega-Lite, and Vega-Altair.
-
-# About the Name
-There are two meanings behind the name "VegaFusion"
-- It's a reference to the [Apache Arrow DataFusion](https://github.com/apache/arrow-datafusion) library which is used to implement many of the supported Vega transforms
-- Vega and Altair are named after stars, and stars are powered by nuclear fusion
-
-# Building VegaFusion
-If you're interested in building VegaFusion from source, see [BUILD.md](BUILD.md)
-
-# Roadmap
-Supporting serverside acceleration for Altair in Jupyter was chosen as the first application of VegaFusion, but there are a lot of exciting ways that VegaFusion can be extended in the future.  For more information, see the [Roadmap](https://vegafusion.io/roadmap.html).
+## Documentation
+See [Documentation](https://vegafusion.io/) and [Examples](https://github.com/vega/vegafusion/tree/v2/examples/python-examples/chart_state.py).

--- a/automation/bump_version.py
+++ b/automation/bump_version.py
@@ -22,7 +22,6 @@ def bump_version(version):
         "vegafusion-python",
         "vegafusion-server",
         "vegafusion-wasm",
-        "vegafusion-jni",
     ]
 
     for package in cargo_packages:
@@ -49,10 +48,7 @@ def bump_version(version):
         print(f"Updated version in {cargo_toml_path}")
 
     # Handle package.json files
-    package_json_dirs = [
-        root / "vegafusion-wasm",
-        root / "javascript" / "vegafusion-embed"
-    ]
+    package_json_dirs = [root / "vegafusion-wasm"]
     for package_json_dir in package_json_dirs:
         for fname in ["package.json", "package-lock.json"]:
             package_json_path = package_json_dir / fname
@@ -73,12 +69,6 @@ def bump_version(version):
             pyproject_toml["project"]["version"] = version
             pyproject_toml_path.write_text(toml.dumps(pyproject_toml))
             print(f"Updated version in {pyproject_toml_path}")
-
-    # Handle java/version.txt
-    version_txt_path = root / "java" / "version.txt"
-    with open(version_txt_path, "wt") as f:
-        f.write(version)
-    print(f"Updated version in {version_txt_path}")
 
     # Run taplo fmt *.toml
     print("Formatting TOML files...")

--- a/vegafusion-common/Cargo.toml
+++ b/vegafusion-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vegafusion-common"
-version = "1.6.9"
+version = "2.0.0-a0"
 edition = "2021"
 description = "Common components required by multiple VegaFusion crates"
 license = "BSD-3-Clause"
@@ -43,7 +43,12 @@ workspace = true
 
 [dependencies.datafusion-functions]
 workspace = true
-features = ["core_expressions", "string_expressions", "datetime_expressions", "hashbrown"]
+features = [
+  "core_expressions",
+  "string_expressions",
+  "datetime_expressions",
+  "hashbrown",
+]
 
 [dependencies.datafusion-functions-nested]
 workspace = true

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vegafusion-core"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "1.6.9"
+version = "2.0.0-a0"
 description = "Core components required by multiple VegaFusion crates, with WASM compatibility"
 
 [features]
@@ -26,7 +26,7 @@ log = "0.4.22"
 workspace = true
 
 [dependencies.deterministic-hash]
- workspace = true
+workspace = true
 
 [dependencies.prost]
 workspace = true
@@ -51,7 +51,7 @@ features = ["preserve_order"]
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.datafusion-common]
 workspace = true

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -2,7 +2,7 @@
 name = "vegafusion"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "1.6.9"
+version = "2.0.0-a0"
 description = "VegaFusion Python interface"
 
 [lib]
@@ -50,16 +50,16 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["pyo3", "base64"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["py", "tonic_support"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.tokio]
 workspace = true

--- a/vegafusion-python/pyproject.toml
+++ b/vegafusion-python/pyproject.toml
@@ -32,3 +32,8 @@ Documentation = "https://vegafusion.io"
 
 [tool.maturin]
 module-name = "vegafusion._vegafusion"
+
+[project.optional-dependencies]
+# For backward compatibility with older versions that used this extra to
+# install vegafusion-python-embed
+embed = []

--- a/vegafusion-python/pyproject.toml
+++ b/vegafusion-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vegafusion"
-version = "1.6.9"
+version = "2.0.0-a0"
 description = "Core tools for using VegaFusion from Python"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/vegafusion-python/vegafusion/__init__.py
+++ b/vegafusion-python/vegafusion/__init__.py
@@ -14,7 +14,7 @@ def patched_version(distribution_name: str) -> str:
     vegafusion package. This is just to satisfy Altair's version check.
     """
     if distribution_name == "vegafusion-python-embed":
-        return cast(str, __version__)
+        return cast(str, __version__).replace("-", "")
     return _original_version(distribution_name)
 
 

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -6,18 +6,27 @@ harness = false
 name = "vegafusion-runtime"
 license = "BSD-3-Clause"
 edition = "2021"
-version = "1.6.9"
+version = "2.0.0-a0"
 description = "VegaFusion Runtime"
 
 [features]
-default = ["fs", "multi-thread", "rustls-tls", "s3", "http", "parquet", "proto", "tonic"]
+default = [
+  "fs",
+  "multi-thread",
+  "rustls-tls",
+  "s3",
+  "http",
+  "parquet",
+  "proto",
+  "tonic",
+]
 py = ["vegafusion-core/py"]
 proto = ["vegafusion-common/proto", "dep:datafusion-proto"]
 tonic = ["dep:tonic", "vegafusion-core/tonic_support", "proto"]
 protobuf-src = ["vegafusion-core/protobuf-src"]
 s3 = ["object_store/aws"]
 http = ["object_store/http"]
-http-wasm = [ "object-store-wasm/http"]
+http-wasm = ["object-store-wasm/http"]
 fs = ["tokio/fs"]
 parquet = ["datafusion-common/parquet", "datafusion/parquet"]
 multi-thread = ["tokio/rt-multi-thread"]
@@ -92,12 +101,12 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser", "prettyprint", "object_store", "url"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["sqlparser"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.serde]
 version = "1.0.137"

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -5,7 +5,7 @@ path = "src/main.rs"
 [package]
 name = "vegafusion-server"
 license = "BSD-3-Clause"
-version = "1.6.9"
+version = "2.0.0-a0"
 edition = "2021"
 description = "VegaFusion Server"
 repository = "https://github.com/vega/vegafusion"
@@ -23,10 +23,6 @@ serde_json = "1.0.91"
 assert_cmd = "2.0"
 predicates = "3.0.2"
 
-[build-dependencies]
-tonic-build = {workspace = true}
-prost-build = { workspace = true }
-
 [dependencies.prost]
 workspace = true
 
@@ -35,16 +31,16 @@ workspace = true
 
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
 features = ["tonic_support"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.tokio]
 workspace = true
@@ -63,6 +59,12 @@ features = ["tls"]
 [dependencies.clap]
 version = "4.2.1"
 features = ["derive"]
+
+[build-dependencies.tonic-build]
+workspace = true
+
+[build-dependencies.prost-build]
+workspace = true
 
 [build-dependencies.protobuf-src]
 version = "1.1.0"

--- a/vegafusion-wasm/Cargo.toml
+++ b/vegafusion-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "vegafusion-wasm"
 license = "BSD-3-Clause"
-version = "1.6.9"
+version = "2.0.0-a0"
 edition = "2021"
 description = "VegaFusion WASM package for embedding Vega charts in the browser with a connection to a VegaFusion Runtime"
 
@@ -18,11 +18,11 @@ serde-wasm-bindgen = "0.6"
 js-sys = "0.3.55"
 indexmap = "1.9.2"
 
-[dependencies.serde_json]
-workspace = true
-
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+
+[dependencies.serde_json]
+workspace = true
 
 [dependencies.prost]
 workspace = true
@@ -33,15 +33,15 @@ workspace = true
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json"]
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-core]
 path = "../vegafusion-core"
-version = "1.6.9"
+version = "2.0.0-a0"
 
 [dependencies.vegafusion-runtime]
 path = "../vegafusion-runtime"
-version = "1.6.9"
+version = "2.0.0-a0"
 default-features = false
 features = ["http-wasm"]
 

--- a/vegafusion-wasm/package-lock.json
+++ b/vegafusion-wasm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vegafusion-wasm",
-  "version": "1.6.9",
+  "version": "2.0.0-a0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/vegafusion-wasm/package.json
+++ b/vegafusion-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vegafusion-wasm",
-  "version": "1.6.9",
+  "version": "2.0.0-a0",
   "author": "Jon Mease <jon@vegafusion.io> (https://jonmmease.dev)",
   "license": "BSD-3-Clause",
   "description": "Wasm library for interfacing with VegaFusion",


### PR DESCRIPTION
- Update GitHub actions to remove deprecations
- Bump version to 2.0.0a0
- Add empty embed group for backward compatibility
- Use release-opt profile consistently for CI artifacts
