### PR TITLE
v2-docs: Update release instructions, add sync_docs script

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,24 +20,10 @@ python automation/bump_version.py $VF_VERSION
 Open a pull request to merge this branch into `main`.  This will start the continuous integration jobs on GitHub Actions. These jobs will test VegaFusion and build packages for publication.
 
 ### Publish Python packages
-To publish the `vegafusion-python-embed` packages to PyPI, first download and unzip the `vegafusion-python-embed-wheels` artifacts from GitHub Actions. Then `cd` into the directory of `*.whl` and `*.tar.gz` files and upload the packages to PyPI using [twine](https://pypi.org/project/twine/).
+To publish the `vegafusion` packages to PyPI, first download and unzip the `vegafusion-python-wheels-all` artifacts from GitHub Actions. Then `cd` into the directory of `*.whl` and `*.tar.gz` files and upload the packages to PyPI using [twine](https://pypi.org/project/twine/).
 
 ```bash
-cd vegafusion-python-embed-wheels
-twine upload *
-```
-
-To publish the `vegafusion` packages, download and unzip the `vegafusion-wheel` artifacts. Then upload with twine.
-
-```bash
-cd vegafusion-packages
-twine upload *
-```
-
-To publish the `vegafusion-jupyter` packages, download and unzip the `vegafusion-jupyter-packages` artifacts. Then upload with twine.
-
-```bash
-cd vegafusion-jupyter-packages
+cd vegafusion-python-wheels-all
 twine upload *
 ```
 
@@ -45,29 +31,8 @@ twine upload *
 First, download and unzip the `vegafusion-wasm-packages` artifact. Then publish the `vegafusion-wasm-X.Y.Z.tgz` package to NPM.  If this is a release candidate, include the `--pre` flag to `npm publish`.
 
 ```bash
-unzip vegafusion-wasm-packages.zip
+cd vegafusion-wasm-package
 npm publish vegafusion-wasm-$VF_VERSION.tgz
-```
-
-Next, change the version of `vegafusion-wasm` in `javascript/vegafusion-embed/package.json` from `"../../vegafusion-wasm/pkg"` to `"~X.Y.Z"`
-
-Then update `package.lock`, and build package, then publish to NPM (include the `--pre` flag to `npm publish` if this is a release candidate)
-```bash
-cd javascript/vegafusion-embed/
-npm install
-npm run build 
-npm publish
-```
-
-Next, change the version of `vegafusion-wasm` and `vegafusion-embed` in `python/vegafusion-jupyter/package.json` from local paths to `"~X.Y.Z"`
-
-Then build and publish the packages (include the `--pre` flag if this is a release candidate)
-
-```bash
-cd python/vegafusion-jupyter/
-npm install
-npm run build:prod
-npm publish
 ```
 
 ### Publish Rust crates
@@ -76,3 +41,12 @@ The Rust crates should be published in the following order
 ```
 pixi run publish-rs
 ```
+
+### Create GitHub Release
+Create a [GitHub Release](https://github.com/vega/vegafusion/releases) with tag `vX.Y.Z` and title `Release X.Y.Z`. Attach:
+ 1. the wheels from the `vegafusion-python-wheels-all` artifact
+ 2. The server binary archives from the `vegafusion-server-all` artifact
+ 2. the `vegafusion-wasm-X.Y.Z.tgz` package from the `vegafusion-wasm-package` artifact
+
+### Publish documentation
+Publish the documentation to the `gh-pages` branch of the https://github.com/vegafusion/vegafusion.github.io repository by running `pixi run docs-publish`, then confirm the push by entering `y` at the prompt.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,25 @@ html_theme_options = {
         }
     ],
 }
