### PR TITLE
[codex] Allow window transforms without fields

### DIFF
--- a/vegafusion-core/src/spec/transform/window.rs
+++ b/vegafusion-core/src/spec/transform/window.rs
@@ -19,6 +19,7 @@ pub struct WindowTransformSpec {
 
     pub ops: Vec<WindowTransformOpSpec>,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub fields: Vec<Option<Field>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/vegafusion-core/src/transform/window.rs
+++ b/vegafusion-core/src/transform/window.rs
@@ -49,11 +49,14 @@ impl Window {
         };
 
         // Process fields (Convert null/None to empty string)
-        let fields: Vec<_> = transform
+        let mut fields: Vec<_> = transform
             .fields
             .iter()
             .map(|f| f.as_ref().map(|f| f.field()).unwrap_or_default())
             .collect();
+        if fields.is_empty() {
+            fields.resize(transform.ops.len(), String::new());
+        }
 
         // Process groupby
         let groupby: Vec<_> = transform
@@ -159,3 +162,32 @@ impl Window {
 }
 
 impl TransformDependencies for Window {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::spec::transform::TransformSpec;
+    use serde_json::json;
+
+    #[test]
+    fn omitted_fields_default_to_one_empty_field_per_op() {
+        let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!(
+            [
+                {
+                    "type": "window",
+                    "ops": ["row_number"],
+                    "as": ["rank"]
+                }
+            ]
+        ))
+        .unwrap();
+
+        let TransformSpec::Window(spec) = &transform_specs[0] else {
+            panic!("expected window transform");
+        };
+        assert!(spec.fields.is_empty());
+
+        let window = Window::try_new(spec).unwrap();
+        assert_eq!(window.fields, vec![""]);
+    }
+}

--- a/vegafusion-runtime/tests/test_transform_window.rs
+++ b/vegafusion-runtime/tests/test_transform_window.rs
@@ -7,8 +7,50 @@ use util::datasets::vega_json_dataset;
 use util::equality::TablesEqualConfig;
 
 use rstest::rstest;
+use serde_json::json;
 use vegafusion_core::spec::transform::aggregate::AggregateOpSpec;
 use vegafusion_core::spec::transform::TransformSpec;
+
+#[test]
+fn test_window_row_number_without_fields() {
+    let dataset = vega_json_dataset("movies");
+    let transform_specs: Vec<TransformSpec> = serde_json::from_value(json!(
+        [
+            {
+                "type": "filter",
+                "expr": "isValid(datum['Title']) && isValid(datum['IMDB Rating'])"
+            },
+            {
+                "type": "window",
+                "ops": ["row_number"],
+                "as": ["rank"],
+                "sort": {
+                    "field": ["IMDB Rating"],
+                    "order": ["descending"]
+                }
+            },
+            {
+                "type": "project",
+                "fields": ["Title", "IMDB Rating", "rank"]
+            },
+            {
+                "type": "collect",
+                "sort": {
+                    "field": ["rank"],
+                    "order": ["ascending"]
+                }
+            }
+        ]
+    ))
+    .unwrap();
+
+    check_transform_evaluation(
+        &dataset,
+        transform_specs.as_slice(),
+        &Default::default(),
+        &Default::default(),
+    );
+}
 
 // For some reason this test is especially slow on Windows on CI.
 // Skip for now.


### PR DESCRIPTION
## Summary

Fixes vega/vegafusion#585.

Vega treats the `fields` property on `window` transforms as optional. VegaFusion's parser currently requires it, so valid specs such as a `row_number` window transform without `fields` fail during deserialization.

This change:
- allows `WindowTransformSpec.fields` to deserialize when omitted
- normalizes omitted/empty fields to one empty field per window op when building the internal transform proto
- adds focused coverage for parsing and evaluating a `row_number` window transform without `fields`

## Validation

- `git diff --check`

I could not run the Rust test suite locally because this host has no `cargo`, `rustc`, or `pixi` on `PATH`, and Docker is installed but its daemon is not running. The targeted tests added are:
- `omitted_fields_default_to_one_empty_field_per_op`
- `test_window_row_number_without_fields`

## AI disclosure

This draft PR was prepared with assistance from OpenAI Codex/ChatGPT. The code changes, tests, PR description, and validation summary were AI-assisted and reviewed in the local checkout before submission.
