### PR TITLE
Fix Linux CI: build cp39 wheels

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,7 +143,7 @@ jobs:
           command: build
           manylinux: 2014
           rust-toolchain: stable
-          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --sdist
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --sdist -i python3.9
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
         with:
@@ -167,7 +167,7 @@ jobs:
           command: build
           manylinux: 2_28
           rust-toolchain: stable
-          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu -i python3.9
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5646,7 +5646,6 @@ dependencies = [
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-proto",
- "datafusion-sql",
  "env_logger",
  "float-cmp",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.20"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -111,22 +111,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -137,15 +137,9 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrow"
-<<<<<<< HEAD
 version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -164,15 +158,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -184,22 +172,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eaff85a44e9fa914660fb0d0bb00b79c4a3d888b5334adb3ea4330c84f002"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "chrono-tz 0.10.4",
+ "chrono-tz 0.10.3",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -209,15 +191,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2819d893750cb3380ab31ebdc8c68874dd4429f90fd09180f3c93538bd21626"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
  "half",
@@ -227,15 +203,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d131abb183f80c450d4591dc784f8d7750c50c6e2bc3fcaad148afc8361271"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -255,15 +225,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -276,15 +240,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05738f3d42cb922b9096f7786f606fcb8669260c2640df8490533bb2fa38c9d3"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -295,15 +253,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d09446e8076c4b3f235603d9ea7c5494e73d441b01cd61fb33d7254c11964b3"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -312,20 +264,13 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
- "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371ffd66fa77f71d7628c63f209c9ca5341081051aa32f9c8020feb0def787c0"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -334,12 +279,8 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
-<<<<<<< HEAD
  "indexmap 2.12.1",
  "itoa",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "lexical-core",
  "memchr",
  "num-traits",
@@ -351,15 +292,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc94fc7adec5d1ba9e8cd1b1e8d6f72423b33fe978bf1f46d970fafab787521"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -370,15 +305,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -389,15 +318,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27609cd7dd45f006abae27995c2729ef6f4b9361cde1ddd019dc31a5aa017e0"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bitflags 2.9.1",
  "serde_core",
@@ -406,15 +329,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae980d021879ea119dd6e2a13912d81e64abed372d53163e804dfe84639d8010"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-array",
@@ -426,15 +343,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -464,26 +375,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "async-compression"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
-dependencies = [
- "bzip2 0.5.2",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "xz2",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,11 +400,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -535,11 +422,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -550,11 +433,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -574,9 +453,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
@@ -717,9 +596,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytemuck"
@@ -740,37 +619,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "bzip2"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
-dependencies = [
- "bzip2-sys",
-]
-
-[[package]]
-name = "bzip2"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
-dependencies = [
- "libbz2-rs-sys",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,9 +626,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -820,19 +668,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
- "chrono-tz-build",
- "phf 0.11.3",
+ "chrono-tz-build 0.3.0",
+ "phf",
  "uncased",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.10.4"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
 dependencies = [
  "chrono",
- "phf 0.12.1",
+ "chrono-tz-build 0.4.1",
+ "phf",
 ]
 
 [[package]]
@@ -842,10 +691,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
- "phf 0.11.3",
+ "phf",
  "phf_codegen",
  "regex",
  "uncased",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
+dependencies = [
+ "parse-zoneinfo",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -877,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -887,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -899,18 +758,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.41"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -1009,9 +864,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1077,9 +932,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1128,24 +983,14 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f47772c28553d837e12cdcc0fb04c2a0fe8eca8b704a30f721d076f32407435"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "bytes",
-<<<<<<< HEAD
-=======
- "bzip2 0.6.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -1172,13 +1017,12 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "hex",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.2",
+ "rand 0.9.1",
  "regex",
  "rstest 0.26.1",
  "tempfile",
@@ -1189,15 +1033,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b29c9c922959285fac53139e12c81014e2ca54704f20355edd7e9d11fd773"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1220,15 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7313553e4c01d184dd49183afdfa22f23204a10a26dd12e6f799203d8fdb95c2"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1250,32 +1082,17 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d66104731b7476a8c86fbe7a6fd741e6329791166ac89a91fcd8336a560ddaf"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ipc",
-<<<<<<< HEAD
  "chrono",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.12.1",
-=======
- "base64 0.22.1",
- "chrono",
- "half",
- "hashbrown 0.14.5",
- "hex",
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "libc",
  "log",
  "object_store",
@@ -1288,15 +1105,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7527ecdfeae6961a8564d3b036507a67bd467fd36a9f10cf8ad7a99db1f1bc"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "futures",
  "log",
@@ -1305,23 +1116,13 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40e5076be33d8eb9f4d99858e5f3477b36c07e61eee8eb93c4320428d9e1e344"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
-<<<<<<< HEAD
-=======
- "bzip2 0.6.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1337,19 +1138,12 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
-<<<<<<< HEAD
  "rand 0.9.1",
-=======
- "parquet",
- "rand 0.9.2",
- "tempfile",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
  "url",
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "datafusion-datasource-arrow"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1378,12 +1172,6 @@ name = "datafusion-datasource-csv"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
-=======
-name = "datafusion-datasource-csv"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "785518d0f2f136c19b9389a10762c01a5aeb5fcdebdb244297bb656b2862dc88"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1404,15 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cb7c3bad0951bf5c52505d0e6d87e6c0098156d2a195924cbcdc82238d29ba"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1432,15 +1214,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea76ad2c5189c98a6b1d4bdf6c3b3caacc9701c417af6661597c946a201bc328"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1458,22 +1234,16 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "hex",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
-<<<<<<< HEAD
-=======
- "rand 0.9.2",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-doc"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
@@ -1483,17 +1253,6 @@ name = "datafusion-execution"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcc45e380db5c6033c3f39e765a3d752679f14315060a7f4030a60066a36946"
-
-[[package]]
-name = "datafusion-execution"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8209805fdce3d5c6e1625f674d3e4ce93e995a56d3709a0bb8d4361062652596"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1504,22 +1263,16 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.1",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7879a845e72a00cacffacbdf5f40626049cb9584d2ba8aa0b9172f09833110ab"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1530,12 +1283,8 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
-<<<<<<< HEAD
  "indexmap 2.12.1",
  "itertools 0.14.0",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "paste",
  "serde_json",
  "sqlparser",
@@ -1543,7 +1292,6 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
@@ -1551,30 +1299,15 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap 2.12.1",
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6da7e47e70ef2c7678735c82c392bd74687004043f5fc8072ab8678dc6fa459d"
-dependencies = [
- "arrow",
- "datafusion-common",
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e7b92b04c5c3b1151f055251b36e272071f9088d9701826a533cb4f764af1c8"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1589,13 +1322,8 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
-<<<<<<< HEAD
  "num-traits",
  "rand 0.9.1",
-=======
- "md-5",
- "rand 0.9.2",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -1603,15 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f16cb922b62e535a4d484961ac2c1c6d188dbe02e85e026c05f0fabbc8f814e"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1630,15 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f71bb59dc8b4dc985c911f2e0d8cf426c21f565b56dca4b852c244101a1a7a2"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1649,15 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27eb3b98a2eb02a8af4ef19cc793cac21fc98d8720b987f15d7d25b8cc875f4d"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1678,15 +1388,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e0940fc3e2fa4645a4d323f9ebf9258b2d7fdad12013a471cae4ae5568683"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1700,15 +1404,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df03c6c62039578fd110b327c474846fdf3d9077a568f1e8706e585ed30cb98d"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1724,15 +1422,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083659a95914bf3ca568a72b085cb8654576fef1236b260dc2379cb8e5f922b2"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1740,36 +1432,20 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cabe1f32daa2fa54e6b20d14a13a9e85bef97c4161fe8a90d76b6d9693a5ac4"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "datafusion-doc",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
 name = "datafusion-optimizer"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e12a97dcb0ccc569798be1289c744829cce5f18cc9b037054f8d7f93e1d57be"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "chrono",
@@ -1777,11 +1453,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "log",
  "regex",
@@ -1790,15 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41312712b8659a82b4e9faa8d97a018e7f2ccbdedf2f7cb93ecf256e39858c86"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1809,11 +1475,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "parking_lot",
  "paste",
@@ -1837,15 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1649a60ea0319496d616ae3554e84dfcc262c201ab4439abcd83cca989b85b"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1857,15 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3f5b8ba6122426774aaaf11325740b8e5d3afaab9ab39dc63423adca554748"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1881,15 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a595f296929d6cffa12b993ea53e9fe8215fada050d78626c5cf0e2f02b0205"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1908,11 +1552,7 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.5",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "log",
  "parking_lot",
@@ -1922,15 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d368093a98a17d1449b1083ac22ed16b7128e4c67789991869480d8c4a40ecb9"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ab6f4fa0f3bbfbc0b4f89485bcd7cbed6cca0347e8d1eda50b66b779725b6e"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "chrono",
@@ -1955,15 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6aef3d5e5c1d2bc3114c4876730cb76a9bdc5a8df31ef1b6db48f0c1671895"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba94d76d85459ebbf7c29aa1b001234d551e840192c742a4237ec22de45a557"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1988,34 +1616,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "datafusion-pruning"
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391a457b9d23744c53eeb89edd1027424cba100581488d89800ed841182df905"
-dependencies = [
- "arrow",
- "arrow-schema",
- "datafusion-common",
- "datafusion-datasource",
- "datafusion-expr-common",
- "datafusion-physical-expr",
- "datafusion-physical-expr-common",
- "datafusion-physical-plan",
- "itertools 0.14.0",
- "log",
-]
-
-[[package]]
 name = "datafusion-session"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5f2fe790f43839c70fb9604c4f9b59ad290ef64e1d2f927925dd34a9245406"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2027,26 +1631,16 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
-<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
-=======
-version = "49.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebebb82fda37f62f06fe14339f4faa9f197a0320cc4d26ce2a5fd53a5ccd27c"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "log",
  "regex",
  "sqlparser",
@@ -2086,11 +1680,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -2145,12 +1735,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2278,11 +1868,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -2376,9 +1962,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -2386,11 +1972,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "slab",
  "tokio",
  "tokio-util",
@@ -2399,9 +1981,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2409,11 +1991,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "slab",
  "tokio",
  "tokio-util",
@@ -2567,7 +2145,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2590,7 +2168,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -2635,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2651,11 +2229,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
-<<<<<<< HEAD
  "socket2 0.5.10",
-=======
- "socket2 0.6.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
  "tower-service",
  "tracing",
@@ -2823,15 +2397,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-<<<<<<< HEAD
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
-=======
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2848,17 +2416,6 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "io-uring"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "ipnet"
@@ -2945,11 +2502,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3052,23 +2605,10 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
-=======
-name = "libbz2-rs-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
-
-[[package]]
-name = "libc"
-version = "0.2.174"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "libm"
@@ -3109,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "lodepng"
-version = "3.12.1"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a32335d22e44238e2bb0b4d726964d18952ce1f1279ec3305305d2c61539eb"
+checksum = "a7720115060cd38dcfe5c758525a43fd34dc615d0566374212ff0dc3b6151eac"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -3142,15 +2682,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-<<<<<<< HEAD
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
-=======
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "twox-hash",
 ]
@@ -3411,15 +2945,9 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-<<<<<<< HEAD
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
-=======
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -3436,8 +2964,8 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
- "reqwest 0.12.22",
+ "rand 0.9.1",
+ "reqwest 0.12.20",
  "ring",
  "serde",
  "serde_json",
@@ -3518,15 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be3e4f6d320dd92bfa7d612e265d7d08bba0a240bab86af3425e1d255a511d89"
-=======
-version = "55.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17da4150748086bd43352bc77372efa9b6e3dbd06a04831d2a98c041c225cfa"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3550,7 +3072,6 @@ dependencies = [
  "num-traits",
  "object_store",
  "paste",
- "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -3588,11 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3603,11 +3120,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "serde",
 ]
 
@@ -3617,16 +3130,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared 0.12.1",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3636,7 +3140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared 0.11.3",
+ "phf_shared",
 ]
 
 [[package]]
@@ -3645,7 +3149,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared 0.11.3",
+ "phf_shared",
  "rand 0.8.5",
 ]
 
@@ -3657,15 +3161,6 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "uncased",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3685,11 +3180,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3824,16 +3315,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.36"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3890,11 +3377,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tempfile",
 ]
 
@@ -3908,7 +3391,6 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
 ]
 
@@ -3923,9 +3405,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3953,13 +3432,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "chrono",
-<<<<<<< HEAD
  "chrono-tz 0.10.3",
  "indexmap 2.12.1",
-=======
- "chrono-tz 0.10.4",
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "indoc",
  "libc",
  "memoffset",
@@ -3968,7 +3442,6 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "serde",
  "unindent",
 ]
 
@@ -3987,11 +3460,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.10.3",
  "half",
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "numpy",
  "pyo3",
  "thiserror 1.0.69",
@@ -4025,11 +3494,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4042,11 +3507,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4061,15 +3522,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-<<<<<<< HEAD
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-=======
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "memchr",
  "serde",
@@ -4104,7 +3559,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4118,9 +3573,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.13"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4141,9 +3596,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -4158,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -4231,33 +3686,10 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "recursive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
-dependencies = [
- "recursive-proc-macro-impl",
- "stacker",
-]
-
-[[package]]
-name = "recursive-proc-macro-impl"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
-dependencies = [
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -4308,7 +3740,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -4337,16 +3769,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.22"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4381,9 +3813,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -4439,7 +3871,6 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
-<<<<<<< HEAD
  "syn 2.0.111",
  "unicode-ident",
 ]
@@ -4459,9 +3890,6 @@ dependencies = [
  "relative-path",
  "rustc_version",
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "unicode-ident",
 ]
 
@@ -4471,7 +3899,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "datafusion",
- "reqwest 0.12.22",
+ "reqwest 0.12.20",
  "serde_json",
  "tokio",
  "tonic",
@@ -4481,15 +3909,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-=======
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
-
-[[package]]
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4506,22 +3925,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.31"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "log",
  "once_cell",
@@ -4565,9 +3984,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4618,9 +4037,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -4689,24 +4108,16 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itoa",
  "memchr",
  "ryu",
@@ -4795,21 +4206,7 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-<<<<<<< HEAD
 version = "0.6.1"
-=======
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "sqlparser"
-version = "0.55.0"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
@@ -4835,11 +4232,7 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4898,15 +4291,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-<<<<<<< HEAD
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
-=======
-version = "2.0.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4936,11 +4323,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5021,11 +4404,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5036,11 +4415,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "test-case-core",
 ]
 
@@ -5070,11 +4445,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5085,11 +4456,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5160,31 +4527,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-<<<<<<< HEAD
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
-=======
-version = "1.47.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
- "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
-<<<<<<< HEAD
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
-=======
- "slab",
- "socket2 0.6.0",
- "tokio-macros",
- "windows-sys 0.59.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5195,11 +4548,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5225,15 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-<<<<<<< HEAD
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
-=======
-version = "0.7.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
  "futures-core",
@@ -5254,11 +4597,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
-<<<<<<< HEAD
  "indexmap 2.12.1",
-=======
- "indexmap 2.10.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "toml_datetime",
  "winnow",
 ]
@@ -5274,7 +4613,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.12",
+ "h2 0.4.10",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -5306,11 +4645,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5427,17 +4762,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5611,7 +4942,7 @@ dependencies = [
  "prost-types",
  "protobuf-src",
  "pyo3",
- "rand 0.9.2",
+ "rand 0.9.1",
  "regex",
  "serde",
  "serde_json",
@@ -5662,7 +4993,7 @@ dependencies = [
  "pixelmatch",
  "prost 0.13.5",
  "regex",
- "reqwest 0.12.22",
+ "reqwest 0.12.20",
  "rgb",
  "rstest 0.24.0",
  "serde",
@@ -5686,7 +5017,7 @@ dependencies = [
  "clap",
  "datafusion",
  "futures",
- "h2 0.3.27",
+ "h2 0.3.26",
  "predicates",
  "prost 0.13.5",
  "prost-build",
@@ -5800,11 +5131,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "wasm-bindgen-shared",
 ]
 
@@ -5839,11 +5166,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5878,11 +5201,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5920,9 +5239,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6018,11 +5337,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -6033,11 +5348,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -6113,7 +5424,6 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
-<<<<<<< HEAD
  "windows-targets 0.53.5",
 ]
 
@@ -6124,9 +5434,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-=======
- "windows-targets 0.53.3",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -6162,7 +5469,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-<<<<<<< HEAD
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -6176,21 +5482,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-=======
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -6216,15 +5507,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6240,15 +5525,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6264,15 +5543,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -6282,15 +5555,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6306,15 +5573,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6330,15 +5591,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6354,15 +5609,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-=======
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6378,7 +5627,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
@@ -6386,17 +5634,8 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winnow"
 version = "0.7.11"
-=======
-version = "0.53.0"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
-
-[[package]]
-name = "winnow"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -6446,32 +5685,21 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-<<<<<<< HEAD
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
-=======
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-<<<<<<< HEAD
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
@@ -6479,15 +5707,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-=======
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -6507,11 +5726,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "synstructure",
 ]
 
@@ -6534,9 +5749,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6551,11 +5766,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
-<<<<<<< HEAD
  "syn 2.0.111",
-=======
- "syn 2.0.104",
->>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -111,22 +111,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -137,9 +137,15 @@ checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrow"
+<<<<<<< HEAD
 version = "57.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4df8bb5b0bd64c0b9bc61317fcc480bad0f00e56d3bc32c69a4c8dada4786bae"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3f15b4c6b148206ff3a2b35002e08929c2462467b62b9c02036d9c34f9ef994"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -158,9 +164,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f377dcd19e440174596d83deb49cd724886d91060c07fec4f67014ef9d54049"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30feb679425110209ae35c3fbf82404a39a4c0436bb3ec36164d8bffed2a4ce4"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -172,16 +184,22 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eaff85a44e9fa914660fb0d0bb00b79c4a3d888b5334adb3ea4330c84f002"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70732f04d285d49054a48b72c54f791bb3424abae92d27aafdf776c98af161c8"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "chrono-tz 0.10.3",
+ "chrono-tz 0.10.4",
  "half",
  "hashbrown 0.16.1",
  "num-complex",
@@ -191,9 +209,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2819d893750cb3380ab31ebdc8c68874dd4429f90fd09180f3c93538bd21626"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169b1d5d6cb390dd92ce582b06b23815c7953e9dfaaea75556e89d890d19993d"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
  "half",
@@ -203,9 +227,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3d131abb183f80c450d4591dc784f8d7750c50c6e2bc3fcaad148afc8361271"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f12eccc3e1c05a766cafb31f6a60a46c2f8efec9b74c6e0648766d30686af8"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -225,9 +255,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2275877a0e5e7e7c76954669366c2aa1a829e340ab1f612e647507860906fb6b"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "012c9fef3f4a11573b2c74aec53712ff9fdae4a95f4ce452d1bbf088ee00f06b"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -240,9 +276,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05738f3d42cb922b9096f7786f606fcb8669260c2640df8490533bb2fa38c9d3"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de1ce212d803199684b658fc4ba55fb2d7e87b213de5af415308d2fee3619c2"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -253,9 +295,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d09446e8076c4b3f235603d9ea7c5494e73d441b01cd61fb33d7254c11964b3"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9ea5967e8b2af39aff5d9de2197df16e305f47f404781d3230b2dc672da5d92"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,13 +312,20 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex",
+ "zstd",
 ]
 
 [[package]]
 name = "arrow-json"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "371ffd66fa77f71d7628c63f209c9ca5341081051aa32f9c8020feb0def787c0"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5709d974c4ea5be96d900c01576c7c0b99705f4a3eec343648cb1ca863988a9c"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -279,8 +334,12 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
+<<<<<<< HEAD
  "indexmap 2.12.1",
  "itoa",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "lexical-core",
  "memchr",
  "num-traits",
@@ -292,9 +351,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbc94fc7adec5d1ba9e8cd1b1e8d6f72423b33fe978bf1f46d970fafab787521"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6506e3a059e3be23023f587f79c82ef0bcf6d293587e3272d20f2d30b969b5a7"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -305,9 +370,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169676f317157dc079cc5def6354d16db63d8861d61046d2f3883268ced6f99f"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52bf7393166beaf79b4bed9bfdf19e97472af32ce5b6b48169d321518a08cae2"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -318,9 +389,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27609cd7dd45f006abae27995c2729ef6f4b9361cde1ddd019dc31a5aa017e0"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bitflags 2.9.1",
  "serde_core",
