### PR TITLE
Fix CI: Python 3.9 wheels and maybe improve flaky jupyter test

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -143,7 +143,7 @@ jobs:
           command: build
           manylinux: 2014
           rust-toolchain: stable
-          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --sdist
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --sdist -i python3.9
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
         with:
@@ -167,7 +167,7 @@ jobs:
           command: build
           manylinux: 2_28
           rust-toolchain: stable
-          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu
+          args: -m vegafusion-python/Cargo.toml --profile release-opt --features=protobuf-src --strip --target aarch64-unknown-linux-gnu -i python3.9
       - name: Upload artifacts
         uses: actions/upload-artifact@v4.4.3
         with:

--- a/vegafusion-python/tests/test_jupyter_widget.py
+++ b/vegafusion-python/tests/test_jupyter_widget.py
@@ -461,7 +461,7 @@ def export_image_sequence(
         chrome_driver.execute_script(script)
 
         # Get canvas element (the canvas that Vega renders to)
-        @retry(wait=wait.wait_fixed(0.5), stop=stop.stop_after_delay(10))
+        @retry(wait=wait.wait_fixed(1.0), stop=stop.stop_after_delay(30))
         def get_canvas():
             return chrome_driver.find_element("xpath", "//canvas")
 


### PR DESCRIPTION
## Summary
- Build cp39 Linux wheels to match `requires-python >= 3.9`
- Increase canvas element retry timeout in jupyter widget tests from 10s to 30s to reduce flaky failures on slower CI runners (e.g. `maps/choropleth`)