+html_sidebars = {
+    "posts/**": [
+        "ablog/postcard.html",
+        "ablog/recentposts.html",
+        "ablog/archives.html",
+        "ablog/categories.html",
+        "ablog/tagcloud.html",
+        "ablog/authors.html",
+    ],
+    "blog": [
+        "ablog/postcard.html",
+        "ablog/recentposts.html",
+        "ablog/archives.html",
+        "ablog/categories.html",
+        "ablog/tagcloud.html",
+        "ablog/authors.html",
+    ],
+}
+
 # Add custom CSS
 html_css_files = [
     'custom.css',
@@ -49,9 +68,21 @@ _title = "VegaFusion"
 # -- Blog configuration ------------------------------------------------------
 blog_baseurl = "https://vegafusion.io"  # Replace with your actual base URL
 blog_post_pattern = "posts/*/*"
-blog_path = "blog"
+blog_path = "posts"
 blog_title = "VegaFusion Blog"
-templates_path = ['_templates']
+templates_path = [
+    "_templates",
+]
+
+blog_authors = {
+    "Jon Mease": ("Jon Mease", "https://github.com/jonmmease"),
+}
+
+blog_default_author = "Jon Mease"
+blog_feed_archives = True
+blog_feed_fulltext = True
+blog_feed_subtitle = "VegaFusion Updates"
+
 
 # MyST settings
 myst_enable_extensions = [
@@ -61,4 +92,5 @@ myst_enable_extensions = [
     "tasklist",       # Task lists
     "attrs_inline",   # Inline attributes
 ]
+
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -46,4 +46,5 @@ features/features
 Vega Coverage <vega_coverage/supported_transforms>
 About <about/background>
 Community <community/governance>
+Blog <posts/posts>
 ```

--- a/docs/source/posts/2022/2022-01-19_Release_0.0.1.md
+++ b/docs/source/posts/2022/2022-01-19_Release_0.0.1.md
@@ -1,7 +1,8 @@
 ---
 date: 2022-01-19 
 category: Release
+author: Jon Mease
 ---
 
-# Announcing VegaFusion 0.0.1
+# VegaFusion 0.0.1
 The first public version of VegaFusion has been released as 0.0.1.  Full project announcement to follow!

--- a/docs/source/posts/2022/2022-01-27_ProjectAnnouncement.md
+++ b/docs/source/posts/2022/2022-01-27_ProjectAnnouncement.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 0.1
+# VegaFusion 0.1
 **Server-side acceleration for the Vega visualization grammar with Rust and WebAssembly**
 
 By: Jon Mease

--- a/docs/source/posts/2023/2023-01-21_Release_1.0.0.md
+++ b/docs/source/posts/2023/2023-01-21_Release_1.0.0.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 1.0
+# VegaFusion 1.0
 **Mime renderer, transform evaluation, and a permissive license**
 
 By: Jon Mease

--- a/docs/source/posts/2023/2023-03-25_Release_1.1.0.md
+++ b/docs/source/posts/2023/2023-03-25_Release_1.1.0.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 1.1
+# VegaFusion 1.1
 **DuckDB and Polars support, Altair 5 compatibility, and lots of bug fixes**
 
 By: Jon Mease

--- a/docs/source/posts/2023/2023-04-12_Release_1.2.0.md
+++ b/docs/source/posts/2023/2023-04-12_Release_1.2.0.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 1.2
+# VegaFusion 1.2
 **Pre-transform and Save Altair Charts**
 
 By: Jon Mease

--- a/docs/source/posts/2023/2023-06-10_Release_1.3.0.md
+++ b/docs/source/posts/2023/2023-06-10_Release_1.3.0.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 1.3
+# VegaFusion 1.3
 **Transformed data for compound charts, Java library**
 
 By: Jon Mease

--- a/docs/source/posts/2023/2023-08-21_Release_1.4.0.md
+++ b/docs/source/posts/2023/2023-08-21_Release_1.4.0.md
@@ -4,7 +4,7 @@ category: Release
 author: Jon Mease
 ---
 
-# Announcing VegaFusion 1.4
+# VegaFusion 1.4
 **Improved Vega coverage, external data source foundations, extended architecture support**
 
 By: Jon Mease

--- a/docs/source/posts/2024/2024-11-13_Release_2.0.0.md
+++ b/docs/source/posts/2024/2024-11-13_Release_2.0.0.md
@@ -1,0 +1,22 @@
+---
+date: 2024-11-13
+category: Release
+author: Jon Mease
+---
+
+# VegaFusion 2.0
+**A new era: Building blocks for scaling Vega visualizations:**
+
+By: Jon Mease
+
+---
+
+Details to follow...
+
+## Learn more
+Check out these resources to learn more:
+ - [2.0.0 Changelog](https://github.com/hex-inc/vegafusion/releases/tag/v2.0.0)
+ - [VegaFusion Documentation](https://vegafusion.io/)
+ - [VegaFusion GitHub](https://github.com/hex-inc/vegafusion)
+ - [Report and Issue](https://github.com/hex-inc/vegafusion/issues)
+ - [Start a Discussions](https://github.com/hex-inc/vegafusion/discussions)

--- a/docs/source/posts/posts.md
+++ b/docs/source/posts/posts.md
@@ -1,0 +1,10 @@
+# Blog Posts
+
+:::{postlist} 5
+:date: '%Y-%m-%d'
+:format: '{date} - {title}'
+:excerpts:
+:::
+
+
+

--- a/docs/sync_docs.sh
+++ b/docs/sync_docs.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# get git hash for commit message
+GITHASH=$(git rev-parse HEAD)
+MSG="doc build for commit $GITHASH"
+cd build
+
+# clone the repo if needed
+if test -d vegafusion.github.io;
+then rm -rf vegafusion.github.io;
+fi
+
+git clone https://github.com/vegafusion/vegafusion.github.io.git;
+
+# sync the website
+cd vegafusion.github.io
+git pull
+
+# switch to gh-pages branch
+git checkout gh-pages
+
+
+# When the v2 docs become the default, overwrite everything in the branch
+# -----------------------------------------------------------------------------
+# remove all tracked files
+# git ls-files -z | xargs -0 rm -f
+#
+# # sync files from html build
+# rsync -r ../html/ ./
+# -----------------------------------------------------------------------------
+
+# While the v1 docs are still the default, only sync the new docs under the v2/ folder
+# -----------------------------------------------------------------------------
+rsync -r ../html/ ./v2/
+# -----------------------------------------------------------------------------
+
+# add commit, and push to github
+git add . --all
+git commit -m "$MSG"
+
+# Add confirmation prompt before pushing
+read -p "Ready to push to gh-pages branch. Continue? (y/n) " answer
+if [[ $answer == "y" || $answer == "Y" ]]; then
+    git push origin gh-pages
+else
+    echo "Push cancelled"
+    exit 1
+fi

--- a/pixi.toml
+++ b/pixi.toml
@@ -99,6 +99,7 @@ docs-build = { cmd = "sphinx-build -b html docs/source docs/build/html" }
 docs-clean = { cmd = "rm -rf docs/build" }
 docs-rebuild = { depends_on = ["docs-clean", "docs-build"] }
 docs-serve = { cmd = "python -m http.server --directory docs/build/html 8000" }
+docs-publish = { cmd = "./sync_docs.sh", depends_on = ["docs-rebuild"], cwd = "docs" }
 
 # Note: the `--no-verify` flag below for `vegafusion-core` is due to this cargo publish error:
 #


### PR DESCRIPTION
Updates the RELEASE.md for the new release artifacts, adds a sync_docs.sh script to push the docs to the gh-pages branch of https://github.com/vegafusion/vegafusion.github.io (currently under a v2 sub-directory, but after release this will be the root).