@@ -329,9 +406,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae980d021879ea119dd6e2a13912d81e64abed372d53163e804dfe84639d8010"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2b45757d6a2373faa3352d02ff5b54b098f5e21dccebc45a21806bc34501e5"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-array",
@@ -343,9 +426,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf35e8ef49dcf0c5f6d175edee6b8af7b45611805333129c541a8b89a0fc0534"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0377d532850babb4d927a06294314b316e23311503ed580ec6ce6a0158f49d40"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -375,6 +464,26 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "async-compression"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
+dependencies = [
+ "bzip2 0.5.2",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "xz2",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,7 +509,11 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -422,7 +535,11 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -433,7 +550,11 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -453,9 +574,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -596,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -619,6 +740,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bea8dcd42434048e4f7a304411d9273a411f647446c1234a65ce0554923f4cff"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,9 +778,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
 dependencies = [
  "jobserver",
  "libc",
@@ -668,20 +820,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.3.0",
- "phf",
+ "chrono-tz-build",
+ "phf 0.11.3",
  "uncased",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
- "chrono-tz-build 0.4.1",
- "phf",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -691,20 +842,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "regex",
  "uncased",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
-dependencies = [
- "parse-zoneinfo",
- "phf_codegen",
 ]
 
 [[package]]
@@ -736,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.40"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
+checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -746,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.40"
+version = "4.5.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
+checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
 dependencies = [
  "anstream",
  "anstyle",
@@ -758,14 +899,18 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.40"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -864,9 +1009,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -932,9 +1077,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -983,14 +1128,24 @@ dependencies = [
 
 [[package]]
 name = "datafusion"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba7cb113e9c0bedf9e9765926031e132fa05a1b09ba6e93a6d1a4d7044457b8"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f47772c28553d837e12cdcc0fb04c2a0fe8eca8b704a30f721d076f32407435"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-schema",
  "async-trait",
  "bytes",
+<<<<<<< HEAD
+=======
+ "bzip2 0.6.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -1017,12 +1172,13 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "rstest 0.26.1",
  "tempfile",
@@ -1033,9 +1189,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66a3a799f914a59b1ea343906a0486f17061f39509af74e874a866428951130d"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6b29c9c922959285fac53139e12c81014e2ca54704f20355edd7e9d11fd773"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1058,9 +1220,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog-listing"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db1b113c80d7a0febcd901476a57aef378e717c54517a163ed51417d87621b0"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7313553e4c01d184dd49183afdfa22f23204a10a26dd12e6f799203d8fdb95c2"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1082,17 +1250,32 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c10f7659e96127d25e8366be7c8be4109595d6a2c3eac70421f380a7006a1b0"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d66104731b7476a8c86fbe7a6fd741e6329791166ac89a91fcd8336a560ddaf"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
  "arrow-ipc",
+<<<<<<< HEAD
  "chrono",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.12.1",
+=======
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "hashbrown 0.14.5",
+ "hex",
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "libc",
  "log",
  "object_store",
@@ -1105,9 +1288,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common-runtime"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b92065bbc6532c6651e2f7dd30b55cba0c7a14f860c7e1d15f165c41a1868d95"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7527ecdfeae6961a8564d3b036507a67bd467fd36a9f10cf8ad7a99db1f1bc"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "futures",
  "log",
@@ -1116,13 +1305,23 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde13794244bc7581cd82f6fff217068ed79cdc344cafe4ab2c3a1c3510b38d6"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e5076be33d8eb9f4d99858e5f3477b36c07e61eee8eb93c4320428d9e1e344"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
  "bytes",
+<<<<<<< HEAD
+=======
+ "bzip2 0.6.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "chrono",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -1138,12 +1337,19 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "object_store",
+<<<<<<< HEAD
  "rand 0.9.1",
+=======
+ "parquet",
+ "rand 0.9.2",
+ "tempfile",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
  "url",
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "datafusion-datasource-arrow"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1172,6 +1378,12 @@ name = "datafusion-datasource-csv"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61a1641a40b259bab38131c5e6f48fac0717bedb7dc93690e604142a849e0568"
+=======
+name = "datafusion-datasource-csv"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "785518d0f2f136c19b9389a10762c01a5aeb5fcdebdb244297bb656b2862dc88"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1192,9 +1404,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-json"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adeacdb00c1d37271176f8fb6a1d8ce096baba16ea7a4b2671840c5c9c64fe85"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cb7c3bad0951bf5c52505d0e6d87e6c0098156d2a195924cbcdc82238d29ba"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1214,9 +1432,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-datasource-parquet"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d0b60ffd66f28bfb026565d62b0a6cbc416da09814766a3797bba7d85a3cd9"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea76ad2c5189c98a6b1d4bdf6c3b3caacc9701c417af6661597c946a201bc328"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1234,16 +1458,22 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
+ "hex",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
  "parquet",
+<<<<<<< HEAD
+=======
+ "rand 0.9.2",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-doc"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b99e13947667b36ad713549237362afb054b2d8f8cc447751e23ec61202db07"
@@ -1253,6 +1483,17 @@ name = "datafusion-execution"
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63695643190679037bc946ad46a263b62016931547bf119859c511f7ff2f5178"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc45e380db5c6033c3f39e765a3d752679f14315060a7f4030a60066a36946"
+
+[[package]]
+name = "datafusion-execution"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8209805fdce3d5c6e1625f674d3e4ce93e995a56d3709a0bb8d4361062652596"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1263,16 +1504,22 @@ dependencies = [
  "log",
  "object_store",
  "parking_lot",
- "rand 0.9.1",
+ "rand 0.9.2",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a4787cbf5feb1ab351f789063398f67654a6df75c4d37d7f637dc96f951a91"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7879a845e72a00cacffacbdf5f40626049cb9584d2ba8aa0b9172f09833110ab"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1283,8 +1530,12 @@ dependencies = [
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
+<<<<<<< HEAD
  "indexmap 2.12.1",
  "itertools 0.14.0",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "paste",
  "serde_json",
  "sqlparser",
@@ -1292,6 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion-expr-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ce2fb1b8c15c9ac45b0863c30b268c69dc9ee7a1ee13ecf5d067738338173dc"
@@ -1299,15 +1551,30 @@ dependencies = [
  "arrow",
  "datafusion-common",
  "indexmap 2.12.1",
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da7e47e70ef2c7678735c82c392bd74687004043f5fc8072ab8678dc6fa459d"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794a9db7f7b96b3346fc007ff25e994f09b8f0511b4cf7dff651fadfe3ebb28f"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e7b92b04c5c3b1151f055251b36e272071f9088d9701826a533cb4f764af1c8"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1322,8 +1589,13 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
+<<<<<<< HEAD
  "num-traits",
  "rand 0.9.1",
+=======
+ "md-5",
+ "rand 0.9.2",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "regex",
  "unicode-segmentation",
  "uuid",
@@ -1331,9 +1603,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c25210520a9dcf9c2b2cbbce31ebd4131ef5af7fc60ee92b266dc7d159cb305"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f16cb922b62e535a4d484961ac2c1c6d188dbe02e85e026c05f0fabbc8f814e"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1352,9 +1630,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f4a66f3b87300bb70f4124b55434d2ae3fe80455f3574701d0348da040b55d"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f71bb59dc8b4dc985c911f2e0d8cf426c21f565b56dca4b852c244101a1a7a2"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1365,9 +1649,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-nested"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5c06eed03918dc7fe7a9f082a284050f0e9ecf95d72f57712d1496da03b8c4"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27eb3b98a2eb02a8af4ef19cc793cac21fc98d8720b987f15d7d25b8cc875f4d"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "arrow-ord",
@@ -1388,9 +1678,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-table"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db4fed1d71738fbe22e2712d71396db04c25de4111f1ec252b8f4c6d3b25d7f5"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e0940fc3e2fa4645a4d323f9ebf9258b2d7fdad12013a471cae4ae5568683"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "async-trait",
@@ -1404,9 +1700,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d92206aa5ae21892f1552b4d61758a862a70956e6fd7a95cb85db1de74bc6d1"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df03c6c62039578fd110b327c474846fdf3d9077a568f1e8706e585ed30cb98d"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1422,9 +1724,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53ae9bcc39800820d53a22d758b3b8726ff84a5a3e24cecef04ef4e5fdf1c7cc"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "083659a95914bf3ca568a72b085cb8654576fef1236b260dc2379cb8e5f922b2"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -1432,20 +1740,36 @@ dependencies = [
 
 [[package]]
 name = "datafusion-macros"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1063ad4c9e094b3f798acee16d9a47bd7372d9699be2de21b05c3bd3f34ab848"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cabe1f32daa2fa54e6b20d14a13a9e85bef97c4161fe8a90d76b6d9693a5ac4"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "datafusion-doc",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
 name = "datafusion-optimizer"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f35f9ec5d08b87fd1893a30c2929f2559c2f9806ca072d8fefca5009dc0f06a"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e12a97dcb0ccc569798be1289c744829cce5f18cc9b037054f8d7f93e1d57be"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "chrono",
@@ -1453,7 +1777,11 @@ dependencies = [
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-physical-expr",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "log",
  "regex",
@@ -1462,9 +1790,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30cc8012e9eedcb48bbe112c6eff4ae5ed19cf3003cb0f505662e88b7014c5d"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41312712b8659a82b4e9faa8d97a018e7f2ccbdedf2f7cb93ecf256e39858c86"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1475,7 +1809,11 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "parking_lot",
  "paste",
@@ -1499,9 +1837,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90da43e1ec550b172f34c87ec68161986ced70fd05c8d2a2add66eef9c276f03"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1649a60ea0319496d616ae3554e84dfcc262c201ab4439abcd83cca989b85b"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1513,9 +1857,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-optimizer"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce9804f799acd7daef3be7aaffe77c0033768ed8fdbf5fb82fc4c5f2e6bc14e6"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3f5b8ba6122426774aaaf11325740b8e5d3afaab9ab39dc63423adca554748"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1531,9 +1881,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-plan"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acf0ad6b6924c6b1aa7d213b181e012e2d3ec0a64ff5b10ee6282ab0f8532ac"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a595f296929d6cffa12b993ea53e9fe8215fada050d78626c5cf0e2f02b0205"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow",
@@ -1552,7 +1908,11 @@ dependencies = [
  "futures",
  "half",
  "hashbrown 0.14.5",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itertools 0.14.0",
  "log",
  "parking_lot",
@@ -1562,9 +1922,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d368093a98a17d1449b1083ac22ed16b7128e4c67789991869480d8c4a40ecb9"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ab6f4fa0f3bbfbc0b4f89485bcd7cbed6cca0347e8d1eda50b66b779725b6e"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "chrono",
@@ -1589,9 +1955,15 @@ dependencies = [
 
 [[package]]
 name = "datafusion-proto-common"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b6aef3d5e5c1d2bc3114c4876730cb76a9bdc5a8df31ef1b6db48f0c1671895"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba94d76d85459ebbf7c29aa1b001234d551e840192c742a4237ec22de45a557"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "datafusion-common",
@@ -1616,10 +1988,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-pruning"
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391a457b9d23744c53eeb89edd1027424cba100581488d89800ed841182df905"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "itertools 0.14.0",
+ "log",
+]
+
+[[package]]
 name = "datafusion-session"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f96eebd17555386f459037c65ab73aae8df09f464524c709d6a3134ad4f4776"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5f2fe790f43839c70fb9604c4f9b59ad290ef64e1d2f927925dd34a9245406"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -1631,16 +2027,26 @@ dependencies = [
 
 [[package]]
 name = "datafusion-sql"
+<<<<<<< HEAD
 version = "51.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fc195fe60634b2c6ccfd131b487de46dc30eccae8a3c35a13f136e7f440414f"
+=======
+version = "49.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ebebb82fda37f62f06fe14339f4faa9f197a0320cc4d26ce2a5fd53a5ccd27c"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "arrow",
  "bigdecimal",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "log",
  "regex",
  "sqlparser",
@@ -1680,7 +2086,11 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -1735,12 +2145,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1868,7 +2278,11 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -1962,9 +2376,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -1972,7 +2386,11 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "slab",
  "tokio",
  "tokio-util",
@@ -1981,9 +2399,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1991,7 +2409,11 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "slab",
  "tokio",
  "tokio-util",
@@ -2145,7 +2567,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2168,7 +2590,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -2213,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2229,7 +2651,11 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
+<<<<<<< HEAD
  "socket2 0.5.10",
+=======
+ "socket2 0.6.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tokio",
  "tower-service",
  "tracing",
@@ -2397,9 +2823,15 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+<<<<<<< HEAD
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+=======
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2416,6 +2848,17 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -2502,7 +2945,11 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -2605,10 +3052,23 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+=======
+name = "libbz2-rs-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "libm"
@@ -2649,9 +3109,9 @@ dependencies = [
 
 [[package]]
 name = "lodepng"
-version = "3.11.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7720115060cd38dcfe5c758525a43fd34dc615d0566374212ff0dc3b6151eac"
+checksum = "77a32335d22e44238e2bb0b4d726964d18952ce1f1279ec3305305d2c61539eb"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -2682,9 +3142,15 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
+<<<<<<< HEAD
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab6473172471198271ff72e9379150e9dfd70d8e533e0752a27e515b48dd375e"
+=======
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "twox-hash",
 ]
@@ -2945,9 +3411,15 @@ dependencies = [
 
 [[package]]
 name = "object_store"
+<<<<<<< HEAD
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+=======
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc4f07659e11cd45a341cd24d71e683e3be65d9ff1f8150061678fe60437496"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2964,8 +3436,8 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.1",
- "reqwest 0.12.20",
+ "rand 0.9.2",
+ "reqwest 0.12.22",
  "ring",
  "serde",
  "serde_json",
@@ -3046,9 +3518,15 @@ dependencies = [
 
 [[package]]
 name = "parquet"
+<<<<<<< HEAD
 version = "57.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be3e4f6d320dd92bfa7d612e265d7d08bba0a240bab86af3425e1d255a511d89"
+=======
+version = "55.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b17da4150748086bd43352bc77372efa9b6e3dbd06a04831d2a98c041c225cfa"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "ahash",
  "arrow-array",
@@ -3072,6 +3550,7 @@ dependencies = [
  "num-traits",
  "object_store",
  "paste",
+ "ring",
  "seq-macro",
  "simdutf8",
  "snap",
@@ -3109,7 +3588,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3120,7 +3603,11 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.4",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "serde",
 ]
 
@@ -3130,7 +3617,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -3140,7 +3636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -3149,7 +3645,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -3161,6 +3657,15 @@ checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
  "uncased",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3180,7 +3685,11 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3315,12 +3824,16 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "ff24dfcda44452b9816fff4cd4227e1bb73ff5a2f1bc1105aa92fb8565ce44d2"
 dependencies = [
  "proc-macro2",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3377,7 +3890,11 @@ dependencies = [
  "prost 0.13.5",
  "prost-types",
  "regex",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "tempfile",
 ]
 
@@ -3391,6 +3908,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
 ]
 
@@ -3405,6 +3923,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3432,8 +3953,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "chrono",
+<<<<<<< HEAD
  "chrono-tz 0.10.3",
  "indexmap 2.12.1",
+=======
+ "chrono-tz 0.10.4",
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "indoc",
  "libc",
  "memoffset",
@@ -3442,6 +3968,7 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
+ "serde",
  "unindent",
 ]
 
@@ -3460,7 +3987,11 @@ dependencies = [
  "chrono",
  "chrono-tz 0.10.3",
  "half",
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "numpy",
  "pyo3",
  "thiserror 1.0.69",
@@ -3494,7 +4025,11 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3507,7 +4042,11 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -3522,9 +4061,15 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
+<<<<<<< HEAD
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+=======
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9845d9dccf565065824e69f9f235fafba1587031eda353c1f1561cd6a6be78f4"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "memchr",
  "serde",
@@ -3559,7 +4104,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.1",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3573,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3596,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -3613,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -3686,10 +4231,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.13"
+<<<<<<< HEAD
+=======
+name = "recursive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
+dependencies = [
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -3740,7 +4308,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
@@ -3769,16 +4337,16 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.20"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -3813,9 +4381,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
 ]
@@ -3871,6 +4439,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
+<<<<<<< HEAD
  "syn 2.0.111",
  "unicode-ident",
 ]
@@ -3890,6 +4459,9 @@ dependencies = [
  "relative-path",
  "rustc_version",
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "unicode-ident",
 ]
 
@@ -3898,7 +4470,7 @@ name = "rust-examples"
 version = "0.1.0"
 dependencies = [
  "datafusion",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "serde_json",
  "tokio",
  "tonic",
@@ -3908,6 +4480,15 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+=======
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,22 +4505,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "log",
  "once_cell",
@@ -3983,9 +4564,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4036,9 +4617,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
  "bitflags 2.9.1",
  "core-foundation 0.10.1",
@@ -4107,16 +4688,24 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "itoa",
  "memchr",
  "ryu",
@@ -4205,7 +4794,21 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+<<<<<<< HEAD
 version = "0.6.1"
+=======
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.55.0"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
@@ -4231,7 +4834,11 @@ checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4290,9 +4897,15 @@ dependencies = [
 
 [[package]]
 name = "syn"
+<<<<<<< HEAD
 version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+=======
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4322,7 +4935,11 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4403,7 +5020,11 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4414,7 +5035,11 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "test-case-core",
 ]
 
@@ -4444,7 +5069,11 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4455,7 +5084,11 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4526,17 +5159,31 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
+<<<<<<< HEAD
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+=======
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
+<<<<<<< HEAD
  "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
+=======
+ "slab",
+ "socket2 0.6.0",
+ "tokio-macros",
+ "windows-sys 0.59.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4547,7 +5194,11 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4573,9 +5224,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
+<<<<<<< HEAD
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+=======
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "bytes",
  "futures-core",
@@ -4596,7 +5253,11 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
+<<<<<<< HEAD
  "indexmap 2.12.1",
+=======
+ "indexmap 2.10.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "toml_datetime",
  "winnow",
 ]
@@ -4612,7 +5273,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.10",
+ "h2 0.4.12",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4644,7 +5305,11 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4761,13 +5426,17 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -4877,6 +5546,7 @@ version = "2.0.3"
 dependencies = [
  "arrow",
  "async-trait",
+ "datafusion",
  "env_logger",
  "lazy_static",
  "log",
@@ -4929,6 +5599,7 @@ dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
  "datafusion-common",
+ "futures",
  "itertools 0.12.1",
  "lazy_static",
  "log",
@@ -4939,7 +5610,7 @@ dependencies = [
  "prost-types",
  "protobuf-src",
  "pyo3",
- "rand 0.9.1",
+ "rand 0.9.2",
  "regex",
  "serde",
  "serde_json",
@@ -4974,6 +5645,7 @@ dependencies = [
  "datafusion-optimizer",
  "datafusion-physical-expr",
  "datafusion-proto",
+ "datafusion-sql",
  "env_logger",
  "float-cmp",
  "futures",
@@ -4990,7 +5662,7 @@ dependencies = [
  "pixelmatch",
  "prost 0.13.5",
  "regex",
- "reqwest 0.12.20",
+ "reqwest 0.12.22",
  "rgb",
  "rstest 0.24.0",
  "serde",
@@ -5013,8 +5685,8 @@ dependencies = [
  "assert_cmd",
  "clap",
  "datafusion",
- "futures-util",
- "h2 0.3.26",
+ "futures",
+ "h2 0.3.27",
  "predicates",
  "prost 0.13.5",
  "prost-build",
@@ -5128,7 +5800,11 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "wasm-bindgen-shared",
 ]
 
@@ -5163,7 +5839,11 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5198,7 +5878,11 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5236,9 +5920,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5334,7 +6018,11 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5345,7 +6033,11 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5421,6 +6113,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
+<<<<<<< HEAD
  "windows-targets 0.53.5",
 ]
 
@@ -5431,6 +6124,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+=======
+ "windows-targets 0.53.3",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5466,6 +6162,7 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+<<<<<<< HEAD
 version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
@@ -5479,6 +6176,21 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+=======
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5504,9 +6216,15 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5522,9 +6240,15 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5540,9 +6264,15 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -5552,9 +6282,15 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5570,9 +6306,15 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5588,9 +6330,15 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5606,9 +6354,15 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+=======
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5624,6 +6378,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
+<<<<<<< HEAD
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
@@ -5631,8 +6386,17 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winnow"
 version = "0.7.11"
+=======
+version = "0.53.0"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -5682,21 +6446,32 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
+<<<<<<< HEAD
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
+=======
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
+<<<<<<< HEAD
 version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
@@ -5704,6 +6479,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+=======
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]
@@ -5723,7 +6507,11 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
  "synstructure",
 ]
 
@@ -5746,9 +6534,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5763,7 +6551,11 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
+<<<<<<< HEAD
  "syn 2.0.111",
+=======
+ "syn 2.0.104",
+>>>>>>> 14aa8670 (feat: Add support for custom plan executors)
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4469,6 +4469,7 @@ dependencies = [
 name = "rust-examples"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "datafusion",
  "reqwest 0.12.22",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4866,7 +4866,6 @@ dependencies = [
  "chrono",
  "chrono-tz 0.9.0",
  "datafusion-common",
- "futures",
  "itertools 0.14.0",
  "lazy_static",
  "log",

--- a/examples/rust-examples/Cargo.toml
+++ b/examples/rust-examples/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dev-dependencies]
+async-trait = { workspace = true }
 serde_json = { workspace = true }
 vegafusion-common = { path = "../../vegafusion-common" }
 vegafusion-core = { path = "../../vegafusion-core" }

--- a/examples/rust-examples/examples/chart_state.rs
+++ b/examples/rust-examples/examples/chart_state.rs
@@ -10,7 +10,7 @@ async fn main() {
     let spec = get_spec();
 
     // Make runtime
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     // Construct ChartState
     let chart_state = ChartState::try_new(

--- a/examples/rust-examples/examples/custom_executor.rs
+++ b/examples/rust-examples/examples/custom_executor.rs
@@ -1,0 +1,140 @@
+use datafusion::prelude::SessionContext;
+use std::sync::Arc;
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlan;
+use vegafusion_common::error::Result;
+use vegafusion_core::runtime::{PlanExecutor, VegaFusionRuntimeTrait};
+use vegafusion_core::spec::chart::ChartSpec;
+use vegafusion_runtime::datafusion::context::make_datafusion_context;
+use vegafusion_runtime::plan_executor::DataFusionPlanExecutor;
+use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
+
+/// A custom executor that logs plan execution and forwards to DataFusion
+#[derive(Clone)]
+struct LoggingExecutor {
+    fallback: Arc<DataFusionPlanExecutor>,
+}
+
+impl LoggingExecutor {
+    fn new(ctx: Arc<SessionContext>) -> Self {
+        Self {
+            fallback: Arc::new(DataFusionPlanExecutor::new(ctx)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl PlanExecutor for LoggingExecutor {
+    async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
+        println!("Custom executor received logical plan");
+        println!("Plan details:\n{}\n", plan.display_indent());
+
+        // Forward to DataFusion for actual execution
+        let result = self.fallback.execute_plan(plan).await?;
+
+        println!(
+            "Custom executor executed plan, returned {} rows\n",
+            result.num_rows()
+        );
+
+        Ok(result)
+    }
+}
+
+/// This example demonstrates how to use a custom plan executor with VegaFusion.
+/// The custom executor logs each plan execution before forwarding to DataFusion.
+#[tokio::main]
+async fn main() {
+    let spec = get_spec();
+
+    // Create a custom executor
+    let ctx = Arc::new(make_datafusion_context());
+    let custom_executor = Arc::new(LoggingExecutor::new(ctx)) as Arc<dyn PlanExecutor>;
+
+    // Create runtime with custom executor
+    let runtime = VegaFusionRuntime::new(None, Some(custom_executor));
+
+    println!("Starting pre-transform with custom executor\n");
+
+    let (_transformed_spec, warnings) = runtime
+        .pre_transform_spec(
+            &spec,
+            &Default::default(), // Inline datasets
+            &Default::default(), // Options
+        )
+        .await
+        .unwrap();
+    println!("Spec transformed");
+    assert_eq!(warnings.len(), 0);
+}
+
+fn get_spec() -> ChartSpec {
+    let spec_str = r##"
+    {
+      "$schema": "https://vega.github.io/schema/vega/v5.json",
+      "description": "A histogram demonstrating custom executor usage",
+      "width": 400,
+      "height": 200,
+      "padding": 5,
+      "data": [
+        {
+          "name": "table",
+          "url": "data/movies.json",
+          "transform": [
+            {
+              "type": "extent", 
+              "field": "IMDB Rating",
+              "signal": "extent"
+            },
+            {
+              "type": "bin", 
+              "signal": "bins",
+              "field": "IMDB Rating", 
+              "extent": {"signal": "extent"},
+              "maxbins": 10
+            },
+            {
+              "type": "aggregate",
+              "groupby": ["bin0", "bin1"],
+              "ops": ["count"],
+              "fields": [null],
+              "as": ["count"]
+            }
+          ]
+        }
+      ],
+      "scales": [
+        {
+          "name": "xscale",
+          "type": "linear",
+          "range": "width",
+          "domain": {"signal": "extent"}
+        },
+        {
+          "name": "yscale",
+          "type": "linear",
+          "range": "height",
+          "round": true,
+          "domain": {"data": "table", "field": "count"},
+          "zero": true,
+          "nice": true
+        }
+      ],
+      "marks": [
+        {
+          "type": "rect",
+          "from": {"data": "table"},
+          "encode": {
+            "update": {
+              "x": {"scale": "xscale", "field": "bin0"},
+              "x2": {"scale": "xscale", "field": "bin1"},
+              "y": {"scale": "yscale", "field": "count"},
+              "y2": {"scale": "yscale", "value": 0}
+            }
+          }
+        }
+      ]
+    }
+    "##;
+    serde_json::from_str(spec_str).unwrap()
+}

--- a/examples/rust-examples/examples/custom_executor.rs
+++ b/examples/rust-examples/examples/custom_executor.rs
@@ -25,6 +25,10 @@ impl LoggingExecutor {
 
 #[async_trait::async_trait]
 impl PlanExecutor for LoggingExecutor {
+    fn name(&self) -> &str {
+        "LoggingExecutor"
+    }
+
     async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
         println!("Custom executor received logical plan");
         println!("Plan details:\n{}\n", plan.display_indent());

--- a/examples/rust-examples/examples/grpc.rs
+++ b/examples/rust-examples/examples/grpc.rs
@@ -3,7 +3,7 @@ use tonic::transport::{Channel, Uri};
 use vegafusion_core::proto::gen::tasks::Variable;
 use vegafusion_core::runtime::VegaFusionRuntimeTrait;
 use vegafusion_core::spec::chart::ChartSpec;
-use vegafusion_core::task_graph::task_value::TaskValue;
+use vegafusion_core::task_graph::task_value::MaterializedTaskValue;
 use vegafusion_runtime::task_graph::GrpcVegaFusionRuntime;
 
 /// This example demonstrates how to connect to a VegaFusion Server instance over gRPC then use
@@ -40,7 +40,7 @@ async fn main() {
     assert_eq!(values.len(), 1);
     assert_eq!(warnings.len(), 0);
 
-    let TaskValue::Table(counts_table) = &values[0] else {
+    let MaterializedTaskValue::Table(counts_table) = &values[0] else {
         panic!("Expected a table")
     };
 

--- a/examples/rust-examples/examples/inline_datasets.rs
+++ b/examples/rust-examples/examples/inline_datasets.rs
@@ -30,7 +30,7 @@ async fn main() {
     let inline_datasets: HashMap<String, VegaFusionDataset> =
         vec![("movies".to_string(), dataset)].into_iter().collect();
 
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let (transformed_spec, warnings) = runtime
         .pre_transform_spec(

--- a/examples/rust-examples/examples/inline_datasets_plan.rs
+++ b/examples/rust-examples/examples/inline_datasets_plan.rs
@@ -43,7 +43,7 @@ async fn main() -> vegafusion_common::error::Result<()> {
     let inline_datasets: HashMap<String, VegaFusionDataset> =
         vec![("movies".to_string(), dataset)].into_iter().collect();
 
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let (transformed_spec, warnings) = runtime
         .pre_transform_spec(

--- a/examples/rust-examples/examples/pre_transform_data.rs
+++ b/examples/rust-examples/examples/pre_transform_data.rs
@@ -1,7 +1,7 @@
 use vegafusion_core::proto::gen::tasks::Variable;
 use vegafusion_core::runtime::VegaFusionRuntimeTrait;
 use vegafusion_core::spec::chart::ChartSpec;
-use vegafusion_core::task_graph::task_value::TaskValue;
+use vegafusion_core::task_graph::task_value::MaterializedTaskValue;
 use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 
 /// This example demonstrates how to use the `pre_transform_values` method to get
@@ -10,7 +10,7 @@ use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 async fn main() {
     let spec = get_spec();
 
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let (values, warnings) = runtime
         .pre_transform_values(
@@ -25,7 +25,7 @@ async fn main() {
     assert_eq!(values.len(), 1);
     assert_eq!(warnings.len(), 0);
 
-    let TaskValue::Table(counts_table) = &values[0] else {
+    let MaterializedTaskValue::Table(counts_table) = &values[0] else {
         panic!("Expected a table")
     };
 

--- a/examples/rust-examples/examples/pre_transform_extract.rs
+++ b/examples/rust-examples/examples/pre_transform_extract.rs
@@ -9,7 +9,7 @@ use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 async fn main() {
     let spec = get_spec();
 
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let (transformed_spec, datasets, warnings) = runtime
         .pre_transform_extract(

--- a/examples/rust-examples/examples/pre_transform_spec.rs
+++ b/examples/rust-examples/examples/pre_transform_spec.rs
@@ -8,7 +8,7 @@ use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 async fn main() {
     let spec = get_spec();
 
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let (transformed_spec, warnings) = runtime
         .pre_transform_spec(

--- a/vegafusion-common/src/data/table.rs
+++ b/vegafusion-common/src/data/table.rs
@@ -342,7 +342,8 @@ impl VegaFusionTable {
             let hash = vf_table.get_hash();
 
             // Now rechunk for better multithreaded efficiency with DataFusion
-            let kwargs = [("max_chunksize", 8096)].into_py_dict(py)?;
+            let kwargs = PyDict::new(py);
+            kwargs.set_item("max_chunksize", 8096)?;
 
             let rechunked_table = data
                 .call_method("rechunk", (), Some(&kwargs))?

--- a/vegafusion-common/src/data/table.rs
+++ b/vegafusion-common/src/data/table.rs
@@ -342,8 +342,7 @@ impl VegaFusionTable {
             let hash = vf_table.get_hash();
 
             // Now rechunk for better multithreaded efficiency with DataFusion
-            let kwargs = PyDict::new(py);
-            kwargs.set_item("max_chunksize", 8096)?;
+            let kwargs = [("max_chunksize", 8096)].into_py_dict(py)?;
 
             let rechunked_table = data
                 .call_method("rechunk", (), Some(&kwargs))?

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -42,6 +42,9 @@ optional = true
 workspace = true
 features = ["preserve_order"]
 
+[dependencies.futures]
+workspace = true
+
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser"]

--- a/vegafusion-core/Cargo.toml
+++ b/vegafusion-core/Cargo.toml
@@ -42,9 +42,6 @@ optional = true
 workspace = true
 features = ["preserve_order"]
 
-[dependencies.futures]
-workspace = true
-
 [dependencies.vegafusion-common]
 path = "../vegafusion-common"
 features = ["json", "sqlparser"]

--- a/vegafusion-core/src/data/dataset.rs
+++ b/vegafusion-core/src/data/dataset.rs
@@ -9,6 +9,20 @@ pub enum VegaFusionDataset {
 }
 
 impl VegaFusionDataset {
+    pub fn as_table(&self) -> Option<&VegaFusionTable> {
+        match self {
+            VegaFusionDataset::Table { table, .. } => Some(table),
+            _ => None,
+        }
+    }
+
+    pub fn as_plan(&self) -> Option<&LogicalPlan> {
+        match self {
+            VegaFusionDataset::Plan { plan } => Some(plan),
+            _ => None,
+        }
+    }
+
     pub fn fingerprint(&self) -> String {
         match self {
             VegaFusionDataset::Table { hash, .. } => hash.to_string(),

--- a/vegafusion-core/src/planning/apply_pre_transform.rs
+++ b/vegafusion-core/src/planning/apply_pre_transform.rs
@@ -1,7 +1,7 @@
 use super::{
     destringify_selection_datetimes::destringify_selection_datetimes,
     plan::SpecPlan,
-    watch::{ExportUpdateArrow, ExportUpdateNamespace},
+    watch::{ExportUpdateNamespace, MaterializedExportUpdate},
 };
 use crate::{
     proto::gen::{
@@ -20,7 +20,7 @@ use vegafusion_common::error::{Result, VegaFusionError};
 pub fn apply_pre_transform_datasets(
     input_spec: &ChartSpec,
     plan: &SpecPlan,
-    init: Vec<ExportUpdateArrow>,
+    init: Vec<MaterializedExportUpdate>,
     row_limit: Option<u32>,
 ) -> Result<(ChartSpec, Vec<PreTransformSpecWarning>)> {
     // Update client spec with server values

--- a/vegafusion-core/src/planning/watch.rs
+++ b/vegafusion-core/src/planning/watch.rs
@@ -1,7 +1,7 @@
 use crate::planning::stitch::CommPlan;
 use crate::proto::gen::tasks::{Variable, VariableNamespace};
 use crate::task_graph::graph::ScopedVariable;
-use crate::task_graph::task_value::TaskValue;
+use crate::task_graph::task_value::{MaterializedTaskValue, TaskValue};
 use datafusion_common::ScalarValue;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -120,11 +120,19 @@ impl TryFrom<VariableNamespace> for ExportUpdateNamespace {
 }
 
 #[derive(Debug, Clone)]
-pub struct ExportUpdateArrow {
+pub struct ExportUpdate {
     pub namespace: ExportUpdateNamespace,
     pub name: String,
     pub scope: Vec<u32>,
     pub value: TaskValue,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExportUpdateArrow {
+    pub namespace: ExportUpdateNamespace,
+    pub name: String,
+    pub scope: Vec<u32>,
+    pub value: MaterializedTaskValue,
 }
 
 impl ExportUpdateArrow {

--- a/vegafusion-core/src/planning/watch.rs
+++ b/vegafusion-core/src/planning/watch.rs
@@ -128,14 +128,14 @@ pub struct ExportUpdate {
 }
 
 #[derive(Debug, Clone)]
-pub struct ExportUpdateArrow {
+pub struct MaterializedExportUpdate {
     pub namespace: ExportUpdateNamespace,
     pub name: String,
     pub scope: Vec<u32>,
     pub value: MaterializedTaskValue,
 }
 
-impl ExportUpdateArrow {
+impl MaterializedExportUpdate {
     pub fn to_json(&self) -> Result<ExportUpdateJSON> {
         Ok(ExportUpdateJSON {
             namespace: self.namespace.clone(),

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -115,3 +115,23 @@ message PreTransformExtractRequest {
   repeated tasks.InlineDataset inline_datasets = 2;
   PreTransformExtractOpts opts = 3;
 }
+
+message PreTransformLogicalPlanOpts {
+  string local_tz = 1;
+  optional string default_input_tz = 2;
+  bool preserve_interactivity = 3;
+  repeated PreTransformVariable keep_variables = 4;
+}
+
+message ExportUpdate {
+  string namespace = 1;
+  string name = 2;
+  repeated uint32 scope = 3;
+  tasks.MaterializedTaskValue value = 4;
+}
+
+message PreTransformLogicalPlanWarning {
+  oneof warning_type {
+    PlannerWarning planner = 1;
+  }
+}

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -123,7 +123,7 @@ message PreTransformLogicalPlanOpts {
   repeated PreTransformVariable keep_variables = 4;
 }
 
-message ExportUpdate {
+message MaterializedExportUpdate {
   string namespace = 1;
   string name = 2;
   repeated uint32 scope = 3;

--- a/vegafusion-core/src/proto/pretransform.proto
+++ b/vegafusion-core/src/proto/pretransform.proto
@@ -116,22 +116,9 @@ message PreTransformExtractRequest {
   PreTransformExtractOpts opts = 3;
 }
 
-message PreTransformLogicalPlanOpts {
-  string local_tz = 1;
-  optional string default_input_tz = 2;
-  bool preserve_interactivity = 3;
-  repeated PreTransformVariable keep_variables = 4;
-}
-
 message MaterializedExportUpdate {
   string namespace = 1;
   string name = 2;
   repeated uint32 scope = 3;
   tasks.MaterializedTaskValue value = 4;
-}
-
-message PreTransformLogicalPlanWarning {
-  oneof warning_type {
-    PlannerWarning planner = 1;
-  }
 }

--- a/vegafusion-core/src/proto/tasks.proto
+++ b/vegafusion-core/src/proto/tasks.proto
@@ -4,8 +4,9 @@ package tasks;
 import "expression.proto";
 import "transforms.proto";
 
-// ## Task Value
-message TaskValue {
+// ## Materialized Task Value
+// Represents a fully materialized (computed) task value, either a scalar or table
+message MaterializedTaskValue {
   oneof data {
   /*
    * Representation of scalar as single column, single row, record batch in Arrow IPC format
@@ -109,7 +110,7 @@ message Task {
   Variable variable = 1;
   repeated uint32 scope = 2;
   oneof task_kind {
-    TaskValue value = 3;
+    MaterializedTaskValue value = 3;
     DataValuesTask data_values = 4;
     DataUrlTask data_url = 5;
     DataSourceTask data_source = 6;
@@ -156,7 +157,7 @@ message TaskGraphValueRequest {
 message ResponseTaskValue {
   Variable variable = 1;
   repeated uint32 scope = 2;
-  TaskValue value = 3;
+  MaterializedTaskValue value = 3;
 }
 
 message TaskGraphValueResponse {

--- a/vegafusion-core/src/runtime/mod.rs
+++ b/vegafusion-core/src/runtime/mod.rs
@@ -1,2 +1,5 @@
+mod plan_executor;
 mod runtime;
+
+pub use plan_executor::{NoOpPlanExecutor, PlanExecutor};
 pub use runtime::{PreTransformExtractTable, VegaFusionRuntimeTrait};

--- a/vegafusion-core/src/runtime/mod.rs
+++ b/vegafusion-core/src/runtime/mod.rs
@@ -1,5 +1,5 @@
 mod plan_executor;
 mod runtime;
 
-pub use plan_executor::{NoOpPlanExecutor, PlanExecutor};
+pub use plan_executor::PlanExecutor;
 pub use runtime::{PreTransformExtractTable, VegaFusionRuntimeTrait};

--- a/vegafusion-core/src/runtime/plan_executor.rs
+++ b/vegafusion-core/src/runtime/plan_executor.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlan;
+use vegafusion_common::error::{Result, VegaFusionError};
+
+#[async_trait]
+pub trait PlanExecutor: Send + Sync {
+    async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable>;
+}
+
+/// A no-op implementation of PlanExecutor that always returns an error
+/// This is useful for contexts where a PlanExecutor is required but plan execution is not expected
+#[derive(Debug, Clone, Default)]
+pub struct NoOpPlanExecutor;
+
+#[async_trait]
+impl PlanExecutor for NoOpPlanExecutor {
+    async fn execute_plan(&self, _plan: LogicalPlan) -> Result<VegaFusionTable> {
+        Err(VegaFusionError::internal(
+            "NoOpPlanExecutor cannot execute logical plans. Provide a concrete PlanExecutor (e.g., DataFusionPlanExecutor).",
+        ))
+    }
+}

--- a/vegafusion-core/src/runtime/plan_executor.rs
+++ b/vegafusion-core/src/runtime/plan_executor.rs
@@ -1,28 +1,10 @@
 use async_trait::async_trait;
 use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_common::datafusion_expr::LogicalPlan;
-use vegafusion_common::error::{Result, VegaFusionError};
+use vegafusion_common::error::Result;
 
 #[async_trait]
 pub trait PlanExecutor: Send + Sync {
     fn name(&self) -> &str;
     async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable>;
-}
-
-/// A no-op implementation of PlanExecutor that always returns an error
-/// This is useful for contexts where a PlanExecutor is required but plan execution is not expected
-#[derive(Debug, Clone, Default)]
-pub struct NoOpPlanExecutor;
-
-#[async_trait]
-impl PlanExecutor for NoOpPlanExecutor {
-    fn name(&self) -> &str {
-        "NoOpPlanExecutor"
-    }
-
-    async fn execute_plan(&self, _plan: LogicalPlan) -> Result<VegaFusionTable> {
-        Err(VegaFusionError::internal(
-            "NoOpPlanExecutor cannot execute logical plans. Provide a concrete PlanExecutor (e.g., DataFusionPlanExecutor).",
-        ))
-    }
 }

--- a/vegafusion-core/src/runtime/plan_executor.rs
+++ b/vegafusion-core/src/runtime/plan_executor.rs
@@ -5,6 +5,7 @@ use vegafusion_common::error::{Result, VegaFusionError};
 
 #[async_trait]
 pub trait PlanExecutor: Send + Sync {
+    fn name(&self) -> &str;
     async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable>;
 }
 
@@ -15,6 +16,10 @@ pub struct NoOpPlanExecutor;
 
 #[async_trait]
 impl PlanExecutor for NoOpPlanExecutor {
+    fn name(&self) -> &str {
+        "NoOpPlanExecutor"
+    }
+
     async fn execute_plan(&self, _plan: LogicalPlan) -> Result<VegaFusionTable> {
         Err(VegaFusionError::internal(
             "NoOpPlanExecutor cannot execute logical plans. Provide a concrete PlanExecutor (e.g., DataFusionPlanExecutor).",

--- a/vegafusion-core/src/runtime/runtime.rs
+++ b/vegafusion-core/src/runtime/runtime.rs
@@ -42,7 +42,7 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        Arc::new(NoOpPlanExecutor::default())
+        Arc::new(NoOpPlanExecutor)
     }
 
     async fn query_request(
@@ -381,7 +381,6 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
 
         let materialized_futures = named_task_values.into_iter().map(|named_task_value| {
             let plan_executor = plan_executor.clone();
-            let row_limit = row_limit;
             async move {
                 let value = named_task_value.value;
                 let variable = named_task_value.variable;

--- a/vegafusion-core/src/runtime/runtime.rs
+++ b/vegafusion-core/src/runtime/runtime.rs
@@ -79,12 +79,14 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
         Ok(materialized
             .into_iter()
             .zip(metadata)
-            .map(|(value, (namespace, name, scope))| MaterializedExportUpdate {
-                namespace,
-                name,
-                scope,
-                value,
-            })
+            .map(
+                |(value, (namespace, name, scope))| MaterializedExportUpdate {
+                    namespace,
+                    name,
+                    scope,
+                    value,
+                },
+            )
             .collect())
     }
 
@@ -403,22 +405,19 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
 
         let mut task_values = Vec::new();
         for (materialized_value, variable) in materialized.into_iter().zip(variables) {
-            let final_value =
-                if let (Some(row_limit), MaterializedTaskValue::Table(table)) =
-                    (row_limit, &materialized_value)
-                {
-                    let warning = PreTransformValuesWarning {
-                        warning_type: Some(ValuesWarningType::RowLimit(
-                            PreTransformRowLimitWarning {
-                                datasets: vec![variable],
-                            },
-                        )),
-                    };
-                    warnings.push(warning);
-                    MaterializedTaskValue::Table(table.head(row_limit))
-                } else {
-                    materialized_value
+            let final_value = if let (Some(row_limit), MaterializedTaskValue::Table(table)) =
+                (row_limit, &materialized_value)
+            {
+                let warning = PreTransformValuesWarning {
+                    warning_type: Some(ValuesWarningType::RowLimit(PreTransformRowLimitWarning {
+                        datasets: vec![variable],
+                    })),
                 };
+                warnings.push(warning);
+                MaterializedTaskValue::Table(table.head(row_limit))
+            } else {
+                materialized_value
+            };
 
             task_values.push(final_value);
         }

--- a/vegafusion-core/src/runtime/runtime.rs
+++ b/vegafusion-core/src/runtime/runtime.rs
@@ -9,7 +9,7 @@ use crate::{
         apply_pre_transform::apply_pre_transform_datasets,
         destringify_selection_datetimes::destringify_selection_datetimes,
         plan::{PlannerConfig, SpecPlan},
-        watch::{ExportUpdate, ExportUpdateArrow, ExportUpdateNamespace},
+        watch::{ExportUpdate, ExportUpdateNamespace, MaterializedExportUpdate},
     },
     proto::gen::{
         pretransform::{
@@ -55,13 +55,13 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
     async fn materialize_export_updates(
         &self,
         export_updates: Vec<ExportUpdate>,
-    ) -> Result<Vec<ExportUpdateArrow>> {
+    ) -> Result<Vec<MaterializedExportUpdate>> {
         let executor = self.plan_executor();
         try_join_all(export_updates.into_iter().map(|eu| {
             let exec = executor.clone();
             async move {
                 let value = eu.value.to_materialized(exec).await?;
-                Ok(ExportUpdateArrow {
+                Ok(MaterializedExportUpdate {
                     namespace: eu.namespace,
                     name: eu.name,
                     scope: eu.scope,

--- a/vegafusion-core/src/runtime/runtime.rs
+++ b/vegafusion-core/src/runtime/runtime.rs
@@ -13,8 +13,7 @@ use crate::{
     proto::gen::{
         pretransform::{
             pre_transform_extract_warning, PlannerWarning, PreTransformExtractOpts,
-            PreTransformExtractWarning, PreTransformLogicalPlanOpts,
-            PreTransformLogicalPlanWarning, PreTransformRowLimitWarning, PreTransformSpecOpts,
+            PreTransformExtractWarning, PreTransformRowLimitWarning, PreTransformSpecOpts,
             PreTransformSpecWarning, PreTransformValuesOpts, PreTransformValuesWarning,
         },
         tasks::{NodeValueIndex, TaskGraph, TzConfig, VariableNamespace},
@@ -423,49 +422,5 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
         }
 
         Ok((task_values, warnings))
-    }
-
-    async fn pre_transform_logical_plan(
-        &self,
-        spec: &ChartSpec,
-        inline_datasets: HashMap<String, VegaFusionDataset>,
-        options: &PreTransformLogicalPlanOpts,
-    ) -> Result<(
-        ChartSpec,
-        Vec<ExportUpdate>,
-        Vec<PreTransformLogicalPlanWarning>,
-    )> {
-        let keep_variables: Vec<ScopedVariable> = options
-            .keep_variables
-            .clone()
-            .into_iter()
-            .map(|var| (var.variable.unwrap(), var.scope))
-            .collect();
-        let (plan, export_updates) = self
-            .pre_transform_spec_plan(
-                spec,
-                &options.local_tz,
-                &options.default_input_tz,
-                options.preserve_interactivity,
-                &inline_datasets,
-                keep_variables,
-            )
-            .await?;
-
-        let warnings: Vec<PreTransformLogicalPlanWarning> = plan
-            .warnings
-            .iter()
-            .map(|planner_warning| PreTransformLogicalPlanWarning {
-                warning_type: Some(
-                    crate::proto::gen::pretransform::pre_transform_logical_plan_warning::WarningType::Planner(
-                        PlannerWarning {
-                            message: planner_warning.message(),
-                        },
-                    ),
-                ),
-            })
-            .collect();
-
-        Ok((plan.client_spec, export_updates, warnings))
     }
 }

--- a/vegafusion-core/src/runtime/runtime.rs
+++ b/vegafusion-core/src/runtime/runtime.rs
@@ -1,8 +1,7 @@
 use std::{any::Any, collections::HashMap, sync::Arc};
 
 use crate::proto::gen::pretransform::pre_transform_values_warning::WarningType as ValuesWarningType;
-use crate::runtime::{NoOpPlanExecutor, PlanExecutor};
-use crate::task_graph::task_value::MaterializedTaskValue;
+use crate::task_graph::task_value::{MaterializedTaskValue, TaskValue};
 use crate::{
     data::dataset::VegaFusionDataset,
     planning::{
@@ -24,7 +23,6 @@ use crate::{
     task_graph::{graph::ScopedVariable, task_value::NamedTaskValue},
 };
 use async_trait::async_trait;
-use futures::future::try_join_all;
 use vegafusion_common::{
     data::table::VegaFusionTable,
     error::{Result, ResultWithContext, VegaFusionError},
@@ -41,10 +39,6 @@ pub struct PreTransformExtractTable {
 pub trait VegaFusionRuntimeTrait: Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
-    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        Arc::new(NoOpPlanExecutor)
-    }
-
     async fn query_request(
         &self,
         task_graph: Arc<TaskGraph>,
@@ -52,24 +46,46 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
         inline_datasets: &HashMap<String, VegaFusionDataset>,
     ) -> Result<Vec<NamedTaskValue>>;
 
+    async fn materialize_task_values(
+        &self,
+        values: Vec<TaskValue>,
+    ) -> Result<Vec<MaterializedTaskValue>> {
+        let mut results = Vec::with_capacity(values.len());
+        for value in values {
+            results.push(match value {
+                TaskValue::Scalar(s) => MaterializedTaskValue::Scalar(s),
+                TaskValue::Table(t) => MaterializedTaskValue::Table(t),
+                TaskValue::Plan(_) => {
+                    return Err(VegaFusionError::internal(
+                        "Cannot materialize LogicalPlan in this runtime. Use a runtime with a PlanExecutor.",
+                    ))
+                }
+            });
+        }
+        Ok(results)
+    }
+
     async fn materialize_export_updates(
         &self,
         export_updates: Vec<ExportUpdate>,
     ) -> Result<Vec<MaterializedExportUpdate>> {
-        let executor = self.plan_executor();
-        try_join_all(export_updates.into_iter().map(|eu| {
-            let exec = executor.clone();
-            async move {
-                let value = eu.value.to_materialized(exec).await?;
-                Ok(MaterializedExportUpdate {
-                    namespace: eu.namespace,
-                    name: eu.name,
-                    scope: eu.scope,
-                    value,
-                })
-            }
-        }))
-        .await
+        let (values, metadata): (Vec<_>, Vec<_>) = export_updates
+            .into_iter()
+            .map(|eu| (eu.value, (eu.namespace, eu.name, eu.scope)))
+            .unzip();
+
+        let materialized = self.materialize_task_values(values).await?;
+
+        Ok(materialized
+            .into_iter()
+            .zip(metadata)
+            .map(|(value, (namespace, name, scope))| MaterializedExportUpdate {
+                namespace,
+                name,
+                scope,
+                value,
+            })
+            .collect())
     }
 
     async fn pre_transform_spec_plan(
@@ -375,49 +391,36 @@ pub trait VegaFusionRuntimeTrait: Send + Sync {
             .query_request(Arc::new(task_graph.clone()), &indices, inline_datasets)
             .await?;
 
-        // Collect values and handle row limit in parallel
+        // Collect values and handle row limit
         let row_limit = options.row_limit.map(|l| l as usize);
-        let plan_executor = self.plan_executor();
 
-        let materialized_futures = named_task_values.into_iter().map(|named_task_value| {
-            let plan_executor = plan_executor.clone();
-            async move {
-                let value = named_task_value.value;
-                let variable = named_task_value.variable;
+        let (values, variables): (Vec<_>, Vec<_>) = named_task_values
+            .into_iter()
+            .map(|ntv| (ntv.value, ntv.variable))
+            .unzip();
 
-                let materialized_value = value.to_materialized(plan_executor).await?;
+        let materialized = self.materialize_task_values(values).await?;
 
-                // Apply row_limit and collect warnings
-                let (final_value, warning) =
-                    if let (Some(row_limit), MaterializedTaskValue::Table(table)) =
-                        (row_limit, &materialized_value)
-                    {
-                        let warning = PreTransformValuesWarning {
-                            warning_type: Some(ValuesWarningType::RowLimit(
-                                PreTransformRowLimitWarning {
-                                    datasets: vec![variable],
-                                },
-                            )),
-                        };
-                        (
-                            MaterializedTaskValue::Table(table.head(row_limit)),
-                            Some(warning),
-                        )
-                    } else {
-                        (materialized_value, None)
-                    };
-
-                Ok::<_, VegaFusionError>((final_value, warning))
-            }
-        });
-
-        let materialized_results = try_join_all(materialized_futures).await?;
         let mut task_values = Vec::new();
-        for (value, warning) in materialized_results {
-            task_values.push(value);
-            if let Some(warning) = warning {
-                warnings.push(warning);
-            }
+        for (materialized_value, variable) in materialized.into_iter().zip(variables) {
+            let final_value =
+                if let (Some(row_limit), MaterializedTaskValue::Table(table)) =
+                    (row_limit, &materialized_value)
+                {
+                    let warning = PreTransformValuesWarning {
+                        warning_type: Some(ValuesWarningType::RowLimit(
+                            PreTransformRowLimitWarning {
+                                datasets: vec![variable],
+                            },
+                        )),
+                    };
+                    warnings.push(warning);
+                    MaterializedTaskValue::Table(table.head(row_limit))
+                } else {
+                    materialized_value
+                };
+
+            task_values.push(final_value);
         }
 
         Ok((task_values, warnings))

--- a/vegafusion-core/src/spec/visitors.rs
+++ b/vegafusion-core/src/spec/visitors.rs
@@ -17,7 +17,7 @@ use crate::spec::signal::{SignalOnEventSpec, SignalSpec};
 use crate::spec::values::{SignalExpressionSpec, StringOrSignalSpec};
 use crate::task_graph::graph::ScopedVariable;
 use crate::task_graph::scope::TaskScope;
-use crate::task_graph::task_value::TaskValue;
+use crate::task_graph::task_value::MaterializedTaskValue;
 use datafusion_common::ScalarValue;
 use rand::random;
 use std::collections::{HashMap, HashSet};
@@ -218,8 +218,8 @@ impl ChartVisitor for MakeTasksVisitor<'_> {
             };
 
             if pipeline.is_none() && format_type.is_none() {
-                // If no transforms, treat as regular TaskValue task
-                Task::new_value(data_var, scope, TaskValue::Table(values_table))
+                // If no transforms, treat as regular MaterializedTaskValue task
+                Task::new_value(data_var, scope, MaterializedTaskValue::Table(values_table))
             } else {
                 // Otherwise, create data values task (which supports transforms)
                 Task::new_data_values(
@@ -242,13 +242,13 @@ impl ChartVisitor for MakeTasksVisitor<'_> {
         let signal_var = Variable::new_signal(&signal.name);
 
         let task = if let Some(value) = &signal.value.as_option() {
-            let value = TaskValue::Scalar(ScalarValue::from_json(value)?);
+            let value = MaterializedTaskValue::Scalar(ScalarValue::from_json(value)?);
             Task::new_value(signal_var, scope, value)
         } else if let Some(update) = &signal.update {
             let expression = parse(update)?;
             Task::new_signal(signal_var, scope, expression, &self.tz_config)
         } else {
-            let value = TaskValue::Scalar(ScalarValue::Null);
+            let value = MaterializedTaskValue::Scalar(ScalarValue::Null);
             Task::new_value(signal_var, scope, value)
         };
 

--- a/vegafusion-core/src/task_graph/graph.rs
+++ b/vegafusion-core/src/task_graph/graph.rs
@@ -11,9 +11,9 @@ use std::collections::HashMap;
 
 use crate::task_graph::task_value::TaskValue;
 
+use crate::proto::gen::tasks::materialized_task_value::Data;
 use crate::proto::gen::tasks::task::TaskKind;
-use crate::proto::gen::tasks::task_value::Data;
-use crate::proto::gen::tasks::TaskValue as ProtoTaskValue;
+use crate::proto::gen::tasks::MaterializedTaskValue as ProtoMaterializedTaskValue;
 use std::convert::TryFrom;
 use std::hash::{BuildHasher, Hash, Hasher};
 
@@ -302,7 +302,9 @@ impl TaskGraph {
         node.task = Some(Task {
             variable: node.task().variable.clone(),
             scope: node.task().scope.clone(),
-            task_kind: Some(TaskKind::Value(ProtoTaskValue::try_from(&value)?)),
+            task_kind: Some(TaskKind::Value(ProtoMaterializedTaskValue::try_from(
+                &value,
+            )?)),
             tz_config: None,
         });
 

--- a/vegafusion-core/src/task_graph/memory.rs
+++ b/vegafusion-core/src/task_graph/memory.rs
@@ -5,6 +5,7 @@ use vegafusion_common::arrow::array::ArrayRef;
 use vegafusion_common::arrow::datatypes::{DataType, Field, FieldRef, Schema};
 use vegafusion_common::arrow::record_batch::RecordBatch;
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlan;
 
 /// Get the size of a Field value, including any inner heap-allocated data
 fn size_of_field(field: &FieldRef) -> usize {
@@ -93,4 +94,13 @@ pub fn inner_size_of_table(value: &VegaFusionTable) -> usize {
     let schema_size: usize = size_of_schema(&value.schema);
     let size_of_batches: usize = value.batches.iter().map(size_of_record_batch).sum();
     schema_size + size_of_batches
+}
+
+pub fn inner_size_of_logical_plan(plan: &LogicalPlan) -> usize {
+    size_of_val(plan)
+        + plan
+            .inputs()
+            .iter()
+            .map(|p| inner_size_of_logical_plan(p))
+            .sum::<usize>()
 }

--- a/vegafusion-core/src/task_graph/task.rs
+++ b/vegafusion-core/src/task_graph/task.rs
@@ -3,7 +3,7 @@ use crate::proto::gen::tasks::{
     task::TaskKind, DataSourceTask, DataUrlTask, DataValuesTask, NodeValueIndex, Task, TzConfig,
     Variable,
 };
-use crate::proto::gen::tasks::{SignalTask, TaskValue as ProtoTaskValue};
+use crate::proto::gen::tasks::{MaterializedTaskValue as ProtoMaterializedTaskValue, SignalTask};
 use crate::task_graph::task_value::TaskValue;
 use std::convert::TryFrom;
 
@@ -33,7 +33,9 @@ impl Task {
         Self {
             variable: Some(variable),
             scope: Vec::from(scope),
-            task_kind: Some(TaskKind::Value(ProtoTaskValue::try_from(&value).unwrap())),
+            task_kind: Some(TaskKind::Value(
+                ProtoMaterializedTaskValue::try_from(&value).unwrap(),
+            )),
             tz_config: None,
         }
     }

--- a/vegafusion-core/src/task_graph/task.rs
+++ b/vegafusion-core/src/task_graph/task.rs
@@ -3,7 +3,7 @@ use crate::proto::gen::tasks::{
     task::TaskKind, DataSourceTask, DataUrlTask, DataValuesTask, Task, TzConfig, Variable,
 };
 use crate::proto::gen::tasks::{MaterializedTaskValue as ProtoMaterializedTaskValue, SignalTask};
-use crate::task_graph::task_value::TaskValue;
+use crate::task_graph::task_value::MaterializedTaskValue;
 use std::convert::TryFrom;
 
 use crate::proto::gen::expression::Expression;
@@ -28,7 +28,7 @@ impl Task {
         self.scope.as_slice()
     }
 
-    pub fn new_value(variable: Variable, scope: &[u32], value: TaskValue) -> Self {
+    pub fn new_value(variable: Variable, scope: &[u32], value: MaterializedTaskValue) -> Self {
         Self {
             variable: Some(variable),
             scope: Vec::from(scope),
@@ -39,9 +39,9 @@ impl Task {
         }
     }
 
-    pub fn to_value(&self) -> Result<TaskValue> {
+    pub fn to_value(&self) -> Result<MaterializedTaskValue> {
         if let TaskKind::Value(value) = self.task_kind() {
-            Ok(TaskValue::try_from(value)?)
+            Ok(MaterializedTaskValue::try_from(value)?)
         } else {
             Err(VegaFusionError::internal("Task is not a TaskValue"))
         }

--- a/vegafusion-core/src/task_graph/task_value.rs
+++ b/vegafusion-core/src/task_graph/task_value.rs
@@ -112,6 +112,25 @@ impl TryFrom<&ProtoMaterializedTaskValue> for TaskValue {
     }
 }
 
+impl TryFrom<&ProtoMaterializedTaskValue> for MaterializedTaskValue {
+    type Error = VegaFusionError;
+
+    fn try_from(value: &ProtoMaterializedTaskValue) -> std::result::Result<Self, Self::Error> {
+        match value.data.as_ref().unwrap() {
+            MaterializedTaskValueData::Table(value) => {
+                Ok(Self::Table(VegaFusionTable::from_ipc_bytes(value)?))
+            }
+            MaterializedTaskValueData::Scalar(value) => {
+                let scalar_table = VegaFusionTable::from_ipc_bytes(value)?;
+                let scalar_rb = scalar_table.to_record_batch()?;
+                let scalar_array = scalar_rb.column(0);
+                let scalar = ScalarValue::try_from_array(scalar_array, 0)?;
+                Ok(Self::Scalar(scalar))
+            }
+        }
+    }
+}
+
 impl TryFrom<&TaskValue> for ProtoMaterializedTaskValue {
     type Error = VegaFusionError;
 

--- a/vegafusion-python/Cargo.toml
+++ b/vegafusion-python/Cargo.toml
@@ -63,6 +63,9 @@ version = "2.0.3"
 path = "../vegafusion-runtime"
 version = "2.0.3"
 
+[dependencies.datafusion]
+workspace = true
+
 [dependencies.tokio]
 workspace = true
 features = ["macros", "rt-multi-thread", "time"]

--- a/vegafusion-python/src/chart_state.rs
+++ b/vegafusion-python/src/chart_state.rs
@@ -1,0 +1,107 @@
+use std::sync::Arc;
+
+use pyo3::prelude::*;
+use pythonize::{depythonize, pythonize};
+use std::collections::HashMap;
+use tokio::runtime::Runtime;
+use vegafusion_core::planning::watch::ExportUpdateJSON;
+use vegafusion_core::{
+    chart_state::{ChartState as RsChartState, ChartStateOpts},
+    data::dataset::VegaFusionDataset,
+    planning::{plan::PreTransformSpecWarningSpec, watch::WatchPlan},
+    proto::gen::tasks::TzConfig,
+    runtime::VegaFusionRuntimeTrait,
+    spec::chart::ChartSpec,
+};
+
+#[pyclass]
+pub struct PyChartState {
+    runtime: Arc<dyn VegaFusionRuntimeTrait>,
+    state: RsChartState,
+    tokio_runtime: Arc<Runtime>,
+}
+
+impl PyChartState {
+    pub fn try_new(
+        runtime: Arc<dyn VegaFusionRuntimeTrait>,
+        tokio_runtime: Arc<Runtime>,
+        spec: ChartSpec,
+        inline_datasets: HashMap<String, VegaFusionDataset>,
+        tz_config: TzConfig,
+        row_limit: Option<u32>,
+    ) -> PyResult<Self> {
+        let state = tokio_runtime.block_on(RsChartState::try_new(
+            runtime.as_ref(),
+            spec,
+            inline_datasets,
+            ChartStateOpts {
+                tz_config,
+                row_limit,
+            },
+        ))?;
+        Ok(Self {
+            runtime,
+            state,
+            tokio_runtime,
+        })
+    }
+}
+
+#[pymethods]
+impl PyChartState {
+    /// Update chart state with updates from the client
+    pub fn update(&self, py: Python, updates: Vec<PyObject>) -> PyResult<Vec<PyObject>> {
+        let updates = updates
+            .into_iter()
+            .map(|el| Ok(depythonize::<ExportUpdateJSON>(&el.bind(py))?))
+            .collect::<PyResult<Vec<_>>>()?;
+
+        let result_updates = py.allow_threads(|| {
+            self.tokio_runtime
+                .block_on(self.state.update(self.runtime.as_ref(), updates))
+        })?;
+
+        let py_updates = result_updates
+            .into_iter()
+            .map(|el| Ok(pythonize(py, &el)?.into()))
+            .collect::<PyResult<Vec<PyObject>>>()?;
+        Ok(py_updates)
+    }
+
+    /// Get ChartState's initial input spec
+    pub fn get_input_spec(&self, py: Python) -> PyResult<PyObject> {
+        Ok(pythonize(py, self.state.get_input_spec())?.into())
+    }
+
+    /// Get ChartState's server spec
+    pub fn get_server_spec(&self, py: Python) -> PyResult<PyObject> {
+        Ok(pythonize(py, self.state.get_server_spec())?.into())
+    }
+
+    /// Get ChartState's client spec
+    pub fn get_client_spec(&self, py: Python) -> PyResult<PyObject> {
+        Ok(pythonize(py, self.state.get_client_spec())?.into())
+    }
+
+    /// Get ChartState's initial transformed spec
+    pub fn get_transformed_spec(&self, py: Python) -> PyResult<PyObject> {
+        Ok(pythonize(py, self.state.get_transformed_spec())?.into())
+    }
+
+    /// Get ChartState's watch plan
+    pub fn get_comm_plan(&self, py: Python) -> PyResult<PyObject> {
+        let comm_plan = WatchPlan::from(self.state.get_comm_plan().clone());
+        Ok(pythonize(py, &comm_plan)?.into())
+    }
+
+    /// Get list of transform warnings
+    pub fn get_warnings(&self, py: Python) -> PyResult<PyObject> {
+        let warnings: Vec<_> = self
+            .state
+            .get_warnings()
+            .iter()
+            .map(PreTransformSpecWarningSpec::from)
+            .collect();
+        Ok(pythonize(py, &warnings)?.into())
+    }
+}

--- a/vegafusion-python/src/lib.rs
+++ b/vegafusion-python/src/lib.rs
@@ -167,7 +167,7 @@ impl PyVegaFusionRuntime {
         inline_datasets: Option<&Bound<PyDict>>,
         keep_signals: Option<Vec<(String, Vec<u32>)>>,
         keep_datasets: Option<Vec<(String, Vec<u32>)>>,
-    ) -> PyResult<(PyObject, PyObject)> {
+    ) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
         let inline_datasets = process_inline_datasets(inline_datasets)?;
 
         let spec = parse_json_spec(spec)?;
@@ -227,7 +227,7 @@ impl PyVegaFusionRuntime {
         default_input_tz: Option<String>,
         row_limit: Option<u32>,
         inline_datasets: Option<&Bound<PyDict>>,
-    ) -> PyResult<(PyObject, PyObject)> {
+    ) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
         let inline_datasets = process_inline_datasets(inline_datasets)?;
         let spec = parse_json_spec(spec)?;
 
@@ -272,8 +272,8 @@ impl PyVegaFusionRuntime {
         Python::attach(|py| -> PyResult<(Py<PyAny>, Py<PyAny>)> {
             let py_response_list = PyList::empty(py);
             for value in values {
-                let pytable: PyObject = if let MaterializedTaskValue::Table(table) = value {
-                    table.to_pyo3_arrow()?.to_pyarrow(py)?.into()
+                let pytable: Py<PyAny> = if let MaterializedTaskValue::Table(table) = value {
+                    table.to_pyo3_arrow()?.into_pyarrow(py)?.into()
                 } else {
                     return Err(PyErr::from(VegaFusionError::internal(
                         "Unexpected value type",
@@ -301,7 +301,7 @@ impl PyVegaFusionRuntime {
         inline_datasets: Option<&Bound<PyDict>>,
         keep_signals: Option<Vec<(String, Vec<u32>)>>,
         keep_datasets: Option<Vec<(String, Vec<u32>)>>,
-    ) -> PyResult<(PyObject, Vec<PyObject>, PyObject)> {
+    ) -> PyResult<(Py<PyAny>, Vec<Py<PyAny>>, Py<PyAny>)> {
         let inline_datasets = process_inline_datasets(inline_datasets)?;
         let spec = parse_json_spec(spec)?;
         let preserve_interactivity = preserve_interactivity.unwrap_or(true);

--- a/vegafusion-python/src/utils.rs
+++ b/vegafusion-python/src/utils.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::datasource::empty::EmptyTable;
+use datafusion::datasource::provider_as_source;
+use pyo3::exceptions::PyValueError as PyValErr;
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use pyo3_arrow::PySchema;
+use pythonize::depythonize;
+use std::borrow::Cow;
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlanBuilder;
+use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::spec::chart::ChartSpec;
+
+/// Convert optional inline datasets provided from Python into VegaFusion datasets.
+pub fn process_inline_datasets(
+    inline_datasets: Option<&Bound<PyDict>>,
+) -> PyResult<HashMap<String, VegaFusionDataset>> {
+    if let Some(inline_datasets) = inline_datasets {
+        Python::with_gil(|py| -> PyResult<_> {
+            let imported_datasets = inline_datasets
+                .iter()
+                .map(|(name, inline_dataset)| {
+                    let inline_dataset = inline_dataset;
+                    let dataset = if inline_dataset.hasattr("__arrow_c_stream__")? {
+                        // Import via Arrow PyCapsule Interface
+                        let (table, hash) =
+                            VegaFusionTable::from_pyarrow_with_hash(py, &inline_dataset)?;
+                        VegaFusionDataset::from_table(table, Some(hash))?
+                    } else if let Ok(pyschema) = inline_dataset.extract::<PySchema>() {
+                        // Handle PyArrow Schema as VegaFusionDataset::Plan
+                        let schema = pyschema.into_inner();
+
+                        // Build an empty table provider with the given schema and scan it
+                        let provider = Arc::new(EmptyTable::new(schema.clone()));
+                        let table_source = provider_as_source(provider);
+                        let logical_plan =
+                            LogicalPlanBuilder::scan(&name.to_string(), table_source, None)
+                                .map_err(|e| {
+                                    PyValErr::new_err(format!(
+                                        "Failed to build logical plan from schema: {}",
+                                        e
+                                    ))
+                                })?
+                                .build()
+                                .map_err(|e| {
+                                    PyValErr::new_err(format!(
+                                        "Failed to finalize logical plan from schema: {}",
+                                        e
+                                    ))
+                                })?;
+
+                        VegaFusionDataset::from_plan(logical_plan)
+                    } else {
+                        // Assume PyArrow Table
+                        // We convert to ipc bytes for two reasons:
+                        // - It allows VegaFusionDataset to compute an accurate hash of the table
+                        // - It works around https://github.com/hex-inc/vegafusion/issues/268
+                        let table = VegaFusionTable::from_pyarrow(py, &inline_dataset)?;
+                        VegaFusionDataset::from_table_ipc_bytes(&table.to_ipc_bytes()?)?
+                    };
+
+                    Ok((name.to_string(), dataset))
+                })
+                .collect::<PyResult<HashMap<_, _>>>()?;
+            Ok(imported_datasets)
+        })
+    } else {
+        Ok(Default::default())
+    }
+}
+
+/// Parse a Python string or dict into a ChartSpec
+pub fn parse_json_spec(chart_spec: PyObject) -> PyResult<ChartSpec> {
+    Python::with_gil(|py| -> PyResult<ChartSpec> {
+        if let Ok(chart_spec) = chart_spec.extract::<Cow<str>>(py) {
+            match serde_json::from_str::<ChartSpec>(&chart_spec) {
+                Ok(chart_spec) => Ok(chart_spec),
+                Err(err) => Err(PyValErr::new_err(format!(
+                    "Failed to parse chart_spec string as Vega: {err}"
+                ))),
+            }
+        } else if let Ok(chart_spec) = chart_spec.downcast_bound::<PyAny>(py) {
+            match depythonize::<ChartSpec>(&chart_spec.clone()) {
+                Ok(chart_spec) => Ok(chart_spec),
+                Err(err) => Err(PyValErr::new_err(format!(
+                    "Failed to parse chart_spec dict as Vega: {err}"
+                ))),
+            }
+        } else {
+            Err(PyValErr::new_err("chart_spec must be a string or dict"))
+        }
+    })
+}

--- a/vegafusion-python/tests/test_jupyter_widget.py
+++ b/vegafusion-python/tests/test_jupyter_widget.py
@@ -333,6 +333,11 @@ widget
     # Display with default altair renderer
     notebook_text_alt = f"""
 ```python
+import altair as alt
+alt.renderers.enable('default', embed_options={{'actions': False, 'renderer': 'canvas'}});
+```
+
+```python
 {altair_chart_str}
 
 chart

--- a/vegafusion-python/tests/test_jupyter_widget.py
+++ b/vegafusion-python/tests/test_jupyter_widget.py
@@ -33,7 +33,7 @@ failure_output = here / "output" / "failures"
 altair_default_template = r"""
 ```python
 import altair as alt
-alt.renderers.enable('default', embed_options={'actions': False, 'renderer': 'canvas'});
+alt.renderers.enable('default', embed_options={'actions': False});
 ```
 
 ```python
@@ -50,7 +50,7 @@ altair_vegafusion_jupyter_template = r"""
 ```python
 import vegafusion
 import altair as alt
-alt.renderers.enable('jupyter', embed_options={'actions': False, 'renderer': 'canvas'});
+alt.renderers.enable('jupyter', embed_options={'actions': False});
 alt.data_transformers.enable('vegafusion');
 ```
 
@@ -332,11 +332,6 @@ widget
 
     # Display with default altair renderer
     notebook_text_alt = f"""
-```python
-import altair as alt
-alt.renderers.enable('default', embed_options={{'actions': False, 'renderer': 'canvas'}});
-```
-
 ```python
 {altair_chart_str}
 

--- a/vegafusion-python/tests/test_jupyter_widget.py
+++ b/vegafusion-python/tests/test_jupyter_widget.py
@@ -33,7 +33,7 @@ failure_output = here / "output" / "failures"
 altair_default_template = r"""
 ```python
 import altair as alt
-alt.renderers.enable('default', embed_options={'actions': False});
+alt.renderers.enable('default', embed_options={'actions': False, 'renderer': 'canvas'});
 ```
 
 ```python
@@ -50,7 +50,7 @@ altair_vegafusion_jupyter_template = r"""
 ```python
 import vegafusion
 import altair as alt
-alt.renderers.enable('jupyter', embed_options={'actions': False});
+alt.renderers.enable('jupyter', embed_options={'actions': False, 'renderer': 'canvas'});
 alt.data_transformers.enable('vegafusion');
 ```
 

--- a/vegafusion-python/vegafusion/__init__.py
+++ b/vegafusion-python/vegafusion/__init__.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from ._vegafusion import __version__
 from .local_tz import get_local_tz, set_local_tz
-from .runtime import runtime
+from .runtime import VegaFusionRuntime, runtime
 from .utils import get_column_usage
 
 
@@ -24,6 +24,7 @@ importlib.metadata.version = patched_version
 
 __all__ = [
     "runtime",
+    "VegaFusionRuntime",
     "set_local_tz",
     "get_local_tz",
     "get_column_usage",

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -2,11 +2,20 @@ from __future__ import annotations
 
 import sys
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Literal,
+    Protocol,
+    TypedDict,
+    Union,
+    cast,
+)
 
 # Delay narwhals import to avoid eager pandas import
 # We'll import narwhals inside functions to avoid eager pandas import
-from arro3.core import Table
+from arro3.core import Schema, Table
 
 from vegafusion._vegafusion import get_cpu_count, get_virtual_memory
 from vegafusion.transformer import DataFrameLike
@@ -26,6 +35,22 @@ if TYPE_CHECKING:
         PyChartStateGrpc,
         PyVegaFusionRuntime,
     )
+
+
+class PlanExecutorProtocol(Protocol):
+    """Protocol for objects with execute_plan method."""
+
+    def execute_plan(self, logical_plan_json: str) -> pa.Table:
+        """Execute a logical plan and return an Arrow table."""
+        ...
+
+
+# Type alias for plan executors
+PlanExecutor = Union[
+    # Callable that takes logical plan JSON and returns Arrow table
+    Callable[[str], "pa.Table"],
+    PlanExecutorProtocol,  # Object with execute_plan method
+]
 
 # This type isn't defined in the grpcio package, so let's at least name it
 UnaryUnaryMultiCallable = Any
@@ -247,14 +272,14 @@ class VegaFusionRuntime:
         self,
         inline_datasets: dict[str, Any] | None = None,
         inline_dataset_usage: dict[str, list[str]] | None = None,
-    ) -> dict[str, Table]:
+    ) -> dict[str, Table | Schema]:
         """
         Import or register inline datasets.
 
         Args:
-            inline_datasets: A dictionary from dataset names to pandas DataFrames or
-                pyarrow Tables. Inline datasets may be referenced by the input
-                specification using the following url syntax
+            inline_datasets: A dictionary from dataset names to pandas DataFrames,
+                pyarrow Tables, or pyarrow Schemas. Inline datasets may be referenced
+                by the input specification using the following url syntax
                 'vegafusion+dataset://{dataset_name}' or 'table://{dataset_name}'.
             inline_dataset_usage: Columns that are referenced by datasets. If no
                 entry is found, then all columns should be included.
@@ -267,10 +292,14 @@ class VegaFusionRuntime:
 
         inline_datasets = inline_datasets or {}
         inline_dataset_usage = inline_dataset_usage or {}
-        imported_inline_datasets: dict[str, Table] = {}
+        imported_inline_datasets: dict[str, Table | Schema] = {}
         for name, value in inline_datasets.items():
             columns = inline_dataset_usage.get(name)
-            if pd is not None and pa is not None and isinstance(value, pd.DataFrame):
+            if (pa is not None and isinstance(value, pa.Schema)) or hasattr(
+                value, "__arrow_c_schema__"
+            ):
+                imported_inline_datasets[name] = Schema.from_arrow(value)
+            elif pd is not None and pa is not None and isinstance(value, pd.DataFrame):
                 # rename to help mypy
                 inner_value: pd.DataFrame = value
                 del value
@@ -372,10 +401,10 @@ class VegaFusionRuntime:
                 than being pre-transformed. If False, then all possible data
                 transformations are applied even if they break the original interactive
                 behavior of the chart.
-            inline_datasets: A dict from dataset names to pandas DataFrames or pyarrow
-                Tables. Inline datasets may be referenced by the input specification
-                using the following url syntax 'vegafusion+dataset://{dataset_name}' or
-                'table://{dataset_name}'.
+            inline_datasets: A dict from dataset names to pandas DataFrames, pyarrow
+                Tables, or pyarrow Schemas. Inline datasets may be referenced by the
+                input specification using the following url syntax
+                'vegafusion+dataset://{dataset_name}' or 'table://{dataset_name}'.
             keep_signals: Signals from the input spec that must be included in the
                 pre-transformed spec, even if they are no longer referenced.
                 A list with elements that are either:
@@ -450,11 +479,10 @@ class VegaFusionRuntime:
                 datasets. If exceeded, datasets will be truncated to this number of
                 rows and a RowLimitExceeded warning will be included in the ChartState's
                 warnings list.
-            inline_datasets: A dict from dataset names to pandas DataFrames or pyarrow
-                Tables. Inline datasets may be referenced by the input specification
-                using the following url syntax 'vegafusion+dataset://{dataset_name}' or
-                'table://{dataset_name}'.
-
+            inline_datasets: A dict from dataset names to pandas DataFrames, pyarrow
+                Tables, or pyarrow Schemas. Inline datasets may be referenced by the
+                input specification using the following url syntax
+                'vegafusion+dataset://{dataset_name}' or 'table://{dataset_name}'.
         Returns:
             ChartState
         """
@@ -464,7 +492,11 @@ class VegaFusionRuntime:
         )
         return ChartState(
             self.runtime.new_chart_state(
-                spec, local_tz, default_input_tz, row_limit, inline_arrow_dataset
+                spec,
+                local_tz,
+                default_input_tz,
+                row_limit,
+                inline_arrow_dataset,
             )
         )
 
@@ -500,10 +532,10 @@ class VegaFusionRuntime:
                 datasets. If exceeded, datasets will be truncated to this number of
                 rows and a RowLimitExceeded warning will be included in the resulting
                 warnings list.
-            inline_datasets: A dict from dataset names to pandas DataFrames or pyarrow
-                Tables. Inline datasets may be referenced by the input specification
-                using the following url syntax 'vegafusion+dataset://{dataset_name}'
-                or 'table://{dataset_name}'.
+            inline_datasets: A dict from dataset names to pandas DataFrames, pyarrow
+                Tables, or pyarrow Schemas. Inline datasets may be referenced by the
+                input specification using the following url syntax
+                'vegafusion+dataset://{dataset_name}' or 'table://{dataset_name}'.
             trim_unused_columns: If True, unused columns are removed from returned
                 datasets.
             dataset_format: Format for returned datasets. One of:
@@ -664,8 +696,8 @@ class VegaFusionRuntime:
                 * ``"pyarrow"``: pyarrow.Table
                 * ``"arrow-ipc"``: bytes in arrow IPC format
                 * ``"arrow-ipc-base64"``: base64 encoded arrow IPC format
-            inline_datasets: A dict from dataset names to pandas DataFrames or pyarrow
-                Tables. Inline datasets may be referenced by the input specification
+            inline_datasets: A dict from dataset names to pandas DataFrames, pyarrow
+                Tables, or pyarrow Schemas. Inline datasets may be referenced by the input specification
                 using the following url syntax 'vegafusion+dataset://{dataset_name}' or
                 'table://{dataset_name}'.
             keep_signals: Signals from the input spec that must be included in the

--- a/vegafusion-python/vegafusion/runtime.py
+++ b/vegafusion-python/vegafusion/runtime.py
@@ -5,9 +5,7 @@ from types import ModuleType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Literal,
-    Protocol,
     TypedDict,
     Union,
     cast,
@@ -36,21 +34,6 @@ if TYPE_CHECKING:
         PyVegaFusionRuntime,
     )
 
-
-class PlanExecutorProtocol(Protocol):
-    """Protocol for objects with execute_plan method."""
-
-    def execute_plan(self, logical_plan_json: str) -> pa.Table:
-        """Execute a logical plan and return an Arrow table."""
-        ...
-
-
-# Type alias for plan executors
-PlanExecutor = Union[
-    # Callable that takes logical plan JSON and returns Arrow table
-    Callable[[str], "pa.Table"],
-    PlanExecutorProtocol,  # Object with execute_plan method
-]
 
 # This type isn't defined in the grpcio package, so let's at least name it
 UnaryUnaryMultiCallable = Any

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -154,10 +154,6 @@ workspace = true
 [dependencies.datafusion-functions-window]
 workspace = true
 
-[dependencies.datafusion-sql]
-workspace = true
-features = ["unparser"]
-
 [dependencies.datafusion-proto]
 workspace = true
 optional = true

--- a/vegafusion-runtime/Cargo.toml
+++ b/vegafusion-runtime/Cargo.toml
@@ -154,6 +154,10 @@ workspace = true
 [dependencies.datafusion-functions-window]
 workspace = true
 
+[dependencies.datafusion-sql]
+workspace = true
+features = ["unparser"]
+
 [dependencies.datafusion-proto]
 workspace = true
 optional = true

--- a/vegafusion-runtime/benches/spec_benchmarks.rs
+++ b/vegafusion-runtime/benches/spec_benchmarks.rs
@@ -52,7 +52,7 @@ async fn eval_spec_get_variable(full_spec: ChartSpec, var: &ScopedVariable) -> V
     let task_graph_mapping = task_graph.build_mapping();
 
     // Initialize task graph runtime
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     let node_index = task_graph_mapping.get(var).unwrap();
 
@@ -103,7 +103,7 @@ async fn eval_spec_sequence(full_spec: ChartSpec, full_updates: Vec<ExportUpdate
     let task_graph_mapping = task_graph.build_mapping();
 
     // Initialize task graph runtime
-    let runtime = VegaFusionRuntime::new(None);
+    let runtime = VegaFusionRuntime::default();
 
     // Get initial values
     let mut query_indices = Vec::new();

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -3,12 +3,14 @@ use crate::expression::compiler::config::CompilationConfig;
 use crate::expression::compiler::utils::ExprHelpers;
 use crate::task_graph::task::TaskCall;
 use std::borrow::Cow;
+use vegafusion_core::runtime::PlanExecutor;
 
 use async_trait::async_trait;
 
 use datafusion_expr::{expr, lit, Expr};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::Arc;
 use vegafusion_core::data::dataset::VegaFusionDataset;
 
 use crate::task_graph::timezone::RuntimeTzConfig;
@@ -20,7 +22,6 @@ use datafusion::execution::options::{ArrowReadOptions, ReadOptions};
 use datafusion::prelude::{CsvReadOptions, DataFrame, SessionContext};
 use datafusion_common::config::TableOptions;
 use datafusion_functions::expr_fn::make_date;
-use std::sync::Arc;
 
 use vegafusion_common::data::scalar::{ScalarValue, ScalarValueHelpers};
 use vegafusion_common::error::{Result, ResultWithContext, VegaFusionError};
@@ -29,7 +30,6 @@ use vegafusion_core::proto::gen::tasks::data_url_task::Url;
 use vegafusion_core::proto::gen::tasks::scan_url_format;
 use vegafusion_core::proto::gen::tasks::scan_url_format::Parse;
 use vegafusion_core::proto::gen::tasks::{DataSourceTask, DataUrlTask, DataValuesTask};
-use vegafusion_core::proto::gen::transforms::TransformPipeline;
 use vegafusion_core::task_graph::task::{InputVariable, TaskDependencies};
 use vegafusion_core::task_graph::task_value::TaskValue;
 
@@ -40,7 +40,6 @@ use object_store::ObjectStore;
 use vegafusion_common::arrow::datatypes::{DataType, Field, Schema, TimeUnit};
 use vegafusion_common::column::flat_col;
 use vegafusion_common::data::table::VegaFusionTable;
-use vegafusion_common::data::ORDER_COL;
 use vegafusion_common::datatypes::{is_integer_datatype, is_string_datatype};
 use vegafusion_core::proto::gen::transforms::transform::TransformKind;
 use vegafusion_core::spec::visitors::extract_inline_dataset;
@@ -64,10 +63,11 @@ pub fn build_compilation_config(
     input_vars: &[InputVariable],
     values: &[TaskValue],
     tz_config: &Option<RuntimeTzConfig>,
+    plan_executor: Arc<dyn PlanExecutor>,
 ) -> CompilationConfig {
     // Build compilation config from input_vals
     let mut signal_scope: HashMap<String, ScalarValue> = HashMap::new();
-    let mut data_scope: HashMap<String, VegaFusionTable> = HashMap::new();
+    let mut data_scope: HashMap<String, VegaFusionDataset> = HashMap::new();
 
     for (input_var, input_val) in input_vars.iter().zip(values) {
         match input_val {
@@ -75,7 +75,16 @@ pub fn build_compilation_config(
                 signal_scope.insert(input_var.var.name.clone(), value.clone());
             }
             TaskValue::Table(table) => {
-                data_scope.insert(input_var.var.name.clone(), table.clone());
+                data_scope.insert(
+                    input_var.var.name.clone(),
+                    VegaFusionDataset::from_table(table.clone(), None).unwrap(),
+                );
+            }
+            TaskValue::Plan(plan) => {
+                data_scope.insert(
+                    input_var.var.name.clone(),
+                    VegaFusionDataset::from_plan(plan.clone()),
+                );
             }
         }
     }
@@ -86,6 +95,7 @@ pub fn build_compilation_config(
         signal_scope,
         data_scope,
         tz_config: *tz_config,
+        plan_executor,
         ..Default::default()
     }
 }
@@ -98,15 +108,17 @@ impl TaskCall for DataUrlTask {
         tz_config: &Option<RuntimeTzConfig>,
         inline_datasets: HashMap<String, VegaFusionDataset>,
         ctx: Arc<SessionContext>,
+        plan_executor: Arc<dyn PlanExecutor>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
         // Build compilation config for url signal (if any) and transforms (if any)
-        let config = build_compilation_config(&self.input_vars(), values, tz_config);
+        let config =
+            build_compilation_config(&self.input_vars(), values, tz_config, plan_executor.clone());
 
         // Build url string
         let url = match self.url.as_ref().unwrap() {
             Url::String(url) => url.clone(),
             Url::Expr(expr) => {
-                let compiled = compile(expr, &config, None)?;
+                let compiled = compile(expr, &config, None).await?;
                 let url_scalar = compiled.eval_to_scalar()?;
                 url_scalar.to_scalar_string()?
             }
@@ -131,19 +143,23 @@ impl TaskCall for DataUrlTask {
             file_type.as_deref()
         };
 
-        let df = if let Some(inline_name) = extract_inline_dataset(&url) {
-            let inline_name = inline_name.trim().to_string();
-            if let Some(inline_dataset) = inline_datasets.get(&inline_name) {
+        let inline_name = extract_inline_dataset(&url).map(|name| name.trim().to_string());
+        let inline_dataset_info: Option<&VegaFusionDataset> = inline_name
+            .as_ref()
+            .and_then(|name| inline_datasets.get(name));
+
+        let df = if let Some(inline_name) = &inline_name {
+            if let Some(inline_dataset) = inline_dataset_info {
                 match inline_dataset {
                     VegaFusionDataset::Table { table, .. } => {
                         let table = table.clone().with_ordering()?;
                         ctx.vegafusion_table(table).await?
                     }
                     VegaFusionDataset::Plan { plan } => {
-                        ctx.execute_logical_plan(plan.clone()).await?
+                        DataFrame::new(ctx.state(), plan.clone()).with_index()?
                     }
                 }
-            } else if let Ok(df) = ctx.table(&inline_name).await {
+            } else if let Ok(df) = ctx.table(inline_name).await {
                 df
             } else {
                 return Err(VegaFusionError::internal(format!(
@@ -179,11 +195,7 @@ impl TaskCall for DataUrlTask {
         };
 
         // Ensure there is an ordering column present
-        let df = if df.schema().inner().column_with_name(ORDER_COL).is_none() {
-            df.with_index(ORDER_COL).await?
-        } else {
-            df
-        };
+        let df = df.with_index()?;
 
         // Perform any up-front type conversions
         let df = pre_process_column_types(df).await?;
@@ -191,34 +203,31 @@ impl TaskCall for DataUrlTask {
         // Process datetime columns
         let df = process_datetimes(&parse, df, &config.tz_config).await?;
 
-        eval_sql_df(df, &self.pipeline, &config).await
+        // Apply transforms (if any)
+        let (result_df, output_values) = if self
+            .pipeline
+            .as_ref()
+            .map(|p| !p.transforms.is_empty())
+            .unwrap_or(false)
+        {
+            let pipeline = self.pipeline.as_ref().unwrap();
+            pipeline.eval_sql(df, &config).await?
+        } else {
+            // No transforms, just remove any ordering column
+            (df, Vec::new())
+        };
+
+        let result_df = result_df.drop_index()?;
+
+        // Return value based on whether inline dataset was used
+        let task_value = if let Some(inline_dataset) = inline_dataset_info {
+            result_df.to_task_value(inline_dataset).await?
+        } else {
+            TaskValue::Table(result_df.collect_to_table().await?)
+        };
+
+        Ok((task_value, output_values))
     }
-}
-
-async fn eval_sql_df(
-    sql_df: DataFrame,
-    pipeline: &Option<TransformPipeline>,
-    config: &CompilationConfig,
-) -> Result<(TaskValue, Vec<TaskValue>)> {
-    // Apply transforms (if any)
-    let (transformed_df, output_values) = if pipeline
-        .as_ref()
-        .map(|p| !p.transforms.is_empty())
-        .unwrap_or(false)
-    {
-        let pipeline = pipeline.as_ref().unwrap();
-        pipeline.eval_sql(sql_df, config).await?
-    } else {
-        // No transforms, just remove any ordering column
-        (
-            sql_df.collect_to_table().await?.without_ordering()?,
-            Vec::new(),
-        )
-    };
-
-    let table_value = TaskValue::Table(transformed_df.without_ordering()?);
-
-    Ok((table_value, output_values))
 }
 
 lazy_static! {
@@ -491,6 +500,7 @@ impl TaskCall for DataValuesTask {
         tz_config: &Option<RuntimeTzConfig>,
         _inline_datasets: HashMap<String, VegaFusionDataset>,
         ctx: Arc<SessionContext>,
+        plan_executor: Arc<dyn PlanExecutor>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
         // Deserialize data into table
         let values_table = VegaFusionTable::from_ipc_bytes(&self.values)?;
@@ -525,23 +535,31 @@ impl TaskCall for DataValuesTask {
         {
             let pipeline = self.pipeline.as_ref().unwrap();
 
-            let config = build_compilation_config(&self.input_vars(), values, tz_config);
+            let config = build_compilation_config(
+                &self.input_vars(),
+                values,
+                tz_config,
+                plan_executor.clone(),
+            );
 
             // Process datetime columns
             let df = ctx.vegafusion_table(values_table).await?;
             let sql_df = process_datetimes(&parse, df, &config.tz_config).await?;
 
-            let (table, output_values) = pipeline.eval_sql(sql_df, &config).await?;
-
+            let (df, output_values) = pipeline.eval_sql(sql_df, &config).await?;
+            let table = df.drop_index()?.collect_to_table().await?;
             (table, output_values)
         } else {
             // No transforms
             let values_df = ctx.vegafusion_table(values_table).await?;
-            let values_df = process_datetimes(&parse, values_df, tz_config).await?;
-            (values_df.collect_to_table().await?, Vec::new())
+            let values_df: DataFrame = process_datetimes(&parse, values_df, tz_config).await?;
+            (
+                values_df.drop_index()?.collect_to_table().await?,
+                Vec::new(),
+            )
         };
 
-        let table_value = TaskValue::Table(transformed_table.without_ordering()?);
+        let table_value = TaskValue::Table(transformed_table);
 
         Ok((table_value, output_values))
     }
@@ -555,40 +573,50 @@ impl TaskCall for DataSourceTask {
         tz_config: &Option<RuntimeTzConfig>,
         _inline_datasets: HashMap<String, VegaFusionDataset>,
         ctx: Arc<SessionContext>,
+        plan_executor: Arc<dyn PlanExecutor>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
         let input_vars = self.input_vars();
-        let mut config = build_compilation_config(&input_vars, values, tz_config);
+        let mut config =
+            build_compilation_config(&input_vars, values, tz_config, plan_executor.clone());
 
-        // Remove source table from config
-        let source_table = config.data_scope.remove(&self.source).with_context(|| {
+        // Remove source dataset from config
+        let source_dataset = config.data_scope.remove(&self.source).with_context(|| {
             format!(
                 "Missing source {} for task with input variables\n{:#?}",
                 self.source, input_vars
             )
         })?;
 
-        // Add ordering column
-        let source_table = source_table.with_ordering()?;
-
-        // Apply transforms (if any)
-        let (transformed_table, output_values) = if self
+        let has_transforms = self
             .pipeline
             .as_ref()
             .map(|p| !p.transforms.is_empty())
-            .unwrap_or(false)
-        {
-            let pipeline = self.pipeline.as_ref().unwrap();
-            let sql_df = ctx.vegafusion_table(source_table).await?;
-            let (table, output_values) = pipeline.eval_sql(sql_df, &config).await?;
+            .unwrap_or(false);
 
-            (table, output_values)
-        } else {
-            // No transforms
-            (source_table, Vec::new())
+        if !has_transforms {
+            match source_dataset {
+                VegaFusionDataset::Plan { plan } => {
+                    return Ok((TaskValue::Plan(plan), Vec::new()));
+                }
+                VegaFusionDataset::Table { table, .. } => {
+                    let table_val = TaskValue::Table(table.without_ordering()?);
+                    return Ok((table_val, Vec::new()));
+                }
+            }
+        }
+
+        let source_df = match &source_dataset {
+            VegaFusionDataset::Table { table, .. } => ctx.vegafusion_table(table.clone()).await?,
+            VegaFusionDataset::Plan { plan } => DataFrame::new(ctx.state(), plan.clone()),
         };
 
-        let table_value = TaskValue::Table(transformed_table.without_ordering()?);
-        Ok((table_value, output_values))
+        let source_df = source_df.with_index()?;
+
+        let pipeline = self.pipeline.as_ref().unwrap();
+        let (df, output_values) = pipeline.eval_sql(source_df, &config).await?;
+        let df = df.drop_index()?;
+        let task_value = df.to_task_value(&source_dataset).await?;
+        Ok((task_value, output_values))
     }
 }
 

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -210,7 +210,6 @@ impl TaskCall for DataUrlTask {
             let pipeline = self.pipeline.as_ref().unwrap();
             pipeline.eval_sql(df, &config).await?
         } else {
-            // No transforms, just remove any ordering column
             (df, Vec::new())
         };
 

--- a/vegafusion-runtime/src/data/tasks.rs
+++ b/vegafusion-runtime/src/data/tasks.rs
@@ -59,6 +59,22 @@ use {datafusion::prelude::ParquetReadOptions, vegafusion_common::error::ToExtern
 #[cfg(target_arch = "wasm32")]
 use object_store_wasm::HttpStore;
 
+async fn maybe_materialize_plan(
+    task_value: TaskValue,
+    plan_executor: &Arc<dyn PlanExecutor>,
+) -> Result<TaskValue> {
+    // HACK: currently we force eager materialization for DataFusion plan executor
+    // to match original behavior (before support for custom executors and lazy evaluation),
+    // see for more context: https://github.com/vega/vegafusion/pull/573
+    if plan_executor.name() == "DataFusionPlanExecutor" {
+        if let TaskValue::Plan(plan) = task_value {
+            let table = plan_executor.execute_plan(plan).await?;
+            return Ok(TaskValue::Table(table));
+        }
+    }
+    Ok(task_value)
+}
+
 pub fn build_compilation_config(
     input_vars: &[InputVariable],
     values: &[TaskValue],
@@ -217,7 +233,8 @@ impl TaskCall for DataUrlTask {
 
         // Return value based on whether inline dataset was used
         let task_value = if let Some(inline_dataset) = inline_dataset_info {
-            result_df.to_task_value(inline_dataset).await?
+            let task_value = result_df.to_task_value(inline_dataset).await?;
+            maybe_materialize_plan(task_value, &plan_executor).await?
         } else {
             TaskValue::Table(result_df.collect_to_table().await?)
         };
@@ -566,7 +583,9 @@ impl TaskCall for DataSourceTask {
         if !has_transforms {
             match source_dataset {
                 VegaFusionDataset::Plan { plan } => {
-                    return Ok((TaskValue::Plan(plan), Vec::new()));
+                    let task_value =
+                        maybe_materialize_plan(TaskValue::Plan(plan), &plan_executor).await?;
+                    return Ok((task_value, Vec::new()));
                 }
                 VegaFusionDataset::Table { table, .. } => {
                     let table_val = TaskValue::Table(table.without_ordering()?);
@@ -586,6 +605,7 @@ impl TaskCall for DataSourceTask {
         let (df, output_values) = pipeline.eval_sql(source_df, &config).await?;
         let df = df.drop_index()?;
         let task_value = df.to_task_value(&source_dataset).await?;
+        let task_value = maybe_materialize_plan(task_value, &plan_executor).await?;
         Ok((task_value, output_values))
     }
 }

--- a/vegafusion-runtime/src/data/util.rs
+++ b/vegafusion-runtime/src/data/util.rs
@@ -2,14 +2,17 @@ use async_trait::async_trait;
 use datafusion::datasource::{provider_as_source, MemTable};
 use datafusion::prelude::{DataFrame, SessionContext};
 use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
-use datafusion_common::TableReference;
+use datafusion_common::{Column, TableReference};
 use datafusion_expr::{col, Expr, LogicalPlanBuilder, UNNAMED_TABLE};
 use datafusion_functions_window::row_number::row_number;
 use std::sync::Arc;
 use vegafusion_common::arrow::array::RecordBatch;
 use vegafusion_common::arrow::compute::concat_batches;
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::data::ORDER_COL;
 use vegafusion_common::error::ResultWithContext;
+use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::task_graph::task_value::TaskValue;
 
 #[async_trait]
 pub trait SessionContextUtils {
@@ -40,7 +43,14 @@ impl SessionContextUtils for SessionContext {
 pub trait DataFrameUtils {
     async fn collect_to_table(self) -> vegafusion_common::error::Result<VegaFusionTable>;
     async fn collect_flat(self) -> vegafusion_common::error::Result<RecordBatch>;
-    async fn with_index(self, index_name: &str) -> vegafusion_common::error::Result<DataFrame>;
+    fn with_index(self) -> vegafusion_common::error::Result<DataFrame>;
+    fn drop_index(self) -> vegafusion_common::error::Result<DataFrame>;
+
+    /// Convert DataFrame to TaskValue, preserving the format type of the source
+    async fn to_task_value(
+        self,
+        source: &VegaFusionDataset,
+    ) -> vegafusion_common::error::Result<TaskValue>;
 
     /// Variant of aggregate that can handle agg expressions that include projections on top
     /// of aggregations. Also includes groupby expressions in the final result
@@ -74,16 +84,52 @@ impl DataFrameUtils for DataFrame {
             .with_context(|| String::from("Failed to concatenate RecordBatches"))
     }
 
-    async fn with_index(self, index_name: &str) -> vegafusion_common::error::Result<DataFrame> {
-        if self.schema().inner().column_with_name(index_name).is_some() {
-            // Column is already present, don't overwrite
-            Ok(self.select(vec![datafusion_expr::expr_fn::wildcard()])?)
-        } else {
-            let selections: Vec<datafusion_expr::select_expr::SelectExpr> = vec![
-                row_number().alias(index_name).into(),
-                datafusion_expr::expr_fn::wildcard(),
-            ];
-            Ok(self.select(selections)?)
+    fn with_index(self) -> vegafusion_common::error::Result<DataFrame> {
+        if self.schema().has_column(&Column::from(ORDER_COL)) {
+            return Ok(self);
+        }
+
+        let df = self.window(vec![row_number().alias(ORDER_COL)])?;
+
+        let mut cols: Vec<Expr> = vec![Expr::Column(Column::from(ORDER_COL))];
+        cols.extend(
+            df.schema()
+                .fields()
+                .iter()
+                .filter(|f| f.name() != ORDER_COL)
+                .map(|f| Expr::Column(Column::from_name(f.name().clone()))),
+        );
+
+        Ok(df.select(cols)?)
+    }
+
+    fn drop_index(self) -> vegafusion_common::error::Result<DataFrame> {
+        if !self.schema().has_column(&Column::from(ORDER_COL)) {
+            return Ok(self);
+        }
+
+        let keep: Vec<String> = self
+            .schema()
+            .fields()
+            .iter()
+            .filter(|f| f.name() != ORDER_COL)
+            .map(|f| f.name().to_string())
+            .collect();
+
+        let keep_refs: Vec<&str> = keep.iter().map(|s| s.as_str()).collect();
+        Ok(self.select_columns(&keep_refs)?)
+    }
+
+    async fn to_task_value(
+        self,
+        source_ds: &VegaFusionDataset,
+    ) -> vegafusion_common::error::Result<TaskValue> {
+        match source_ds {
+            VegaFusionDataset::Plan { .. } => Ok(TaskValue::Plan(self.logical_plan().clone())),
+            VegaFusionDataset::Table { .. } => {
+                let tbl = self.collect_to_table().await?.without_ordering()?;
+                Ok(TaskValue::Table(tbl))
+            }
         }
     }
 

--- a/vegafusion-runtime/src/expression/compiler/array.rs
+++ b/vegafusion-runtime/src/expression/compiler/array.rs
@@ -5,14 +5,14 @@ use vegafusion_common::datafusion_common::DFSchema;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::ArrayExpression;
 
-pub fn compile_array(
+pub async fn compile_array(
     node: &ArrayExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
 ) -> Result<Expr> {
     let mut elements: Vec<Expr> = Vec::new();
     for el in &node.elements {
-        let phys_expr = compile(el, config, Some(schema))?;
+        let phys_expr = compile(el, config, Some(schema)).await?;
         elements.push(phys_expr);
     }
     Ok(make_array(elements))

--- a/vegafusion-runtime/src/expression/compiler/binary.rs
+++ b/vegafusion-runtime/src/expression/compiler/binary.rs
@@ -12,14 +12,14 @@ use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::{BinaryExpression, BinaryOperator};
 
-pub fn compile_binary(
+pub async fn compile_binary(
     node: &BinaryExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
 ) -> Result<Expr> {
     // First, compile argument
-    let lhs = compile(node.left(), config, Some(schema))?;
-    let rhs = compile(node.right(), config, Some(schema))?;
+    let lhs = compile(node.left(), config, Some(schema)).await?;
+    let rhs = compile(node.right(), config, Some(schema)).await?;
 
     let lhs_dtype = data_type(&lhs, schema)?;
     let rhs_dtype = data_type(&rhs, schema)?;

--- a/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/time_offset.rs
+++ b/vegafusion-runtime/src/expression/compiler/builtin_functions/date_time/time_offset.rs
@@ -90,6 +90,7 @@ pub fn time_offset_fn(
     let interval = match unit.to_lowercase().as_str() {
         unit @ ("year" | "month") => interval_year_month_lit(&format!("{step} {unit}")),
         "quarter" => interval_year_month_lit(&format!("{} month", step * 3)),
+        "date" => interval_datetime_lit(&format!("{step} day")),
         unit => interval_datetime_lit(&format!("{step} {unit}")),
     };
 

--- a/vegafusion-runtime/src/expression/compiler/conditional.rs
+++ b/vegafusion-runtime/src/expression/compiler/conditional.rs
@@ -7,15 +7,15 @@ use vegafusion_core::arrow::datatypes::DataType;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::ConditionalExpression;
 
-pub fn compile_conditional(
+pub async fn compile_conditional(
     node: &ConditionalExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
 ) -> Result<Expr> {
     // Compile branches
-    let test_expr = compile(node.test(), config, Some(schema))?;
-    let consequent_expr = compile(node.consequent(), config, Some(schema))?;
-    let alternate_expr = compile(node.alternate(), config, Some(schema))?;
+    let test_expr = compile(node.test(), config, Some(schema)).await?;
+    let consequent_expr = compile(node.consequent(), config, Some(schema)).await?;
+    let alternate_expr = compile(node.alternate(), config, Some(schema)).await?;
 
     let test = to_boolean(test_expr, schema)?;
 

--- a/vegafusion-runtime/src/expression/compiler/config.rs
+++ b/vegafusion-runtime/src/expression/compiler/config.rs
@@ -1,27 +1,36 @@
+use crate::datafusion::context::make_datafusion_context;
 use crate::expression::compiler::call::{default_callables, VegaFusionCallable};
+use crate::plan_executor::DataFusionPlanExecutor;
 use crate::task_graph::timezone::RuntimeTzConfig;
 use num_traits::float::FloatConst;
 use std::collections::HashMap;
-use vegafusion_common::data::table::VegaFusionTable;
+use std::sync::Arc;
 use vegafusion_common::datafusion_common::ScalarValue;
+use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::runtime::PlanExecutor;
 
 #[derive(Clone)]
 pub struct CompilationConfig {
     pub signal_scope: HashMap<String, ScalarValue>,
-    pub data_scope: HashMap<String, VegaFusionTable>,
+    pub data_scope: HashMap<String, VegaFusionDataset>,
     pub callable_scope: HashMap<String, VegaFusionCallable>,
     pub constants: HashMap<String, ScalarValue>,
     pub tz_config: Option<RuntimeTzConfig>,
+    pub plan_executor: Arc<dyn PlanExecutor>,
 }
 
 impl Default for CompilationConfig {
     fn default() -> Self {
+        let ctx = Arc::new(make_datafusion_context());
+        let plan_executor = Arc::new(DataFusionPlanExecutor::new(ctx)) as Arc<dyn PlanExecutor>;
+
         Self {
             signal_scope: Default::default(),
             data_scope: Default::default(),
             callable_scope: default_callables(),
             constants: default_constants(),
             tz_config: None,
+            plan_executor,
         }
     }
 }

--- a/vegafusion-runtime/src/expression/compiler/logical.rs
+++ b/vegafusion-runtime/src/expression/compiler/logical.rs
@@ -7,14 +7,14 @@ use vegafusion_common::datatypes::{cast_to, data_type, is_numeric_datatype, to_b
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::{LogicalExpression, LogicalOperator};
 
-pub fn compile_logical(
+pub async fn compile_logical(
     node: &LogicalExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
 ) -> Result<Expr> {
     // Compile branches
-    let mut compiled_lhs = compile(node.left(), config, Some(schema))?;
-    let mut compiled_rhs = compile(node.right(), config, Some(schema))?;
+    let mut compiled_lhs = compile(node.left(), config, Some(schema)).await?;
+    let mut compiled_rhs = compile(node.right(), config, Some(schema)).await?;
 
     let lhs_dtype = data_type(&compiled_lhs, schema)?;
     let rhs_dtype = data_type(&compiled_rhs, schema)?;

--- a/vegafusion-runtime/src/expression/compiler/member.rs
+++ b/vegafusion-runtime/src/expression/compiler/member.rs
@@ -16,7 +16,7 @@ use vegafusion_common::datatypes::{data_type, is_numeric_datatype};
 use vegafusion_core::error::{Result, ResultWithContext, VegaFusionError};
 use vegafusion_core::proto::gen::expression::{Identifier, MemberExpression};
 
-pub fn compile_member(
+pub async fn compile_member(
     node: &MemberExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
@@ -27,7 +27,7 @@ pub fn compile_member(
     // Get string-form of index
     let property_string = if node.computed {
         // e.g. foo[val]
-        let compiled_property = compile(node.property(), config, Some(schema))?;
+        let compiled_property = compile(node.property(), config, Some(schema)).await?;
         let evaluated_property = compiled_property.eval_to_scalar().with_context(
             || format!("VegaFusion does not support the use of datum expressions in object member access: {node}")
         )?;
@@ -67,7 +67,7 @@ pub fn compile_member(
         _ => {}
     }
 
-    let compiled_object = compile(node.object(), config, Some(schema))?;
+    let compiled_object = compile(node.object(), config, Some(schema)).await?;
     let dtype = data_type(&compiled_object, schema)?;
 
     let expr = match dtype {

--- a/vegafusion-runtime/src/expression/compiler/object.rs
+++ b/vegafusion-runtime/src/expression/compiler/object.rs
@@ -6,7 +6,7 @@ use vegafusion_common::datafusion_common::DFSchema;
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::ObjectExpression;
 
-pub fn compile_object(
+pub async fn compile_object(
     node: &ObjectExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
@@ -14,7 +14,7 @@ pub fn compile_object(
     let mut named_struct_args = Vec::new();
     for prop in &node.properties {
         let name = prop.key().to_object_key_string();
-        let value_expr = compile(prop.value(), config, Some(schema))?;
+        let value_expr = compile(prop.value(), config, Some(schema)).await?;
         named_struct_args.push(lit(name));
         named_struct_args.push(value_expr);
     }

--- a/vegafusion-runtime/src/expression/compiler/unary.rs
+++ b/vegafusion-runtime/src/expression/compiler/unary.rs
@@ -5,13 +5,13 @@ use vegafusion_common::datatypes::{to_boolean, to_numeric};
 use vegafusion_core::error::Result;
 use vegafusion_core::proto::gen::expression::{UnaryExpression, UnaryOperator};
 
-pub fn compile_unary(
+pub async fn compile_unary(
     node: &UnaryExpression,
     config: &CompilationConfig,
     schema: &DFSchema,
 ) -> Result<Expr> {
     // First, compile argument
-    let argument = compile(node.argument(), config, Some(schema))?;
+    let argument = compile(node.argument(), config, Some(schema)).await?;
     let new_expr = match node.to_operator() {
         UnaryOperator::Pos => to_numeric(argument, schema)?,
         UnaryOperator::Neg => Expr::Negative(Box::new(to_numeric(argument, schema)?)),

--- a/vegafusion-runtime/src/lib.rs
+++ b/vegafusion-runtime/src/lib.rs
@@ -5,6 +5,7 @@ extern crate core;
 pub mod data;
 pub mod datafusion;
 pub mod expression;
+pub mod plan_executor;
 pub mod signal;
 pub mod task_graph;
 pub mod tokio_runtime;

--- a/vegafusion-runtime/src/plan_executor.rs
+++ b/vegafusion-runtime/src/plan_executor.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use datafusion::prelude::{DataFrame, SessionContext};
+use std::sync::Arc;
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlan;
+use vegafusion_common::error::Result;
+use vegafusion_core::runtime::PlanExecutor;
+
+use crate::data::util::DataFrameUtils;
+
+#[derive(Clone)]
+pub struct DataFusionPlanExecutor {
+    ctx: Arc<SessionContext>,
+}
+
+impl DataFusionPlanExecutor {
+    pub fn new(ctx: Arc<SessionContext>) -> Self {
+        Self { ctx }
+    }
+}
+
+#[async_trait]
+impl PlanExecutor for DataFusionPlanExecutor {
+    async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
+        let df = DataFrame::new(self.ctx.state(), plan);
+        df.collect_to_table().await
+    }
+}

--- a/vegafusion-runtime/src/plan_executor.rs
+++ b/vegafusion-runtime/src/plan_executor.rs
@@ -21,6 +21,10 @@ impl DataFusionPlanExecutor {
 
 #[async_trait]
 impl PlanExecutor for DataFusionPlanExecutor {
+    fn name(&self) -> &str {
+        "DataFusionPlanExecutor"
+    }
+
     async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
         let df = DataFrame::new(self.ctx.state(), plan);
         df.collect_to_table().await

--- a/vegafusion-runtime/src/signal/mod.rs
+++ b/vegafusion-runtime/src/signal/mod.rs
@@ -7,6 +7,7 @@ use datafusion::prelude::SessionContext;
 use std::collections::HashMap;
 use std::sync::Arc;
 use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::runtime::PlanExecutor;
 
 use crate::task_graph::timezone::RuntimeTzConfig;
 use vegafusion_core::error::Result;
@@ -22,10 +23,11 @@ impl TaskCall for SignalTask {
         tz_config: &Option<RuntimeTzConfig>,
         _inline_datasets: HashMap<String, VegaFusionDataset>,
         _ctx: Arc<SessionContext>,
+        plan_executor: Arc<dyn PlanExecutor>,
     ) -> Result<(TaskValue, Vec<TaskValue>)> {
-        let config = build_compilation_config(&self.input_vars(), values, tz_config);
+        let config = build_compilation_config(&self.input_vars(), values, tz_config, plan_executor);
         let expression = self.expr.as_ref().unwrap();
-        let expr = compile(expression, &config, None)?;
+        let expr = compile(expression, &config, None).await?;
         let value = expr.eval_to_scalar()?;
         let task_value = TaskValue::Scalar(value);
         Ok((task_value, Default::default()))

--- a/vegafusion-runtime/src/task_graph/runtime.rs
+++ b/vegafusion-runtime/src/task_graph/runtime.rs
@@ -20,7 +20,7 @@ use vegafusion_core::proto::gen::tasks::{
 };
 use vegafusion_core::runtime::PlanExecutor;
 use vegafusion_core::runtime::VegaFusionRuntimeTrait;
-use vegafusion_core::task_graph::task_value::{NamedTaskValue, TaskValue};
+use vegafusion_core::task_graph::task_value::{MaterializedTaskValue, NamedTaskValue, TaskValue};
 
 #[cfg(feature = "proto")]
 use {
@@ -60,7 +60,7 @@ impl VegaFusionRuntime {
     ) -> Result<TaskValue> {
         // We shouldn't panic inside get_or_compute_node_value, but since this may be used
         // in a server context, wrap in catch_unwind just in case.
-        let executor = self.plan_executor();
+        let executor = self.plan_executor.clone();
         let node_value = AssertUnwindSafe(get_or_compute_node_value(
             task_graph,
             node_value_index.node_index as usize,
@@ -99,8 +99,16 @@ impl VegaFusionRuntimeTrait for VegaFusionRuntime {
         self
     }
 
-    fn plan_executor(&self) -> Arc<dyn PlanExecutor> {
-        self.plan_executor.clone()
+    async fn materialize_task_values(
+        &self,
+        values: Vec<TaskValue>,
+    ) -> Result<Vec<MaterializedTaskValue>> {
+        let executor = self.plan_executor.clone();
+        futures_util::future::try_join_all(values.into_iter().map(|value| {
+            let exec = executor.clone();
+            async move { value.to_materialized(exec).await }
+        }))
+        .await
     }
 
     async fn query_request(

--- a/vegafusion-runtime/src/transform/filter.rs
+++ b/vegafusion-runtime/src/transform/filter.rs
@@ -20,7 +20,8 @@ impl TransformTrait for Filter {
             self.expr.as_ref().unwrap(),
             config,
             Some(dataframe.schema()),
-        )?;
+        )
+        .await?;
 
         // Cast filter expr to boolean
         let filter_expr = to_boolean(filter_expr, dataframe.schema())?;

--- a/vegafusion-runtime/src/transform/formula.rs
+++ b/vegafusion-runtime/src/transform/formula.rs
@@ -23,7 +23,8 @@ impl TransformTrait for Formula {
             self.expr.as_ref().unwrap(),
             config,
             Some(dataframe.schema()),
-        )?;
+        )
+        .await?;
 
         // Simplify expression prior to evaluation
         let simplifier = ExprSimplifier::new(VfSimplifyInfo::from(dataframe.schema().clone()));

--- a/vegafusion-runtime/src/transform/sequence.rs
+++ b/vegafusion-runtime/src/transform/sequence.rs
@@ -24,16 +24,16 @@ impl TransformTrait for Sequence {
         dataframe: DataFrame,
         config: &CompilationConfig,
     ) -> Result<(DataFrame, Vec<TaskValue>)> {
-        let start_expr = compile(self.start.as_ref().unwrap(), config, None)?;
+        let start_expr = compile(self.start.as_ref().unwrap(), config, None).await?;
         let start_scalar = start_expr.eval_to_scalar()?;
         let start = start_scalar.to_f64()?;
 
-        let stop_expr = compile(self.stop.as_ref().unwrap(), config, None)?;
+        let stop_expr = compile(self.stop.as_ref().unwrap(), config, None).await?;
         let stop_scalar = stop_expr.eval_to_scalar()?;
         let stop = stop_scalar.to_f64()?;
 
         let step = if let Some(step_signal) = &self.step {
-            let step_expr = compile(step_signal, config, None)?;
+            let step_expr = compile(step_signal, config, None).await?;
             let step_scalar = step_expr.eval_to_scalar()?;
             step_scalar.to_f64()?
         } else if stop >= start {

--- a/vegafusion-runtime/tests/test_chart_state.rs
+++ b/vegafusion-runtime/tests/test_chart_state.rs
@@ -25,7 +25,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let chart_state = ChartState::try_new(
             &runtime,

--- a/vegafusion-runtime/tests/test_destringify_selection_datasets.rs
+++ b/vegafusion-runtime/tests/test_destringify_selection_datasets.rs
@@ -24,7 +24,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (chart_spec, _warnings) = runtime
             .pre_transform_spec(

--- a/vegafusion-runtime/tests/test_expression_evaluation.rs
+++ b/vegafusion-runtime/tests/test_expression_evaluation.rs
@@ -6,6 +6,7 @@ use datafusion_common::ScalarValue;
 use rstest::rstest;
 use serde_json::json;
 use std::collections::HashMap;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 
 use util::check::check_scalar_evaluation;
 use vegafusion_common::data::table::VegaFusionTable;
@@ -40,10 +41,16 @@ pub fn dataset_2() -> VegaFusionTable {
     VegaFusionTable::from_json(&json_value).unwrap()
 }
 
-fn datasets() -> HashMap<String, VegaFusionTable> {
+fn datasets() -> HashMap<String, VegaFusionDataset> {
     vec![
-        ("dataA".to_string(), dataset_1()),
-        ("dataB".to_string(), dataset_2()),
+        (
+            "dataA".to_string(),
+            VegaFusionDataset::from_table(dataset_1(), None).unwrap(),
+        ),
+        (
+            "dataB".to_string(),
+            VegaFusionDataset::from_table(dataset_2(), None).unwrap(),
+        ),
     ]
     .into_iter()
     .collect()

--- a/vegafusion-runtime/tests/test_expression_evaluation.rs
+++ b/vegafusion-runtime/tests/test_expression_evaluation.rs
@@ -627,65 +627,65 @@ mod test_string_type_equality {
         }
     }
 
-    fn eval_expr(expr_str: &str) -> ScalarValue {
+    async fn eval_expr(expr_str: &str) -> ScalarValue {
         let config = config();
         let parsed = parse(expr_str).unwrap();
-        let compiled = compile(&parsed, &config, None).unwrap();
+        let compiled = compile(&parsed, &config, None).await.unwrap();
         compiled.eval_to_scalar().unwrap()
     }
 
-    #[test]
-    fn test_utf8view_strict_equals_literal() {
+    #[tokio::test]
+    async fn test_utf8view_strict_equals_literal() {
         // Utf8View === Utf8 literal should be true when values match
-        let result = eval_expr("name_view === 'Bob'");
+        let result = eval_expr("name_view === 'Bob'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
 
         // Should be false when values don't match
-        let result = eval_expr("name_view === 'Alice'");
+        let result = eval_expr("name_view === 'Alice'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(false)));
     }
 
-    #[test]
-    fn test_large_utf8_strict_equals_literal() {
+    #[tokio::test]
+    async fn test_large_utf8_strict_equals_literal() {
         // LargeUtf8 === Utf8 literal should be true when values match
-        let result = eval_expr("name_large === 'Bob'");
+        let result = eval_expr("name_large === 'Bob'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
 
         // Should be false when values don't match
-        let result = eval_expr("name_large === 'Alice'");
+        let result = eval_expr("name_large === 'Alice'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(false)));
     }
 
-    #[test]
-    fn test_utf8_strict_equals_literal() {
+    #[tokio::test]
+    async fn test_utf8_strict_equals_literal() {
         // Utf8 === Utf8 literal (baseline)
-        let result = eval_expr("name_utf8 === 'Bob'");
+        let result = eval_expr("name_utf8 === 'Bob'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
 
-        let result = eval_expr("name_utf8 === 'Alice'");
+        let result = eval_expr("name_utf8 === 'Alice'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(false)));
     }
 
-    #[test]
-    fn test_utf8view_not_strict_equals_literal() {
+    #[tokio::test]
+    async fn test_utf8view_not_strict_equals_literal() {
         // Utf8View !== Utf8 literal
-        let result = eval_expr("name_view !== 'Bob'");
+        let result = eval_expr("name_view !== 'Bob'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(false)));
 
-        let result = eval_expr("name_view !== 'Alice'");
+        let result = eval_expr("name_view !== 'Alice'").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
     }
 
-    #[test]
-    fn test_mixed_string_types_equality() {
+    #[tokio::test]
+    async fn test_mixed_string_types_equality() {
         // Cross-type comparisons should work
-        let result = eval_expr("name_view === name_large");
+        let result = eval_expr("name_view === name_large").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
 
-        let result = eval_expr("name_view === name_utf8");
+        let result = eval_expr("name_view === name_utf8").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
 
-        let result = eval_expr("name_large === name_utf8");
+        let result = eval_expr("name_large === name_utf8").await;
         assert_eq!(result, ScalarValue::Boolean(Some(true)));
     }
 }

--- a/vegafusion-runtime/tests/test_image_comparison.rs
+++ b/vegafusion-runtime/tests/test_image_comparison.rs
@@ -1466,12 +1466,7 @@ async fn check_spec_sequence(
     for var in &spec_plan.comm_plan.server_to_client {
         let node_index = task_graph_mapping.get(var).unwrap();
         let value = runtime
-            .get_node_value(
-                Arc::new(task_graph.clone()),
-                node_index,
-                Default::default(),
-                None,
-            )
+            .get_node_value(Arc::new(task_graph.clone()), node_index, Default::default())
             .await
             .expect("Failed to get node value");
 
@@ -1543,12 +1538,7 @@ async fn check_spec_sequence(
         let mut server_to_client_value_batch = HashMap::new();
         for (var, node_index) in watch_vars.iter().zip(&watch_indices) {
             let value = runtime
-                .get_node_value(
-                    Arc::new(task_graph.clone()),
-                    node_index,
-                    Default::default(),
-                    None,
-                )
+                .get_node_value(Arc::new(task_graph.clone()), node_index, Default::default())
                 .await
                 .unwrap();
 

--- a/vegafusion-runtime/tests/test_plan_executor.rs
+++ b/vegafusion-runtime/tests/test_plan_executor.rs
@@ -1,0 +1,625 @@
+use async_trait::async_trait;
+use datafusion::catalog::TableProvider;
+use datafusion::datasource::{provider_as_source, MemTable};
+use datafusion_common::tree_node::{Transformed, TreeNode, TreeNodeRewriter};
+use datafusion_expr::LogicalPlanBuilder;
+use datafusion_expr::{Expr, LogicalPlan as DFLogicalPlan, TableSource};
+use std::any::Any;
+use std::borrow::Cow;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use vegafusion_common::arrow::array::{Float64Array, Int64Array, RecordBatch, StringArray};
+use vegafusion_common::arrow::datatypes::{DataType, Field, Schema};
+use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_common::datafusion_expr::LogicalPlan;
+use vegafusion_common::error::Result;
+use vegafusion_core::data::dataset::VegaFusionDataset;
+use vegafusion_core::proto::gen::pretransform::PreTransformSpecOpts;
+use vegafusion_core::runtime::{PlanExecutor, VegaFusionRuntimeTrait};
+use vegafusion_core::spec::chart::ChartSpec;
+use vegafusion_runtime::datafusion::context::make_datafusion_context;
+use vegafusion_runtime::plan_executor::DataFusionPlanExecutor;
+use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
+
+// By-default, in DataFusion you construct table provider (i.e. enity which can actually load data and return
+// to execution engine) and then create table source (schema-only entity used for logical plan) from it. To make sure
+// we don't accidentally execute logical plan bypassing plan executor, for tests we implement custom table source which
+// can't load any data. Trying to execute logical plan with this table source will result in an error.
+#[derive(Debug, Clone)]
+struct SchemaOnlyTableSource {
+    schema: Arc<Schema>,
+}
+
+impl SchemaOnlyTableSource {
+    fn new(schema: Arc<Schema>) -> Self {
+        Self { schema }
+    }
+}
+
+impl TableSource for SchemaOnlyTableSource {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> Arc<Schema> {
+        self.schema.clone()
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        _filters: &[&Expr],
+    ) -> datafusion_common::Result<Vec<datafusion_expr::TableProviderFilterPushDown>> {
+        Ok(vec![])
+    }
+
+    fn get_logical_plan(&self) -> Option<Cow<'_, DFLogicalPlan>> {
+        None
+    }
+}
+
+// Custom executor which tracks its invocations and passes actual query execution to DataFusion executor, rewriting
+// plan to replace our custom table source with mem table to make query executable.
+#[derive(Clone)]
+struct TrackingPlanExecutor {
+    call_count: Arc<AtomicUsize>,
+    movies_table: Arc<dyn TableProvider>,
+    fallback_executor: Arc<DataFusionPlanExecutor>,
+}
+
+impl TrackingPlanExecutor {
+    fn new() -> Self {
+        let ctx = Arc::new(make_datafusion_context());
+
+        let movies_table = create_movies_table();
+        let schema = movies_table.schema.clone();
+        let batches = movies_table.batches.clone();
+        let mem_table =
+            Arc::new(MemTable::try_new(schema, vec![batches]).unwrap()) as Arc<dyn TableProvider>;
+
+        Self {
+            call_count: Arc::new(AtomicUsize::new(0)),
+            movies_table: mem_table,
+            fallback_executor: Arc::new(DataFusionPlanExecutor::new(ctx)),
+        }
+    }
+
+    fn get_call_count(&self) -> usize {
+        self.call_count.load(Ordering::SeqCst)
+    }
+}
+
+struct TableRewriter {
+    movies_table: Arc<dyn TableProvider>,
+}
+
+impl TreeNodeRewriter for TableRewriter {
+    type Node = DFLogicalPlan;
+
+    fn f_up(&mut self, node: Self::Node) -> datafusion_common::Result<Transformed<Self::Node>> {
+        if let DFLogicalPlan::TableScan(scan) = &node {
+            if scan.table_name.table() == "movies" {
+                // Verify that the source is actually our SchemaOnlyTableSource
+                if scan
+                    .source
+                    .as_any()
+                    .downcast_ref::<SchemaOnlyTableSource>()
+                    .is_some()
+                {
+                    let new_scan = DFLogicalPlan::TableScan(datafusion_expr::TableScan {
+                        table_name: scan.table_name.clone(),
+                        source: provider_as_source(self.movies_table.clone()),
+                        projection: scan.projection.clone(),
+                        projected_schema: scan.projected_schema.clone(),
+                        filters: scan.filters.clone(),
+                        fetch: scan.fetch,
+                    });
+                    return Ok(Transformed::yes(new_scan));
+                }
+            }
+        }
+        Ok(Transformed::no(node))
+    }
+}
+
+#[async_trait]
+impl PlanExecutor for TrackingPlanExecutor {
+    async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+
+        let mut rewriter = TableRewriter {
+            movies_table: self.movies_table.clone(),
+        };
+        let rewritten_plan = plan.rewrite(&mut rewriter).unwrap().data;
+
+        self.fallback_executor.execute_plan(rewritten_plan).await
+    }
+}
+
+#[tokio::test]
+async fn test_custom_executor_called_in_pre_transform_spec() {
+    let tracking_executor = TrackingPlanExecutor::new();
+    let executor_clone = tracking_executor.clone();
+
+    let runtime = VegaFusionRuntime::new(None, Some(Arc::new(tracking_executor)));
+
+    let spec = get_simple_spec();
+    let inline_datasets = get_inline_datasets();
+
+    let (_transformed_spec, warnings) = runtime
+        .pre_transform_spec(
+            &spec,
+            &inline_datasets,
+            &PreTransformSpecOpts {
+                preserve_interactivity: false,
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+                row_limit: None,
+                keep_variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(warnings.is_empty());
+
+    let call_count = executor_clone.get_call_count();
+    assert!(
+        call_count > 0,
+        "Custom executor should have been called at least once"
+    );
+}
+
+#[tokio::test]
+async fn test_custom_executor_called_in_pre_transform_extract() {
+    let tracking_executor = TrackingPlanExecutor::new();
+    let executor_clone = tracking_executor.clone();
+
+    let runtime = VegaFusionRuntime::new(None, Some(Arc::new(tracking_executor)));
+
+    let spec = get_simple_spec();
+    let inline_datasets = get_inline_datasets();
+
+    let (_transformed_spec, _datasets, warnings) = runtime
+        .pre_transform_extract(
+            &spec,
+            &inline_datasets,
+            &vegafusion_core::proto::gen::pretransform::PreTransformExtractOpts {
+                preserve_interactivity: false,
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+                extract_threshold: 100,
+                keep_variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(warnings.is_empty());
+
+    let call_count = executor_clone.get_call_count();
+    assert!(
+        call_count > 0,
+        "Custom executor should have been called at least once"
+    );
+}
+
+#[tokio::test]
+async fn test_custom_executor_called_in_pre_transform_values() {
+    let tracking_executor = TrackingPlanExecutor::new();
+    let executor_clone = tracking_executor.clone();
+
+    let runtime = VegaFusionRuntime::new(None, Some(Arc::new(tracking_executor)));
+
+    let spec = get_simple_spec();
+    let inline_datasets = get_inline_datasets();
+
+    let variables = vec![(
+        vegafusion_core::proto::gen::tasks::Variable {
+            namespace: vegafusion_core::proto::gen::tasks::VariableNamespace::Data as i32,
+            name: "source_0".to_string(),
+        },
+        vec![],
+    )];
+
+    let (values, warnings) = runtime
+        .pre_transform_values(
+            &spec,
+            &variables,
+            &inline_datasets,
+            &vegafusion_core::proto::gen::pretransform::PreTransformValuesOpts {
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+                row_limit: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(warnings.is_empty());
+    assert_eq!(values.len(), 1);
+
+    let call_count = executor_clone.get_call_count();
+    assert!(
+        call_count > 0,
+        "Custom executor should have been called at least once"
+    );
+}
+
+// Bin transform internally uses data from extent transform to compute binning boundaries.
+// This requires materializing extend data before binning can be done, which creates kind of chain
+// where binning logical plan will depend on materialized results of extent.
+#[tokio::test]
+async fn test_bin_transform_uses_custom_executor() {
+    let tracking_executor = TrackingPlanExecutor::new();
+    let executor_clone = tracking_executor.clone();
+
+    let runtime = VegaFusionRuntime::new(None, Some(Arc::new(tracking_executor)));
+
+    let spec_str = r#"{
+        "$schema": "https://vega.github.io/schema/vega/v5.json",
+        "width": 200,
+        "height": 200,
+        "padding": 5,
+        "data": [
+            {
+                "name": "source_0",
+                "url": "table://movies",
+                "transform": [
+                    {
+                        "type": "extent",
+                        "field": "imdb_rating",
+                        "signal": "bin_maxbins_10_imdb_rating_extent"
+                    },
+                    {
+                        "type": "bin",
+                        "field": "imdb_rating",
+                        "as": [
+                            "bin_maxbins_10_imdb_rating",
+                            "bin_maxbins_10_imdb_rating_end"
+                        ],
+                        "signal": "bin_maxbins_10_imdb_rating_bins",
+                        "extent": {"signal": "bin_maxbins_10_imdb_rating_extent"},
+                        "maxbins": 10
+                    },
+                    {
+                        "type": "aggregate",
+                        "groupby": [
+                            "bin_maxbins_10_imdb_rating",
+                            "bin_maxbins_10_imdb_rating_end"
+                        ],
+                        "ops": ["count"],
+                        "fields": [null],
+                        "as": ["__count"]
+                    }
+                ]
+            }
+        ],
+        "marks": [
+            {
+                "type": "rect",
+                "from": {"data": "source_0"},
+                "encode": {
+                    "update": {
+                        "x": {"scale": "xscale", "field": "bin_maxbins_10_imdb_rating"},
+                        "x2": {"scale": "xscale", "field": "bin_maxbins_10_imdb_rating_end"},
+                        "y": {"scale": "yscale", "field": "__count"},
+                        "y2": {"scale": "yscale", "value": 0}
+                    }
+                }
+            }
+        ],
+        "scales": [
+            {
+                "name": "xscale",
+                "type": "linear",
+                "domain": {
+                    "signal": "[bin_maxbins_10_imdb_rating_bins.start, bin_maxbins_10_imdb_rating_bins.stop]"
+                },
+                "range": "width",
+                "bins": {"signal": "bin_maxbins_10_imdb_rating_bins"}
+            },
+            {
+                "name": "yscale",
+                "type": "linear",
+                "domain": {"data": "source_0", "field": "__count"},
+                "range": "height",
+                "nice": true
+            }
+        ]
+    }"#;
+
+    let spec: ChartSpec = serde_json::from_str(spec_str).unwrap();
+    let inline_datasets = get_inline_datasets();
+
+    let (_transformed_spec, warnings) = runtime
+        .pre_transform_spec(
+            &spec,
+            &inline_datasets,
+            &PreTransformSpecOpts {
+                preserve_interactivity: false,
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+                row_limit: None,
+                keep_variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(warnings.is_empty());
+
+    let call_count = executor_clone.get_call_count();
+
+    assert_eq!(
+        call_count, 3,
+        "Custom executor should have been called 3 times: \
+        (1) extent transform for binning boundaries, \
+        (2) bin + aggregate transforms, \
+        (3) scale domain computation for yscale"
+    );
+}
+
+#[tokio::test]
+async fn test_mixed_data_only_executes_plans() {
+    let tracking_executor = TrackingPlanExecutor::new();
+    let executor_clone = tracking_executor.clone();
+
+    let runtime = VegaFusionRuntime::new(None, Some(Arc::new(tracking_executor)));
+
+    let spec_str = r#"{
+        "$schema": "https://vega.github.io/schema/vega/v5.json",
+        "width": 400,
+        "height": 200,
+        "padding": 5,
+        "data": [
+            {
+                "name": "source_table",
+                "url": "table://movies_table",
+                "transform": [
+                    {
+                        "type": "aggregate",
+                        "groupby": ["genre"],
+                        "ops": ["count"],
+                        "fields": [null],
+                        "as": ["count_from_table"]
+                    }
+                ]
+            },
+            {
+                "name": "source_plan",
+                "url": "table://movies_plan",
+                "transform": [
+                    {
+                        "type": "aggregate",
+                        "groupby": ["genre"],
+                        "ops": ["count"],
+                        "fields": [null],
+                        "as": ["count_from_plan"]
+                    }
+                ]
+            }
+        ],
+        "marks": [
+            {
+                "type": "rect",
+                "from": {"data": "source_table"}
+            },
+            {
+                "type": "rect",
+                "from": {"data": "source_plan"}
+            }
+        ]
+    }"#;
+
+    let spec: ChartSpec = serde_json::from_str(spec_str).unwrap();
+
+    let movies_table = create_movies_table();
+    let movies_plan = create_movies_logical_plan();
+
+    let mut inline_datasets = std::collections::HashMap::new();
+    inline_datasets.insert(
+        "movies_table".to_string(),
+        VegaFusionDataset::from_table(movies_table, None).unwrap(),
+    );
+    inline_datasets.insert(
+        "movies_plan".to_string(),
+        VegaFusionDataset::from_plan(movies_plan),
+    );
+
+    let (_transformed_spec, warnings) = runtime
+        .pre_transform_spec(
+            &spec,
+            &inline_datasets,
+            &PreTransformSpecOpts {
+                preserve_interactivity: false,
+                local_tz: "UTC".to_string(),
+                default_input_tz: None,
+                row_limit: None,
+                keep_variables: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(warnings.is_empty());
+
+    let call_count = executor_clone.get_call_count();
+
+    assert_eq!(
+        call_count, 1,
+        "Custom executor should have been called only once"
+    );
+}
+
+fn get_simple_spec() -> ChartSpec {
+    let spec_str = r#"{
+        "$schema": "https://vega.github.io/schema/vega/v5.json",
+        "width": 400,
+        "height": 200,
+        "padding": 5,
+        "data": [
+            {
+                "name": "source_0",
+                "url": "table://movies",
+                "transform": [
+                    {
+                        "type": "aggregate",
+                        "groupby": ["genre"],
+                        "ops": ["sum", "average", "count"],
+                        "fields": ["worldwide_gross", "imdb_rating", null],
+                        "as": ["total_gross", "avg_rating", "movie_count"]
+                    }
+                ]
+            }
+        ],
+        "scales": [
+            {
+                "name": "xscale",
+                "type": "band",
+                "domain": {"data": "source_0", "field": "genre"},
+                "range": "width",
+                "padding": 0.05
+            },
+            {
+                "name": "yscale",
+                "domain": {"data": "source_0", "field": "total_gross"},
+                "nice": true,
+                "range": "height"
+            }
+        ],
+        "marks": [
+            {
+                "type": "rect",
+                "from": {"data": "source_0"},
+                "encode": {
+                    "enter": {
+                        "x": {"scale": "xscale", "field": "genre"},
+                        "width": {"scale": "xscale", "band": 1},
+                        "y": {"scale": "yscale", "field": "total_gross"},
+                        "y2": {"scale": "yscale", "value": 0}
+                    }
+                }
+            }
+        ]
+    }"#;
+
+    serde_json::from_str(spec_str).unwrap()
+}
+
+fn get_movies_schema() -> Arc<Schema> {
+    Arc::new(Schema::new(vec![
+        Field::new("title", DataType::Utf8, false),
+        Field::new("genre", DataType::Utf8, false),
+        Field::new("director", DataType::Utf8, true),
+        Field::new("release_year", DataType::Int64, false),
+        Field::new("worldwide_gross", DataType::Int64, false),
+        Field::new("production_budget", DataType::Int64, true),
+        Field::new("imdb_rating", DataType::Float64, true),
+        Field::new("rotten_tomatoes", DataType::Int64, true),
+    ]))
+}
+
+#[allow(dead_code)]
+fn create_movies_table() -> VegaFusionTable {
+    let schema = get_movies_schema();
+
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec![
+                "The Shawshank Redemption",
+                "The Dark Knight",
+                "Inception",
+                "Pulp Fiction",
+                "Forrest Gump",
+                "The Matrix",
+                "Goodfellas",
+                "The Silence of the Lambs",
+                "Interstellar",
+                "The Prestige",
+            ])),
+            Arc::new(StringArray::from(vec![
+                "Drama", "Action", "Action", "Crime", "Drama", "Action", "Crime", "Thriller",
+                "Sci-Fi", "Thriller",
+            ])),
+            Arc::new(StringArray::from(vec![
+                Some("Frank Darabont"),
+                Some("Christopher Nolan"),
+                Some("Christopher Nolan"),
+                Some("Quentin Tarantino"),
+                Some("Robert Zemeckis"),
+                Some("The Wachowskis"),
+                Some("Martin Scorsese"),
+                Some("Jonathan Demme"),
+                Some("Christopher Nolan"),
+                Some("Christopher Nolan"),
+            ])),
+            Arc::new(Int64Array::from(vec![
+                1994, 2008, 2010, 1994, 1994, 1999, 1990, 1991, 2014, 2006,
+            ])),
+            Arc::new(Int64Array::from(vec![
+                28341469, 1004558444, 836848102, 213928762, 678226465, 463517383, 46836394,
+                272742922, 677471339, 109676311,
+            ])),
+            Arc::new(Int64Array::from(vec![
+                Some(25000000),
+                Some(185000000),
+                Some(160000000),
+                Some(8000000),
+                Some(55000000),
+                Some(63000000),
+                Some(25000000),
+                Some(19000000),
+                Some(165000000),
+                Some(40000000),
+            ])),
+            Arc::new(Float64Array::from(vec![
+                Some(9.3),
+                Some(9.0),
+                Some(8.8),
+                Some(8.9),
+                Some(8.8),
+                Some(8.7),
+                Some(8.7),
+                Some(8.6),
+                Some(8.6),
+                Some(8.5),
+            ])),
+            Arc::new(Int64Array::from(vec![
+                Some(91),
+                Some(94),
+                Some(87),
+                Some(92),
+                Some(71),
+                Some(88),
+                Some(96),
+                Some(96),
+                Some(72),
+                Some(76),
+            ])),
+        ],
+    )
+    .unwrap();
+
+    VegaFusionTable::from(batch)
+}
+
+fn create_movies_logical_plan() -> LogicalPlan {
+    let schema = get_movies_schema();
+
+    let table_source = Arc::new(SchemaOnlyTableSource::new(schema));
+
+    LogicalPlanBuilder::scan("movies", table_source, None)
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn get_inline_datasets() -> std::collections::HashMap<String, VegaFusionDataset> {
+    let logical_plan = create_movies_logical_plan();
+    let dataset = VegaFusionDataset::from_plan(logical_plan);
+
+    let mut datasets = std::collections::HashMap::new();
+    datasets.insert("movies".to_string(), dataset);
+    datasets
+}

--- a/vegafusion-runtime/tests/test_plan_executor.rs
+++ b/vegafusion-runtime/tests/test_plan_executor.rs
@@ -123,6 +123,10 @@ impl TreeNodeRewriter for TableRewriter {
 
 #[async_trait]
 impl PlanExecutor for TrackingPlanExecutor {
+    fn name(&self) -> &str {
+        "TrackingPlanExecutor"
+    }
+
     async fn execute_plan(&self, plan: LogicalPlan) -> Result<VegaFusionTable> {
         self.call_count.fetch_add(1, Ordering::SeqCst);
 

--- a/vegafusion-runtime/tests/test_planning.rs
+++ b/vegafusion-runtime/tests/test_planning.rs
@@ -61,7 +61,7 @@ async fn test_extract_server_data() {
     let mapping = graph.build_mapping();
     // println!("{:#?}", mapping);
 
-    let graph_runtime = VegaFusionRuntime::new(None);
+    let graph_runtime = VegaFusionRuntime::default();
     let _data_3 = graph_runtime
         .get_node_value(
             graph.clone(),
@@ -69,6 +69,7 @@ async fn test_extract_server_data() {
                 .get(&(Variable::new_data("data_3"), Vec::new()))
                 .unwrap(),
             Default::default(),
+            None,
         )
         .await
         .unwrap();
@@ -85,6 +86,7 @@ async fn test_extract_server_data() {
                 ))
                 .unwrap(),
             Default::default(),
+            None,
         )
         .await
         .unwrap();

--- a/vegafusion-runtime/tests/test_planning.rs
+++ b/vegafusion-runtime/tests/test_planning.rs
@@ -69,7 +69,6 @@ async fn test_extract_server_data() {
                 .get(&(Variable::new_data("data_3"), Vec::new()))
                 .unwrap(),
             Default::default(),
-            None,
         )
         .await
         .unwrap();
@@ -86,7 +85,6 @@ async fn test_extract_server_data() {
                 ))
                 .unwrap(),
             Default::default(),
-            None,
         )
         .await
         .unwrap();

--- a/vegafusion-runtime/tests/test_pre_transform_extract.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_extract.rs
@@ -26,7 +26,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (tx_spec, datasets, warnings) = runtime
             .pre_transform_extract(

--- a/vegafusion-runtime/tests/test_pre_transform_keep_variables.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_keep_variables.rs
@@ -26,7 +26,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (tx_spec, warnings) = runtime
             .pre_transform_spec(

--- a/vegafusion-runtime/tests/test_pre_transform_values.rs
+++ b/vegafusion-runtime/tests/test_pre_transform_values.rs
@@ -39,7 +39,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (values, warnings) = runtime
             .pre_transform_values(
@@ -88,7 +88,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (values, warnings) = runtime
             .pre_transform_values(
@@ -137,7 +137,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         // Check existent but unsupported dataset name
         let result = runtime
@@ -195,7 +195,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let source_0 =
             VegaFusionTable::from_json(&json!([{"normal": 1, "a.b": 2}, {"normal": 1, "a.b": 4}]))
@@ -251,7 +251,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (values, warnings) = runtime
             .pre_transform_values(
@@ -298,7 +298,7 @@ mod tests {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (values, warnings) = runtime
             .pre_transform_values(
@@ -382,7 +382,7 @@ mod tests {
             )));
 
             // Initialize task graph runtime
-            let runtime = VegaFusionRuntime::new(None);
+            let runtime = VegaFusionRuntime::default();
 
             let (values, warnings) = runtime
                 .pre_transform_values(
@@ -441,7 +441,7 @@ mod tests {
         .unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (values, warnings) = runtime
             .pre_transform_values(

--- a/vegafusion-runtime/tests/test_selection.rs
+++ b/vegafusion-runtime/tests/test_selection.rs
@@ -7,12 +7,13 @@ use rstest::*;
 use serde_json::{json, Value};
 use util::check::check_transform_evaluation;
 use vegafusion_common::data::table::VegaFusionTable;
+use vegafusion_core::data::dataset::VegaFusionDataset;
 use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_runtime::expression::compiler::config::CompilationConfig;
 use vegafusion_runtime::task_graph::timezone::RuntimeTzConfig;
 
-fn make_brush_r(ranges: &[Vec<(&str, &str, [f64; 2])>], typ: &str) -> VegaFusionTable {
+fn make_brush_r(ranges: &[Vec<(&str, &str, [f64; 2])>], typ: &str) -> VegaFusionDataset {
     let mut rows: Vec<Value> = Vec::new();
     for (i, row_ranges) in ranges.iter().enumerate() {
         let mut field_elements: Vec<Value> = Vec::new();
@@ -34,10 +35,14 @@ fn make_brush_r(ranges: &[Vec<(&str, &str, [f64; 2])>], typ: &str) -> VegaFusion
             "values": Value::Array(value_elements),
         }));
     }
-    VegaFusionTable::from_json(&Value::Array(rows)).unwrap()
+    VegaFusionDataset::from_table(
+        VegaFusionTable::from_json(&Value::Array(rows)).unwrap(),
+        None,
+    )
+    .unwrap()
 }
 
-fn make_brush_e_single(field: &str, values: &[f64]) -> VegaFusionTable {
+fn make_brush_e_single(field: &str, values: &[f64]) -> VegaFusionDataset {
     let mut rows: Vec<Value> = Vec::new();
 
     for (i, val) in values.iter().enumerate() {
@@ -54,10 +59,14 @@ fn make_brush_e_single(field: &str, values: &[f64]) -> VegaFusionTable {
         }));
     }
 
-    VegaFusionTable::from_json(&Value::Array(rows)).unwrap()
+    VegaFusionDataset::from_table(
+        VegaFusionTable::from_json(&Value::Array(rows)).unwrap(),
+        None,
+    )
+    .unwrap()
 }
 
-fn make_brush_e_str(ranges: &Vec<Vec<(&str, &str, Vec<&str>)>>) -> VegaFusionTable {
+fn make_brush_e_str(ranges: &Vec<Vec<(&str, &str, Vec<&str>)>>) -> VegaFusionDataset {
     let mut rows: Vec<Value> = Vec::new();
     for (i, row_ranges) in ranges.iter().enumerate() {
         let mut field_elements: Vec<Value> = Vec::new();
@@ -80,7 +89,11 @@ fn make_brush_e_str(ranges: &Vec<Vec<(&str, &str, Vec<&str>)>>) -> VegaFusionTab
         }));
     }
 
-    VegaFusionTable::from_json(&Value::Array(rows)).unwrap()
+    VegaFusionDataset::from_table(
+        VegaFusionTable::from_json(&Value::Array(rows)).unwrap(),
+        None,
+    )
+    .unwrap()
 }
 
 fn datum() -> VegaFusionTable {
@@ -98,7 +111,7 @@ fn datum() -> VegaFusionTable {
 
 pub fn check_vl_selection_test(
     selection_expr: &str,
-    brush_dataset: VegaFusionTable,
+    brush_dataset: VegaFusionDataset,
     dataset: &VegaFusionTable,
 ) {
     let formula_spec = FormulaTransformSpec {
@@ -124,7 +137,7 @@ pub fn check_vl_selection_test(
     check_transform_evaluation(dataset, transform_specs.as_slice(), &config, &eq_config);
 }
 
-pub fn check_vl_selection_resolve(selection_expr: &str, brush_dataset: VegaFusionTable) {
+pub fn check_vl_selection_resolve(selection_expr: &str, brush_dataset: VegaFusionDataset) {
     let config = CompilationConfig {
         data_scope: vec![("brush".to_string(), brush_dataset)]
             .into_iter()
@@ -241,7 +254,9 @@ mod test_vl_selection_test_e_mixed_str_bool {
               "values": ["Comedy", false]
             }
         ]);
-        let brush = VegaFusionTable::from_json(&brush_json).unwrap();
+        let brush =
+            VegaFusionDataset::from_table(VegaFusionTable::from_json(&brush_json).unwrap(), None)
+                .unwrap();
 
         let dataset_json = json!([
             {"Major Genre": "Adventure", "is_pg": true, "Title": "A"},

--- a/vegafusion-runtime/tests/test_stringify_datetimes.rs
+++ b/vegafusion-runtime/tests/test_stringify_datetimes.rs
@@ -86,7 +86,7 @@ mod test_stringify_datetimes {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
         let local_tz = local_tz.to_string();
 
         let (spec, _warnings) = runtime
@@ -139,7 +139,7 @@ mod test_stringify_datetimes {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
         // let local_tz = "America/New_York".to_string();
         let local_tz = "UTC".to_string();
         let default_input_tz = "UTC".to_string();
@@ -225,7 +225,7 @@ mod test_stringify_datetimes {
         let spec_str = fs::read_to_string(spec_path).unwrap();
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (spec, _warnings) = runtime
             .pre_transform_spec(
@@ -290,7 +290,7 @@ mod test_stringify_datetimes {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (spec, _warnings) = TOKIO_RUNTIME
             .block_on(runtime.pre_transform_spec(
@@ -335,7 +335,7 @@ mod test_stringify_datetimes {
         let spec: ChartSpec = serde_json::from_str(&spec_str).unwrap();
 
         // Initialize task graph runtime
-        let runtime = VegaFusionRuntime::new(None);
+        let runtime = VegaFusionRuntime::default();
 
         let (spec, _warnings) = runtime
             .pre_transform_spec(

--- a/vegafusion-runtime/tests/test_task_graph_runtime.rs
+++ b/vegafusion-runtime/tests/test_task_graph_runtime.rs
@@ -80,10 +80,15 @@ async fn try_it() {
     ];
 
     let graph = Arc::new(TaskGraph::new(tasks, &task_scope).unwrap());
-    let graph_runtime = VegaFusionRuntime::new(None);
+    let graph_runtime = VegaFusionRuntime::default();
     // let result = graph_runtime.get_node_value(graph, 2, None).await.unwrap();
     let result = graph_runtime
-        .get_node_value(graph, &NodeValueIndex::new(2, Some(0)), Default::default())
+        .get_node_value(
+            graph,
+            &NodeValueIndex::new(2, Some(0)),
+            Default::default(),
+            None,
+        )
         .await
         .unwrap();
 
@@ -138,9 +143,14 @@ async fn try_it_from_spec() {
 
     let graph = Arc::new(TaskGraph::new(tasks, &task_scope).unwrap());
 
-    let graph_runtime = VegaFusionRuntime::new(None);
+    let graph_runtime = VegaFusionRuntime::default();
     let result = graph_runtime
-        .get_node_value(graph, &NodeValueIndex::new(2, Some(0)), Default::default())
+        .get_node_value(
+            graph,
+            &NodeValueIndex::new(2, Some(0)),
+            Default::default(),
+            None,
+        )
         .await
         .unwrap();
     println!("result: {result:?}");

--- a/vegafusion-runtime/tests/test_task_graph_runtime.rs
+++ b/vegafusion-runtime/tests/test_task_graph_runtime.rs
@@ -83,12 +83,7 @@ async fn try_it() {
     let graph_runtime = VegaFusionRuntime::default();
     // let result = graph_runtime.get_node_value(graph, 2, None).await.unwrap();
     let result = graph_runtime
-        .get_node_value(
-            graph,
-            &NodeValueIndex::new(2, Some(0)),
-            Default::default(),
-            None,
-        )
+        .get_node_value(graph, &NodeValueIndex::new(2, Some(0)), Default::default())
         .await
         .unwrap();
 
@@ -145,12 +140,7 @@ async fn try_it_from_spec() {
 
     let graph_runtime = VegaFusionRuntime::default();
     let result = graph_runtime
-        .get_node_value(
-            graph,
-            &NodeValueIndex::new(2, Some(0)),
-            Default::default(),
-            None,
-        )
+        .get_node_value(graph, &NodeValueIndex::new(2, Some(0)), Default::default())
         .await
         .unwrap();
     println!("result: {result:?}");

--- a/vegafusion-runtime/tests/test_task_graph_runtime.rs
+++ b/vegafusion-runtime/tests/test_task_graph_runtime.rs
@@ -11,7 +11,7 @@ use vegafusion_core::proto::gen::transforms::{
 };
 use vegafusion_core::spec::chart::ChartSpec;
 use vegafusion_core::task_graph::scope::TaskScope;
-use vegafusion_core::task_graph::task_value::TaskValue;
+use vegafusion_core::task_graph::task_value::MaterializedTaskValue;
 use vegafusion_runtime::task_graph::runtime::VegaFusionRuntime;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -38,7 +38,7 @@ async fn try_it() {
         Task::new_value(
             Variable::new_signal("url"),
             Default::default(),
-            TaskValue::Scalar(ScalarValue::from(
+            MaterializedTaskValue::Scalar(ScalarValue::from(
                 "https://raw.githubusercontent.com/vega/vega-datasets/master/data/penguins.json",
             )),
         ),

--- a/vegafusion-runtime/tests/test_transform_formula.rs
+++ b/vegafusion-runtime/tests/test_transform_formula.rs
@@ -7,6 +7,7 @@ use datafusion_common::ScalarValue;
 use serde_json::json;
 use util::check::check_transform_evaluation;
 use util::datasets::vega_json_dataset;
+use vegafusion_common::data::table::VegaFusionTable;
 use vegafusion_core::spec::transform::formula::FormulaTransformSpec;
 use vegafusion_core::spec::transform::TransformSpec;
 use vegafusion_runtime::expression::compiler::config::CompilationConfig;
@@ -273,6 +274,45 @@ fn test_formula_span() {
             "type": "formula",
             "expr": "span([1, 2, 5, 6, 7])",
             "as": "span6"
+        },
+    ]))
+    .unwrap();
+
+    let comp_config = Default::default();
+    let eq_config = Default::default();
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &comp_config,
+        &eq_config,
+    );
+}
+
+#[test]
+fn test_formula_time_offset_date() {
+    let dataset = VegaFusionTable::from_json(&json!([
+        {"date": "2023-01-15"},
+        {"date": "2023-06-20"},
+        {"date": "2023-12-31"},
+    ]))
+    .unwrap();
+
+    let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!([
+        {
+            "type": "formula",
+            "expr": "toDate(datum['date'])",
+            "as": "timestamp"
+        },
+        {
+            "type": "formula",
+            "expr": "timeOffset('date', datum['timestamp'], -1)",
+            "as": "prev_day"
+        },
+        {
+            "type": "formula",
+            "expr": "timeOffset('date', datum['timestamp'], 1)",
+            "as": "next_day"
         },
     ]))
     .unwrap();

--- a/vegafusion-runtime/tests/util/vegajs_runtime/mod.rs
+++ b/vegafusion-runtime/tests/util/vegajs_runtime/mod.rs
@@ -259,7 +259,7 @@ impl VegaJsRuntime {
         // Add datasets (for use in data expressions)
         let mut data = vec![];
         for (name, val) in &config.data_scope {
-            data.push(json!({"name": name, "values": val.to_json()?}))
+            data.push(json!({"name": name, "values": val.as_table().unwrap_or(&VegaFusionTable::empty_with_ordering()).to_json()?}))
         }
 
         // Create spec
@@ -288,7 +288,7 @@ impl VegaJsRuntime {
         // Add additional dataset from compilation config
         let mut data = Vec::new();
         for (name, val) in &config.data_scope {
-            data.push(json!({"name": name.clone(), "values": val.to_json()?}))
+            data.push(json!({"name": name.clone(), "values": val.as_table().unwrap_or(&VegaFusionTable::empty_with_ordering()).to_json()?}))
         }
 
         data.push(json!({

--- a/vegafusion-server/Cargo.toml
+++ b/vegafusion-server/Cargo.toml
@@ -14,7 +14,6 @@ repository = "https://github.com/vega/vegafusion"
 protobuf-src = ["vegafusion-core/protobuf-src", "dep:protobuf-src"]
 
 [dependencies]
-futures-util = "0.3.31"
 h2 = "0.3.26"
 
 [dev-dependencies]
@@ -28,6 +27,9 @@ workspace = true
 workspace = true
 
 [dependencies.serde_json]
+workspace = true
+
+[dependencies.futures]
 workspace = true
 
 [dependencies.vegafusion-common]

--- a/vegafusion-server/tests/test_task_graph_runtime.rs
+++ b/vegafusion-server/tests/test_task_graph_runtime.rs
@@ -1,4 +1,3 @@
-use assert_cmd::prelude::*;
 use std::time::Duration;
 use vegafusion_common::data::scalar::ScalarValueHelpers;
 use vegafusion_core::proto::gen::services::query_result::Response;
@@ -64,8 +63,7 @@ async fn try_it_from_spec() {
         )),
     };
 
-    let mut bin = std::process::Command::cargo_bin("vegafusion-server")
-        .expect("Failed to build vegafusion-server");
+    let mut bin = std::process::Command::new(assert_cmd::cargo::cargo_bin!("vegafusion-server"));
     let cmd = bin.args(["--port", "50059"]);
 
     let mut proc = cmd.spawn().expect("Failed to spawn vegafusion-server");

--- a/vegafusion-wasm/src/lib.rs
+++ b/vegafusion-wasm/src/lib.rs
@@ -438,7 +438,7 @@ pub async fn vegafusion_embed(
     let runtime: Box<dyn VegaFusionRuntimeTrait> = if query_fn.is_undefined() || query_fn.is_null()
     {
         // Use embedded runtime
-        Box::new(VegaFusionRuntime::new(None))
+        Box::new(VegaFusionRuntime::default())
     } else {
         let query_fn = query_fn.dyn_into::<js_sys::Function>().map_err(|e| {
             JsError::new(&format!(


### PR DESCRIPTION
## Summary
- The manylinux 2014 container defaults to Python 3.8, producing `cp38` wheels that can't be installed in the pixi test environment (Python 3.10)
- Add `-i python3.9` to maturin args for both x86_64 and arm64 Linux builds, matching `requires-python = ">=3.9"`

Intended to be merged into #573 — targeting main for now to get CI running.

## Test plan
- [ ] `test-vegafusion-python-linux-64` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)