### PR TITLE
Remove Twitter icon for Vegafusion

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,11 +20,6 @@ html_favicon = "_static/favicon.ico"
 html_theme_options = {
     "icon_links": [
         {
-            "name": "Twitter",
-            "url": "https://twitter.com/vegafusion_io",
-            "icon": "fa-brands fa-twitter",
-        },
-        {
             "name": "GitHub",
             "url": "https://github.com/vega/vegafusion",
             "icon": "fa-brands fa-github",


### PR DESCRIPTION
Let's remove the Twitter icon for Vegafusion.
https://vegafusion.io/

Neither [Vega](https://vega.github.io/vega/) nor [Vega-Altair](https://altair-viz.github.io/) has a Twitter icon on their website anymore.
